### PR TITLE
fix: add delay between text injection and Enter key on Unix/tmux

### DIFF
--- a/wrapper_unix.py
+++ b/wrapper_unix.py
@@ -38,6 +38,8 @@ def inject(text: str, *, tmux_session: str):
         ["tmux", "send-keys", "-t", tmux_session, "-l", text],
         capture_output=True,
     )
+    # Let TUI process the text before sending Enter (matches Windows wrapper)
+    time.sleep(0.3)
     subprocess.run(
         ["tmux", "send-keys", "-t", tmux_session, "Enter"],
         capture_output=True,


### PR DESCRIPTION
## Problem

On Linux/Mac (tmux), `wrapper_unix.py`'s `inject()` function sends text and Enter back-to-back with zero delay. Agent TUIs like Codex CLI and Gemini CLI are still rendering the injected text when Enter arrives, so **Enter gets swallowed**. This causes the trigger text (`mcp read #general and if addressed respond in the chat`) to stack up at the agent's input prompt without ever being submitted.

Claude Code's TUI is fast enough to handle the back-to-back send, which is why only Claude responds to @mentions while Codex and Gemini appear stuck.

### What it looks like

The agent's tmux pane shows stacked, unsubmitted text:
```
› mcp read #general and if addressed respond in the chat
  mcp read #general and if addressed respond in the chat
  mcp read #general and if addressed respond in the chat
```

The agents are permanently jammed — every new @mention adds another line to the pile.

## Fix

Add `time.sleep(0.3)` between the text send and Enter send in `wrapper_unix.py`, matching what `wrapper_windows.py` already does (line 67).

```python
subprocess.run(["tmux", "send-keys", "-t", tmux_session, "-l", text], capture_output=True)
time.sleep(0.3)  # Let TUI process the text before sending Enter
subprocess.run(["tmux", "send-keys", "-t", tmux_session, "Enter"], capture_output=True)
```

## Testing

- **Environment:** WSL2 Ubuntu, tmux 3.4, Python 3.12
- **Agents:** Claude Code v2.1.63, Codex CLI v0.106.0, Gemini CLI (gemini-3-pro-preview)
- **Before fix:** Only Claude responds; Codex and Gemini show stacked text at prompt
- **After fix:** All three agents respond reliably on every @mention, confirmed across multiple full restarts

## Bonus note

There's a related (separate) issue: the wrapper sends heartbeats before the agent CLI is fully loaded, so the dashboard shows green "online" dots while the agent is still initializing. If users @mention agents during that window, triggers get injected into a TUI that isn't ready, causing the same text pile-up. Recovery is `Ctrl+C` in the tmux session. A future enhancement could delay heartbeats until the agent is actually accepting input.

Love this project — thanks for building it!