### PR TITLE
Map runtime sender names to configured agent identities

### DIFF
--- a/app.py
+++ b/app.py
@@ -549,7 +549,11 @@ async def websocket_endpoint(websocket: WebSocket):
 
     # Send agent config (names, colors, labels) so UI can build pills + color mentions
     agent_cfg = {
-        name: {"color": cfg.get("color", "#888"), "label": cfg.get("label", name)}
+        name: {
+            "color": cfg.get("color", "#888"),
+            "label": cfg.get("label", name),
+            "command": cfg.get("command", ""),
+        }
         for name, cfg in config.get("agents", {}).items()
     }
     await websocket.send_text(json.dumps({"type": "agents", "data": agent_cfg}))


### PR DESCRIPTION
## Summary
- include each agent's configured command in the websocket gents payload
- resolve sender identity by matching runtime command names (e.g. codex, claude, gemini) to configured agent keys in the UI
- render configured labels in join/leave and message headers
- keep wrapper heartbeat alive for both canonical agent key and runtime command name to reduce false offline transitions

## Why
When wrappers or MCP tools emit runtime sender names, UI identity and presence can drift from configured agents. This keeps identity mapping and presence stable without requiring custom local naming.

## Scope
Upstream-safe generic fix only:
- pp.py
- static/chat.js
- wrapper.py

No local/homebrew configuration or launcher customizations included.
