### PR TITLE
fix: add --headless flag to skip tmux attach when no TTY

### DIFF
--- a/wrapper.py
+++ b/wrapper.py
@@ -151,6 +151,7 @@ def main():
     parser.add_argument("agent", choices=agent_names,
                         help=f"Agent to wrap ({', '.join(agent_names)})")
     parser.add_argument("--no-restart", action="store_true", help="Don't restart on exit")
+    parser.add_argument("--headless", action="store_true", help="Run without attaching to terminal (for background use)")
     args, extra = parser.parse_known_args()
 
     agent = args.agent
@@ -281,6 +282,7 @@ def main():
         queue_file=queue_file,
         agent=agent,
         no_restart=args.no_restart,
+        headless=args.headless,
         start_watcher=start_watcher,
         strip_env=list(strip_vars),
         pid_holder=_agent_pid,

--- a/wrapper_unix.py
+++ b/wrapper_unix.py
@@ -66,9 +66,13 @@ def get_activity_checker(session_name):
     return check
 
 
-def run_agent(command, extra_args, cwd, env, queue_file, agent, no_restart, start_watcher, strip_env=None, pid_holder=None):
+def run_agent(command, extra_args, cwd, env, queue_file, agent, no_restart, headless=False, start_watcher=None, strip_env=None, pid_holder=None):
     """Run agent inside a tmux session, inject via tmux send-keys."""
     _check_tmux()
+
+    # Auto-detect headless: if stdin is not a TTY (e.g. nohup, watchdog), skip attach
+    if not headless:
+        headless = not sys.stdin.isatty()
 
     session_name = f"agentchattr-{agent}"
     agent_cmd = " ".join(
@@ -91,8 +95,11 @@ def run_agent(command, extra_args, cwd, env, queue_file, agent, no_restart, star
     start_watcher(inject_fn)
 
     print(f"  Using tmux session: {session_name}")
-    print(f"  Detach: Ctrl+B, D  (agent keeps running)")
-    print(f"  Reattach: tmux attach -t {session_name}\n")
+    if headless:
+        print(f"  Running headless — attach: tmux attach -t {session_name}\n")
+    else:
+        print(f"  Detach: Ctrl+B, D  (agent keeps running)")
+        print(f"  Reattach: tmux attach -t {session_name}\n")
 
     while True:
         try:
@@ -112,19 +119,30 @@ def run_agent(command, extra_args, cwd, env, queue_file, agent, no_restart, star
                 print(f"  Error: failed to create tmux session (exit {result.returncode})")
                 break
 
-            # Attach — blocks until agent exits or user detaches (Ctrl+B, D)
-            subprocess.run(["tmux", "attach-session", "-t", session_name])
+            if headless:
+                # No TTY to attach to — poll until the session exits
+                while True:
+                    check = subprocess.run(
+                        ["tmux", "has-session", "-t", session_name],
+                        capture_output=True,
+                    )
+                    if check.returncode != 0:
+                        break  # session gone — agent exited
+                    time.sleep(5)
+            else:
+                # Attach — blocks until agent exits or user detaches (Ctrl+B, D)
+                subprocess.run(["tmux", "attach-session", "-t", session_name])
 
-            # Check: did the agent exit, or did the user just detach?
-            check = subprocess.run(
-                ["tmux", "has-session", "-t", session_name],
-                capture_output=True,
-            )
-            if check.returncode == 0:
-                # Session still alive — user detached, agent running in background
-                print(f"\n  Detached. {agent.capitalize()} still running in tmux.")
-                print(f"  Reattach: tmux attach -t {session_name}")
-                break
+                # Check: did the agent exit, or did the user just detach?
+                check = subprocess.run(
+                    ["tmux", "has-session", "-t", session_name],
+                    capture_output=True,
+                )
+                if check.returncode == 0:
+                    # Session still alive — user detached, agent running in background
+                    print(f"\n  Detached. {agent.capitalize()} still running in tmux.")
+                    print(f"  Reattach: tmux attach -t {session_name}")
+                    break
 
             # Session gone — agent exited
             if no_restart:


### PR DESCRIPTION
## Problem

When the wrapper is launched without a TTY (via `nohup`, a watchdog, or any non-interactive shell), `tmux attach-session` returns immediately because there is no terminal to attach to. The wrapper — and its queue watcher — exits right after starting, while the agent keeps running silently in the tmux session.

## Fix

Add a `--headless` CLI flag to `wrapper.py`. When set (or auto-detected when `stdin` is not a TTY), `wrapper_unix.py` skips `tmux attach-session` and instead polls `tmux has-session` every 5 seconds until the session exits.

Changes:
- `wrapper.py`: add `--headless` argparse argument; pass `headless=args.headless` to `run_agent`
- `wrapper_unix.py`: add `headless=False` param to `run_agent`; auto-detect via `not sys.stdin.isatty()`; poll loop replaces attach when headless

**Size:** ~20 lines across 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)