### PR TITLE
fix: add Cache-Control: no-store to HTML response

### DIFF
--- a/run.py
+++ b/run.py
@@ -76,7 +76,7 @@ def main():
             "</head>",
             f'<script>window.__SESSION_TOKEN__="{session_token}";</script>\n</head>',
         )
-        return HTMLResponse(injected)
+        return HTMLResponse(injected, headers={"Cache-Control": "no-store"})
 
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 


### PR DESCRIPTION
## Problem

After a server restart, the browser caches the HTML page (including the old session token embedded in it). On the next visit, the browser serves the stale page with the old token, causing the WebSocket connection to fail with 403 until the user does a hard refresh (Ctrl+Shift+R).

## Fix

One-line change: add `Cache-Control: no-store` header to the `HTMLResponse` in `run.py`. This tells browsers not to cache the page, so the fresh session token is always loaded.

```python
return HTMLResponse(injected, headers={"Cache-Control": "no-store"})
```

**Size:** 1 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)