### PR TITLE
fix: update stale decisions reference to rules in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -36,10 +36,10 @@ def main():
     configure(config, session_token=session_token)
 
     # Share stores with the MCP bridge
-    from app import store, decisions, summaries, jobs, room_settings, registry, router as app_router, agents as app_agents
+    from app import store, rules, summaries, jobs, room_settings, registry, router as app_router, agents as app_agents
     import mcp_bridge
     mcp_bridge.store = store
-    mcp_bridge.decisions = decisions
+    mcp_bridge.rules = rules
     mcp_bridge.summaries = summaries
     mcp_bridge.jobs = jobs
     mcp_bridge.room_settings = room_settings


### PR DESCRIPTION
## Summary
- The `decisions→rules` rename (1c53775) missed `run.py`, causing an `ImportError` on startup: `cannot import name 'decisions' from 'app'`
- Updated the import and `mcp_bridge` assignment from `decisions` to `rules`

## Test plan
- [ ] `sh macos-linux/start.sh` starts the server successfully
- [ ] Verify the web UI loads at http://localhost:8300