### PR TITLE
fix: accept WebSocket before closing with 4003 on stale token

### DIFF
--- a/app.py
+++ b/app.py
@@ -719,6 +719,9 @@ async def websocket_endpoint(websocket: WebSocket):
     # --- Security: validate session token on WebSocket connect ---
     token = websocket.query_params.get("token", "")
     if token != session_token:
+        # Must accept before closing so the browser receives the close frame.
+        # Code 4003 triggers an auto-reload in the client to pick up the new token.
+        await websocket.accept()
         await websocket.close(code=4003, reason="forbidden: invalid session token")
         return
 


### PR DESCRIPTION
## Problem

When the server restarts, browser tabs retain the old session token. The WebSocket endpoint called `close(4003)` before `accept()`, which caused Starlette to send an HTTP 403 rejection instead of a WebSocket close frame. The browser never received the 4003 code, so the existing auto-reload logic in `chat.js` (lines 443–450) could not trigger — resulting in an infinite loop of failed connection attempts.

## Fix

Accept the WebSocket connection before immediately closing it with code 4003. This lets the browser receive the proper close frame, fire `onclose` with `e.code === 4003`, auto-reload the page, and reconnect with the fresh token.

## Change

```diff
 # app.py — websocket_endpoint()
 token = websocket.query_params.get("token", "")
 if token != session_token:
+    await websocket.accept()
     await websocket.close(code=4003, reason="forbidden: invalid session token")
     return
```

## Testing

Verified across multiple server restarts: stale-token connections are accepted, closed with 4003, the browser auto-reloads, and the fresh token connects successfully. No more 403 loops.

Co-Authored-By: Oz <oz-agent@warp.dev>