### PR TITLE
feat: terminal webcam popover, agent spawn/kill, Gemini MCP fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,33 +35,46 @@ On first launch, the script auto-creates a virtual environment, installs Python 
 
 ## Quickstart (Mac / Linux)
 
-**1. Make sure tmux is installed:**
+**1. Install tmux** (required for agent keystroke injection):
 
 ```bash
 brew install tmux    # macOS
 # apt install tmux   # Ubuntu/Debian
 ```
 
-**2. Launch an agent:**
+**2. Start the server:**
 
-Open a terminal in the `macos-linux` folder (right-click → "Open Terminal Here", or `cd` into it) and run:
+```bash
+cd macos-linux
+sh start.sh
+```
 
-- `sh start.sh` — starts the chat server only
-- `sh start_claude.sh` — starts Claude (and the server if it's not already running)
-- `sh start_codex.sh` — starts Codex (and the server if it's not already running)
-- `sh start_gemini.sh` — starts Gemini (and the server if it's not already running)
-- `sh start_kimi.sh` — starts Kimi (and the server if it's not already running)
+This creates a virtual environment (if needed), installs dependencies, and starts the chat server. The server runs in the foreground — keep that terminal open.
 
-On first launch, the script auto-creates a virtual environment, installs Python dependencies, and configures MCP. Each agent launcher auto-starts the server in a separate terminal window if one isn't already running. The agent opens inside a **tmux** session. Detach with `Ctrl+B, D` — the agent keeps running in the background. Reattach with `tmux attach -t agentchattr-claude`.
+**3. Open the chat:** Go to **http://localhost:8300** in your browser.
 
-> **Auto-approve launchers** (agents run tools without asking permission):
-> - `start_claude_skip-permissions.sh` — Claude with `--dangerously-skip-permissions`
-> - `start_codex_bypass.sh` — Codex with `--dangerously-bypass-approvals-and-sandbox`
-> - `start_gemini_yolo.sh` — Gemini with `--yolo`
+**4. Configure and start agents:** Click the gear icon (Settings) in the header. In the **Setup** section:
 
-**3. Open the chat:** Go to **http://localhost:8300** or open `open_chat.html`.
+- **Project directory** — Click **Browse** to pick a folder where agents will work (e.g. your project root)
+- **Auto-approve** — Check to skip permission prompts (YOLO mode)
+- **Start all agents** — Click to launch Claude, Codex, Gemini, and Kimi in separate Terminal windows
 
-**4. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, or `@kimi` in your message, or use the toggle buttons above the input. The agent will wake up, read the chat, and respond.
+Each agent opens in its own Terminal window so you can see output and debug issues. Status pills in the header show when they connect.
+
+**5. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, or `@kimi` in your message, or use the toggle buttons above the input.
+
+---
+
+**Alternative: launch agents in separate Terminal windows** (for debugging or manual control):
+
+- `sh start_claude.sh` — Claude (and server if not running)
+- `sh start_codex.sh` — Codex
+- `sh start_gemini.sh` — Gemini
+- `sh start_kimi.sh` — Kimi
+
+Each opens in a **tmux** session. Detach with `Ctrl+B, D`; reattach with `tmux attach -t agentchattr-claude`.
+
+> **Auto-approve launchers:** `start_claude_skip-permissions.sh`, `start_codex_bypass.sh`, `start_gemini_yolo.sh`
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -2,11 +2,13 @@
 
 import asyncio
 import json
+import logging
+import os
 import re as _re
+import subprocess
 import sys
 import threading
 import uuid
-import logging
 from pathlib import Path
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, UploadFile, File
@@ -52,6 +54,9 @@ room_settings: dict = {
     "channels": ["general"],
     "history_limit": "all",
     "contrast": "normal",
+    "routing_default": "none",
+    "project_dir": "",
+    "auto_approve": False,
 }
 
 # Channel validation
@@ -60,6 +65,60 @@ MAX_CHANNELS = 8
 
 # Agent hats (persisted to data/hats.json)
 agent_hats: dict[str, str] = {}  # { agent_name: svg_string }
+
+
+# ---------------------------------------------------------------------------
+# Auto-trust helpers — called whenever project_dir is set in settings
+# ---------------------------------------------------------------------------
+
+def _gemini_trust_folder(folder: Path) -> None:
+    """Write TRUST_FOLDER for *folder* into ~/.gemini/trustedFolders.json.
+
+    Gemini CLI blocks ALL MCPs (even system-settings ones) for untrusted
+    folders.  A more-specific TRUST_FOLDER entry overrides any parent
+    DO_NOT_TRUST rule, so we always write the exact path we're working in.
+    Respects the GEMINI_CLI_TRUSTED_FOLDERS_PATH env override if set.
+    """
+    trusted_path_env = os.environ.get("GEMINI_CLI_TRUSTED_FOLDERS_PATH", "")
+    trusted_file = Path(trusted_path_env) if trusted_path_env else Path.home() / ".gemini" / "trustedFolders.json"
+    try:
+        data: dict = {}
+        if trusted_file.exists():
+            try:
+                data = json.loads(trusted_file.read_text("utf-8"))
+            except Exception:
+                data = {}
+        folder_key = str(folder.resolve())
+        if data.get(folder_key) == "TRUST_FOLDER":
+            return
+        data[folder_key] = "TRUST_FOLDER"
+        trusted_file.parent.mkdir(parents=True, exist_ok=True)
+        trusted_file.write_text(json.dumps(data, indent=2) + "\n", "utf-8")
+        logging.getLogger(__name__).info("Gemini: trusted folder %s", folder_key)
+    except Exception as exc:
+        logging.getLogger(__name__).warning("Could not update Gemini trusted folders: %s", exc)
+
+
+def _auto_trust_project_dir(project_dir_str: str) -> None:
+    """Trust *project_dir_str* for every agent that requires explicit folder trust.
+
+    Currently handles:
+      - Gemini CLI  → ~/.gemini/trustedFolders.json
+    Add additional agents here as needed.
+    """
+    if not project_dir_str:
+        return
+    folder = Path(project_dir_str)
+    if not folder.is_dir():
+        return
+
+    # Gemini: always trust — MCPs are blocked for untrusted folders
+    agents_cfg = config.get("agents", {})
+    for agent_name, agent_cfg in agents_cfg.items():
+        cmd = agent_cfg.get("command", agent_name)
+        if cmd == "gemini" or agent_name == "gemini" or agent_cfg.get("mcp_inject") == "env":
+            _gemini_trust_folder(folder)
+            break  # only need to write once per directory
 
 
 def _hats_path() -> Path:
@@ -135,6 +194,8 @@ def _load_settings():
         room_settings["channels"] = ["general"]
     elif "general" not in room_settings["channels"]:
         room_settings["channels"].insert(0, "general")
+    # Re-apply folder trust on startup so agents always launch into a trusted dir
+    _auto_trust_project_dir(room_settings.get("project_dir", ""))
 
 
 def _save_settings():
@@ -184,7 +245,7 @@ def _install_security_middleware(token: str, cfg: dict):
             if path == "/" or path.startswith(("/static/", "/uploads/", "/api/roles")):
                 return await call_next(request)
 
-            # Agent registration/heartbeat: loopback only (no remote agent minting).
+            # Agent registration/heartbeat/settings: loopback only (wrappers need settings at startup).
             if path.startswith(("/api/register", "/api/deregister/", "/api/heartbeat/")):
                 client_ip = request.client.host if request.client else ""
                 if client_ip not in ("127.0.0.1", "::1", "localhost"):
@@ -193,6 +254,10 @@ def _install_security_middleware(token: str, cfg: dict):
                         status_code=403,
                     )
                 return await call_next(request)
+            if path == "/api/settings" and request.method == "GET":
+                client_ip = request.client.host if request.client else ""
+                if client_ip in ("127.0.0.1", "::1", "localhost"):
+                    return await call_next(request)
 
             # --- Origin check (blocks cross-origin / DNS-rebinding attacks) ---
             origin = request.headers.get("origin")
@@ -298,9 +363,15 @@ def configure(cfg: dict, session_token: str = ""):
     _load_settings()
     _load_hats()
 
+    # Wire spawn function into mcp_bridge so agents can call chat_spawn
+    import mcp_bridge as _mb
+    _mb._spawn_fn = _spawn_agent
+
     # Apply saved loop guard setting
     if "max_agent_hops" in room_settings:
         router.max_hops = room_settings["max_agent_hops"]
+    if "routing_default" in room_settings:
+        router.default_mention = room_settings["routing_default"]
 
     # Background thread: check for wrapper recovery flag files
     _data_dir = Path(data_dir)
@@ -962,7 +1033,11 @@ async def websocket_endpoint(websocket: WebSocket):
     # Send base agent colors (used for message coloring, no pills)
     base_colors = {}
     for name, cfg in config.get("agents", {}).items():
-        base_colors[name] = {"color": cfg.get("color", "#888"), "label": cfg.get("label", name)}
+        base_colors[name] = {
+            "color": cfg.get("color", "#888"),
+            "label": cfg.get("label", name),
+            "spawnable": bool(cfg.get("command") and cfg.get("type") != "api"),
+        }
     await websocket.send_text(json.dumps({"type": "base_colors", "data": base_colors}))
 
     # Send todos {msg_id: status}
@@ -1191,6 +1266,14 @@ async def websocket_endpoint(websocket: WebSocket):
                             room_settings["history_limit"] = max(1, min(val_int, 10000))
                         except (ValueError, TypeError):
                             pass
+                if "routing_default" in new and new["routing_default"] in ("none", "all"):
+                    room_settings["routing_default"] = new["routing_default"]
+                    router.default_mention = new["routing_default"]
+                if "project_dir" in new and isinstance(new["project_dir"], str):
+                    room_settings["project_dir"] = new["project_dir"].strip()
+                    _auto_trust_project_dir(room_settings["project_dir"])
+                if "auto_approve" in new:
+                    room_settings["auto_approve"] = bool(new["auto_approve"])
                 _save_settings()
                 await broadcast_settings()
 
@@ -1400,6 +1483,248 @@ async def get_status():
 @app.get("/api/settings")
 async def get_settings():
     return room_settings
+
+
+@app.get("/api/terminal/{agent_name}")
+async def get_terminal(agent_name: str, lines: int = 50):
+    """Capture tmux pane output for an agent's terminal. Mac/Linux only.
+
+    Query param `lines` controls how many lines back to capture (default 50,
+    max 500). Scrollback is cleared on each agent registration so only content
+    from the *current* session is ever returned.
+    """
+    if sys.platform == "win32":
+        return {"available": False}
+    session_name = f"agentchattr-{agent_name}"
+    history = max(1, min(int(lines), 500))
+    try:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-t", session_name, "-p", "-S", f"-{history}"],
+            capture_output=True,
+            timeout=2,
+        )
+        if result.returncode != 0:
+            return {"available": False}
+        raw = result.stdout.decode("utf-8", errors="replace")
+        out_lines = raw.strip().split("\n")
+        return {"available": True, "lines": out_lines, "raw": raw}
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return {"available": False}
+
+
+@app.post("/api/terminal/{agent_name}/input")
+async def send_terminal_input(agent_name: str, request: Request):
+    """Send keystrokes to an agent's tmux session. Mac/Linux only."""
+    if sys.platform == "win32":
+        return JSONResponse({"error": "not supported on Windows"}, status_code=400)
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid JSON"}, status_code=400)
+    text = body.get("text", "")
+    enter = body.get("enter", True)
+    session_name = f"agentchattr-{agent_name}"
+    try:
+        if text:
+            subprocess.run(
+                ["tmux", "send-keys", "-t", session_name, "-l", text],
+                capture_output=True,
+                timeout=2,
+            )
+        if enter:
+            subprocess.run(
+                ["tmux", "send-keys", "-t", session_name, "Enter"],
+                capture_output=True,
+                timeout=2,
+            )
+        return {"ok": True}
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+def _browse_roots() -> list[dict]:
+    """Return platform-specific root entries for directory browser."""
+    roots = []
+    if sys.platform == "darwin":
+        for name, p in [("Users", "/Users"), ("Volumes", "/Volumes")]:
+            if Path(p).exists():
+                roots.append({"name": name, "path": p})
+    elif sys.platform == "win32":
+        import string
+        for letter in string.ascii_uppercase:
+            p = f"{letter}:\\"
+            if Path(p).exists():
+                roots.append({"name": p, "path": p})
+    else:
+        for name, p in [("home", "/home"), ("mnt", "/mnt"), ("root", "/")]:
+            if Path(p).exists():
+                roots.append({"name": name, "path": p})
+    return roots
+
+
+@app.get("/api/browse")
+async def browse_directories(path: str = ""):
+    """List directories for folder picker. path='' returns roots."""
+    if not path or path in ("/", "\\"):
+        return {"path": "", "directories": _browse_roots(), "parent": None}
+    try:
+        p = Path(path).resolve()
+        if not p.is_dir():
+            return JSONResponse({"error": "not a directory"}, status_code=400)
+        parent = str(p.parent) if p.parent != p else None
+        dirs = []
+        for child in sorted(p.iterdir()):
+            if child.is_dir() and not child.name.startswith("."):
+                dirs.append({"name": child.name, "path": str(child.resolve())})
+        return {"path": str(p), "directories": dirs, "parent": parent}
+    except (OSError, PermissionError) as e:
+        return JSONResponse({"error": str(e)}, status_code=403)
+
+
+@app.post("/api/agents/start")
+async def start_all_agents():
+    """Launch all CLI agents in separate Terminal windows (server must already be running)."""
+    ROOT = Path(__file__).parent
+    start_script = ROOT / "macos-linux" / "start_all.sh"
+    if not start_script.exists():
+        return JSONResponse({"error": "start_all.sh not found"}, status_code=500)
+    try:
+        agents_cfg = config.get("agents", {})
+        cli_agents = [k for k, v in agents_cfg.items() if v.get("command") and v.get("type") != "api"]
+        subprocess.Popen(
+            ["sh", str(start_script)],
+            cwd=str(ROOT),
+            start_new_session=True,
+        )
+        return JSONResponse({"started": cli_agents, "message": "Launching agents in Terminal windows..."})
+    except Exception as e:
+        log.warning("Failed to start agents: %s", e)
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@app.post("/api/agents/stop")
+async def stop_all_agents():
+    """Kill all agent wrapper processes (does not stop the server)."""
+    try:
+        import psutil
+        killed = 0
+        my_pid = os.getpid()
+        for proc in psutil.process_iter(["pid", "cmdline", "name"]):
+            try:
+                if proc.info["pid"] == my_pid:
+                    continue
+                cmdline = proc.info.get("cmdline") or []
+                cmdstr = " ".join(str(c) for c in cmdline)
+                if "wrapper.py" in cmdstr and "run.py" not in cmdstr:
+                    proc.kill()
+                    killed += 1
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        return JSONResponse({"ok": True, "message": f"Stopped {killed} agent(s)"})
+    except ImportError:
+        return JSONResponse({"error": "psutil not installed"}, status_code=500)
+    except Exception as e:
+        log.warning("Failed to stop agents: %s", e)
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+def _spawn_agent(agent: str, guidance: str = "", label: str = "") -> dict:
+    """Spawn a new wrapper instance for *agent*.  Runs synchronously (blocks up to 12s).
+
+    Launches wrapper.py headlessly: tmux attach-session silently fails without a
+    tty, so the wrapper enters its monitor loop and stays alive until the agent
+    tmux session is killed.  Returns {ok, name} or {error}.
+    """
+    import time as _time
+
+    ROOT = Path(__file__).parent
+    agents_cfg = config.get("agents", {})
+
+    if agent not in agents_cfg:
+        return {"error": f"unknown agent: {agent}"}
+    cfg = agents_cfg[agent]
+    if cfg.get("type") == "api":
+        return {"error": f"'{agent}' is an API agent and cannot be spawned"}
+    if not cfg.get("command"):
+        return {"error": f"'{agent}' has no command configured"}
+
+    before = set(registry.get_all_names()) if registry else set()
+
+    spawn_log = ROOT / config.get("server", {}).get("data_dir", "data") / f"spawn-{agent}.log"
+    spawn_log.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.Popen(
+            [sys.executable, str(ROOT / "wrapper.py"), agent] + (["--label", label] if label else []),
+            cwd=str(ROOT),
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=open(spawn_log, "a"),
+            stderr=subprocess.STDOUT,
+        )
+    except Exception as exc:
+        return {"error": f"failed to start wrapper: {exc}"}
+
+    # Poll registry until the new instance appears (max 12 s)
+    deadline = _time.time() + 12
+    new_name = None
+    while _time.time() < deadline:
+        if registry:
+            new_names = [
+                n for n in set(registry.get_all_names()) - before
+                if (inst := registry.get_instance(n)) and inst.get("base") == agent
+            ]
+            if new_names:
+                new_name = new_names[0]
+                break
+        _time.sleep(0.3)
+
+    if not new_name:
+        return {"error": "timed out waiting for agent to register — check spawn log"}
+
+    if guidance and guidance.strip():
+        data_dir = ROOT / config.get("server", {}).get("data_dir", "data")
+        queue_file = data_dir / f"{new_name}_queue.jsonl"
+        try:
+            queue_file.write_text(json.dumps({"prompt": guidance.strip()}) + "\n", "utf-8")
+        except Exception as exc:
+            log.warning("Could not write guidance for %s: %s", new_name, exc)
+
+    return {"ok": True, "name": new_name}
+
+
+@app.post("/api/agents/{agent}/spawn")
+async def spawn_agent(agent: str, request: Request):
+    """Spawn a new instance of *agent*.  Body: {guidance?, label?}."""
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    guidance = (body.get("guidance") or "").strip()
+    label = (body.get("label") or "").strip()
+    loop = asyncio.get_event_loop()
+    result = await loop.run_in_executor(None, _spawn_agent, agent, guidance, label)
+    if "error" in result:
+        return JSONResponse(result, status_code=400)
+    return JSONResponse(result)
+
+
+@app.post("/api/agents/{name}/kill")
+async def kill_agent(name: str):
+    """Kill a specific agent instance by its canonical name.
+
+    Kills the agent's tmux session; the wrapper detects the dead session and
+    deregisters itself.  Works for both manually-started and UI-spawned agents.
+    """
+    if not registry or not registry.is_registered(name):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    killed_sessions = []
+    if sys.platform != "win32":
+        for session in [f"agentchattr-{name}", f"agentchattr-wrapper-{name}"]:
+            r = subprocess.run(["tmux", "kill-session", "-t", session],
+                               capture_output=True, timeout=3)
+            if r.returncode == 0:
+                killed_sessions.append(session)
+    return JSONResponse({"ok": True, "name": name, "sessions_killed": killed_sessions})
 
 
 @app.delete("/api/hat/{agent_name}")
@@ -1847,6 +2172,16 @@ async def register_agent(request: Request):
     import mcp_bridge
     with mcp_bridge._presence_lock:
         mcp_bridge._presence[result["name"]] = __import__("time").time()
+    # Clear the tmux pane scrollback so the terminal popover only shows
+    # content from this session, not stale output from before a server restart.
+    if sys.platform != "win32":
+        try:
+            subprocess.run(
+                ["tmux", "clear-history", "-t", f"agentchattr-{result['name']}"],
+                capture_output=True, timeout=2,
+            )
+        except Exception:
+            pass
     # If slot 1 was renamed (e.g. "claude" → "claude-1"), migrate state
     renamed = result.pop("_renamed_slot1", None)
     if renamed:

--- a/macos-linux/start_all.sh
+++ b/macos-linux/start_all.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env sh
+# agentchattr - starts server (if not running) + ALL agent wrappers in separate windows
+cd "$(dirname "$0")/.."
+
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+else
+    echo "Python 3 is required but was not found on PATH."
+    exit 1
+fi
+
+ensure_venv() {
+    if [ -d ".venv" ] && [ ! -x ".venv/bin/python" ]; then
+        echo "Recreating .venv for this platform..."
+        rm -rf .venv
+    fi
+
+    if [ ! -x ".venv/bin/python" ]; then
+        echo "Creating virtual environment..."
+        "$PYTHON_BIN" -m venv .venv || {
+            echo "Error: failed to create .venv with $PYTHON_BIN."
+            exit 1
+        }
+        .venv/bin/python -m pip install -q -r requirements.txt || {
+            echo "Error: failed to install Python dependencies."
+            exit 1
+        }
+    fi
+}
+
+is_server_running() {
+    lsof -i :8300 -sTCP:LISTEN >/dev/null 2>&1 || \
+    ss -tlnp 2>/dev/null | grep -q ':8300 '
+}
+
+# Get CLI agents from config (those with 'command', not type='api')
+get_cli_agents() {
+    .venv/bin/python -c "
+import tomllib
+with open('config.toml','rb') as f:
+    c = tomllib.load(f)
+for k, v in c.get('agents', {}).items():
+    if v.get('command') and v.get('type') != 'api':
+        print(k)
+" 2>/dev/null || echo "claude codex gemini kimi"
+}
+
+ensure_venv
+
+if ! is_server_running; then
+    echo "Starting server..."
+    if [ "$(uname -s)" = "Darwin" ]; then
+        osascript -e "tell app \"Terminal\" to do script \"cd '$(pwd)' && .venv/bin/python run.py\"" > /dev/null 2>&1
+    else
+        if command -v gnome-terminal >/dev/null 2>&1; then
+            gnome-terminal -- sh -c "cd '$(pwd)' && .venv/bin/python run.py; printf 'Press Enter to close... '; read _"
+        elif command -v xterm >/dev/null 2>&1; then
+            xterm -e sh -c "cd '$(pwd)' && .venv/bin/python run.py" &
+        else
+            .venv/bin/python run.py > data/server.log 2>&1 &
+        fi
+    fi
+
+    i=0
+    while [ "$i" -lt 30 ]; do
+        if is_server_running; then
+            break
+        fi
+        sleep 0.5
+        i=$((i + 1))
+    done
+fi
+
+echo "Server ready at http://localhost:8300"
+echo "Launching agents in separate windows..."
+PROJECT_DIR="$(pwd)"
+
+for agent in $(get_cli_agents); do
+    echo "  Starting $agent..."
+    if [ "$(uname -s)" = "Darwin" ]; then
+        osascript -e "tell app \"Terminal\" to do script \"cd '$PROJECT_DIR' && .venv/bin/python wrapper.py $agent\""
+    else
+        if command -v gnome-terminal >/dev/null 2>&1; then
+            gnome-terminal -- sh -c "cd '$PROJECT_DIR' && .venv/bin/python wrapper.py $agent; printf 'Press Enter to close... '; read _"
+        elif command -v xterm >/dev/null 2>&1; then
+            xterm -e sh -c "cd '$PROJECT_DIR' && .venv/bin/python wrapper.py $agent" &
+        else
+            .venv/bin/python wrapper.py "$agent" &
+        fi
+    fi
+    sleep 1
+done
+
+echo ""
+echo "Done. Open http://localhost:8300 in your browser."
+echo "Agent windows may take a moment to connect — check status pills in the header."

--- a/macos-linux/stop_agents_only.sh
+++ b/macos-linux/stop_agents_only.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+# Kill agent wrappers only (does not kill the server)
+# Match "wrapper.py" in command line (e.g. "python wrapper.py claude")
+pkill -9 -f "wrapper.py" 2>/dev/null || true

--- a/macos-linux/stop_all.sh
+++ b/macos-linux/stop_all.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# agentchattr - kill server and all agent wrappers
+cd "$(dirname "$0")/.."
+
+echo "Stopping agentchattr..."
+
+# Kill server (listens on 8300; MCP 8200/8201 run in same process)
+if lsof -i :8300 -sTCP:LISTEN 2>/dev/null | grep -q .; then
+    echo "  Killing server (port 8300)..."
+    lsof -ti :8300 | xargs kill -9 2>/dev/null || true
+fi
+
+# Kill all agent wrappers
+if pgrep -f "wrapper\.py" >/dev/null 2>&1; then
+    echo "  Killing agent wrappers..."
+    pkill -9 -f "wrapper\.py" 2>/dev/null || true
+fi
+
+# Brief pause for ports to release
+sleep 1
+
+echo "Done. Run start_all.sh to restart."

--- a/mcp_bridge.py
+++ b/mcp_bridge.py
@@ -847,9 +847,40 @@ def chat_summary(
     return f"Unknown action: {action}. Valid actions: read, write."
 
 
+_spawn_fn = None  # set by app.configure() → _spawn_agent
+
+
+def chat_spawn(
+    agent: str,
+    guidance: str = "",
+    label: str = "",
+    ctx: Context | None = None,
+) -> str:
+    """Spawn a new instance of an agent, optionally with initial guidance.
+
+    Args:
+        agent: base agent name to spawn (e.g. "gemini", "claude", "codex")
+        guidance: first prompt injected into the new instance's queue
+        label: optional custom display label for the new instance
+
+    Returns the assigned name (e.g. "gemini-2") on success, or an error string.
+    This call blocks up to ~12 seconds while waiting for the instance to register.
+    """
+    if _spawn_fn is None:
+        return "Error: spawn is not available in this environment."
+    result = _spawn_fn(agent, guidance, label)
+    if "error" in result:
+        return f"Error: {result['error']}"
+    name = result.get("name", "?")
+    if guidance:
+        snippet = guidance[:80] + ("…" if len(guidance) > 80 else "")
+        return f"Spawned {name}. Guidance injected: '{snippet}'"
+    return f"Spawned {name}."
+
+
 _ALL_TOOLS = [
     chat_send, chat_read, chat_resync, chat_join, chat_who, chat_rules, chat_decision,
-    chat_channels, chat_set_hat, chat_claim, chat_summary, chat_propose_job,
+    chat_channels, chat_set_hat, chat_claim, chat_summary, chat_propose_job, chat_spawn,
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.110
 uvicorn[standard]>=0.29
 mcp>=1.0
+psutil>=5.9

--- a/static/chat.js
+++ b/static/chat.js
@@ -1055,6 +1055,176 @@ document.addEventListener('keydown', (e) => {
     }
 });
 
+// --- Terminal webcam popover ---
+
+let _termPopoverCloseTimer = null;
+let _termPopoverPollInterval = null;
+
+function stripAnsi(str) {
+    return (str || '').replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function detectActions(raw) {
+    const actions = [];
+    const r = (raw || '').toLowerCase();
+    if (/\(y\/n\)|y\/n\?|\[y\/n\]/i.test(r)) {
+        actions.push({ label: 'Yes', keys: 'y', enter: true });
+        actions.push({ label: 'No', keys: 'n', enter: true });
+    }
+    if (/action required/i.test(r)) {
+        actions.push({ label: 'Accept', keys: '', enter: true });
+    }
+    if (/untrusted|folder is untrusted|trust folder/i.test(r)) {
+        actions.push({ label: 'Trust folder', keys: '1', enter: true });
+    }
+    if (/press .* to continue|press enter|continue/i.test(r)) {
+        actions.push({ label: 'Enter', keys: '', enter: true });
+    }
+    return actions;
+}
+
+async function fetchTerminal(name, lines = 50) {
+    const resp = await fetch(`/api/terminal/${encodeURIComponent(name)}?lines=${lines}`, {
+        headers: { 'X-Session-Token': SESSION_TOKEN },
+    });
+    return resp.json();
+}
+
+async function sendInput(name, text, enter) {
+    const resp = await fetch(`/api/terminal/${encodeURIComponent(name)}/input`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Session-Token': SESSION_TOKEN },
+        body: JSON.stringify({ text: text || '', enter: enter !== false }),
+    });
+    return resp.json();
+}
+
+function schedulePopoverClose() {
+    if (_termPopoverCloseTimer) clearTimeout(_termPopoverCloseTimer);
+    _termPopoverCloseTimer = setTimeout(() => {
+        _termPopoverCloseTimer = null;
+        if (_termPopoverPollInterval) {
+            clearInterval(_termPopoverPollInterval);
+            _termPopoverPollInterval = null;
+        }
+        const popover = document.getElementById('term-popover');
+        if (popover) popover.classList.add('hidden');
+    }, 250);
+}
+
+function showTerminalPopover(name, pillEl) {
+    if (_termPopoverCloseTimer) {
+        clearTimeout(_termPopoverCloseTimer);
+        _termPopoverCloseTimer = null;
+    }
+    let popover = document.getElementById('term-popover');
+    if (!popover) {
+        popover = document.createElement('div');
+        popover.id = 'term-popover';
+        popover.className = 'term-popover hidden';
+        popover.innerHTML = `
+            <div class="term-title"></div>
+            <pre class="term-screen"></pre>
+            <div class="term-actions"></div>
+            <div class="term-input-row">
+                <input type="text" class="term-input" placeholder="Type or send keys..." spellcheck="false" autocomplete="off" />
+                <button type="button" class="term-send-btn">Send</button>
+            </div>`;
+        popover.addEventListener('mouseenter', () => {
+            if (_termPopoverCloseTimer) clearTimeout(_termPopoverCloseTimer);
+            _termPopoverCloseTimer = null;
+        });
+        popover.addEventListener('mouseleave', schedulePopoverClose);
+        document.body.appendChild(popover);
+    }
+    const cfg = agentConfig[name] || {};
+    const label = cfg.label || name;
+    const color = cfg.color || '#4ade80';
+    popover.style.setProperty('--agent-color', color);
+    popover.querySelector('.term-title').textContent = `${label} — terminal`;
+    popover.querySelector('.term-screen').textContent = 'Loading...';
+    popover.querySelector('.term-actions').innerHTML = '';
+    popover.querySelector('.term-input').value = '';
+    popover.classList.remove('hidden');
+
+    const rect = pillEl.getBoundingClientRect();
+    const popoverHeight = 320;
+    const above = rect.top > popoverHeight + 20;
+    popover.style.top = above ? `${rect.top - popoverHeight - 8}px` : `${rect.bottom + 8}px`;
+    const popoverWidth = 520;
+    const leftRaw = rect.left + rect.width / 2 - popoverWidth / 2;
+    popover.style.left = `${Math.min(Math.max(8, leftRaw), window.innerWidth - popoverWidth - 8)}px`;
+
+    const inputEl = popover.querySelector('.term-input');
+    const sendBtn = popover.querySelector('.term-send-btn');
+    sendBtn.onclick = () => {
+        const text = inputEl.value;
+        if (!text) return;
+        sendInput(name, text, true).catch(() => {});
+        inputEl.value = '';
+    };
+    inputEl.onkeydown = (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            sendBtn.click();
+        }
+    };
+
+    popover.dataset.agentName = name;
+    // Lines requested from the server — starts small, grows when user loads more
+    let fetchLines = 50;
+
+    async function poll() {
+        const data = await fetchTerminal(name, fetchLines);
+        const screenEl = popover.querySelector('.term-screen');
+        const actionsEl = popover.querySelector('.term-actions');
+        if (!popover.classList.contains('hidden') && popover.dataset.agentName === name) {
+            if (data.available) {
+                const display = stripAnsi(data.raw || '');
+                const atBottom = screenEl.scrollHeight - screenEl.scrollTop - screenEl.clientHeight < 40;
+                screenEl.textContent = display || '(no output)';
+                if (atBottom) screenEl.scrollTop = screenEl.scrollHeight;
+
+                // "Load more" button — appears when user has scrolled to the top
+                // and there might be more history available
+                const hasMore = (data.lines || []).length >= fetchLines && fetchLines < 500;
+                let loadMoreBtn = screenEl.nextElementSibling?.classList?.contains('term-load-more')
+                    ? screenEl.nextElementSibling
+                    : null;
+                if (hasMore && !loadMoreBtn) {
+                    loadMoreBtn = document.createElement('button');
+                    loadMoreBtn.className = 'term-load-more';
+                    loadMoreBtn.textContent = '↑ Load more history';
+                    loadMoreBtn.onclick = () => {
+                        fetchLines = Math.min(fetchLines + 100, 500);
+                        poll();
+                    };
+                    screenEl.insertAdjacentElement('afterend', loadMoreBtn);
+                } else if (!hasMore && loadMoreBtn) {
+                    loadMoreBtn.remove();
+                }
+
+                const actions = detectActions(data.raw);
+                actionsEl.innerHTML = '';
+                actions.forEach(a => {
+                    const btn = document.createElement('button');
+                    btn.className = 'term-action-btn';
+                    btn.textContent = a.label;
+                    btn.onclick = () => sendInput(name, a.keys, a.enter).then(() => poll()).catch(() => {});
+                    actionsEl.appendChild(btn);
+                });
+            } else {
+                screenEl.textContent = 'No tmux session (Mac/Linux only)';
+                actionsEl.innerHTML = '';
+            }
+        }
+    }
+
+    poll();
+    if (_termPopoverPollInterval) clearInterval(_termPopoverPollInterval);
+    _termPopoverPollInterval = setInterval(poll, 1500);
+}
+
 function buildStatusPills() {
     const container = document.getElementById('agent-status');
     container.innerHTML = '';
@@ -1063,10 +1233,16 @@ function buildStatusPills() {
         pill.className = 'status-pill';
         if (cfg.state === 'pending') pill.classList.add('pending');
         pill.id = `status-${name}`;
-        pill.title = `@${name}`;  // Tooltip: canonical name for manual @-typing
+        pill.title = `@${name}`;
         pill.style.setProperty('--agent-color', cfg.color || '#4ade80');
-        pill.innerHTML = `<span class="status-dot"></span><span class="status-label">${escapeHtml(cfg.label || name)}</span>`;
-        // Left-click to rename or name pending instance
+        pill.innerHTML = `
+            <span class="status-dot"></span>
+            <span class="status-label">${escapeHtml(cfg.label || name)}</span>
+            <button class="pill-kill" title="Kill ${escapeHtml(name)}" aria-label="Kill ${escapeHtml(name)}">×</button>`;
+        pill.querySelector('.pill-kill').addEventListener('click', (e) => {
+            e.stopPropagation();
+            killAgent(name);
+        });
         pill.addEventListener('click', () => {
             const mode = cfg.state === 'pending' ? 'pending' : 'rename';
             showAgentNameModal({
@@ -1074,9 +1250,104 @@ function buildStatusPills() {
                 base: cfg.base || '', mode,
             });
         });
+        pill.addEventListener('mouseenter', () => showTerminalPopover(name, pill));
+        pill.addEventListener('mouseleave', schedulePopoverClose);
         container.appendChild(pill);
     }
+
+    // Spawn button — always at the end of the pills row
+    const spawnBtn = document.createElement('button');
+    spawnBtn.className = 'pill-spawn-btn';
+    spawnBtn.title = 'Spawn agent instance';
+    spawnBtn.textContent = '+';
+    spawnBtn.addEventListener('click', showSpawnModal);
+    container.appendChild(spawnBtn);
+
     enableDragScroll(container);
+}
+
+// --- Spawn modal ---
+
+function showSpawnModal() {
+    const spawnableAgents = Object.entries(baseColors)
+        .filter(([, cfg]) => cfg.spawnable)
+        .sort(([a], [b]) => a.localeCompare(b));
+
+    if (spawnableAgents.length === 0) {
+        alert('No spawnable agents configured.');
+        return;
+    }
+
+    let modal = document.getElementById('spawn-modal');
+    if (!modal) {
+        modal = document.createElement('div');
+        modal.id = 'spawn-modal';
+        modal.className = 'spawn-modal hidden';
+        modal.innerHTML = `
+            <div class="spawn-dialog">
+                <h3 class="spawn-title">Spawn agent</h3>
+                <label class="spawn-label">Agent</label>
+                <select class="spawn-agent-select"></select>
+                <label class="spawn-label">Guidance <span class="spawn-optional">(optional)</span></label>
+                <textarea class="spawn-guidance" rows="3" placeholder="Initial instructions for this instance…" spellcheck="false"></textarea>
+                <div class="spawn-actions">
+                    <button class="spawn-cancel">Cancel</button>
+                    <button class="spawn-confirm">Spawn</button>
+                </div>
+            </div>`;
+        modal.addEventListener('click', (e) => { if (e.target === modal) _closeSpawnModal(); });
+        modal.querySelector('.spawn-cancel').addEventListener('click', _closeSpawnModal);
+        document.body.appendChild(modal);
+    }
+
+    const select = modal.querySelector('.spawn-agent-select');
+    select.innerHTML = spawnableAgents
+        .map(([name, cfg]) => `<option value="${escapeHtml(name)}">${escapeHtml(cfg.label || name)}</option>`)
+        .join('');
+    modal.querySelector('.spawn-guidance').value = '';
+    modal.classList.remove('hidden');
+    select.focus();
+
+    const confirmBtn = modal.querySelector('.spawn-confirm');
+    confirmBtn.onclick = async () => {
+        const agent = select.value;
+        const guidance = modal.querySelector('.spawn-guidance').value.trim();
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = 'Spawning…';
+        try {
+            const res = await fetch(`/api/agents/${encodeURIComponent(agent)}/spawn`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Session-Token': SESSION_TOKEN },
+                body: JSON.stringify({ guidance }),
+            });
+            const data = await res.json();
+            if (data.error) throw new Error(data.error);
+            _closeSpawnModal();
+        } catch (err) {
+            confirmBtn.disabled = false;
+            confirmBtn.textContent = 'Spawn';
+            alert(`Spawn failed: ${err.message}`);
+        }
+    };
+}
+
+function _closeSpawnModal() {
+    const modal = document.getElementById('spawn-modal');
+    if (modal) modal.classList.add('hidden');
+}
+
+async function killAgent(name) {
+    if (!confirm(`Kill ${name}?`)) return;
+    try {
+        const res = await fetch(`/api/agents/${encodeURIComponent(name)}/kill`, {
+            method: 'POST',
+            headers: { 'X-Session-Token': SESSION_TOKEN },
+        });
+        const data = await res.json();
+        if (data.error) throw new Error(data.error);
+    } catch (err) {
+        alert(`Kill failed: ${err.message}`);
+    }
 }
 
 // --- Agent naming lightbox ---
@@ -1407,6 +1678,19 @@ function applySettings(data) {
     if (data.rules_refresh_interval !== undefined) {
         document.getElementById('setting-rules-refresh').value = String(data.rules_refresh_interval);
     }
+    if (data.routing_default) {
+        document.getElementById('setting-routing').value = data.routing_default;
+    }
+    if (data.project_dir !== undefined) {
+        const pd = data.project_dir;
+        document.getElementById('setting-project-dir').value = pd;
+        const display = document.getElementById('project-dir-display');
+        display.textContent = pd || 'Not selected';
+        display.title = pd || '';
+    }
+    if (data.auto_approve !== undefined) {
+        document.getElementById('setting-auto-approve').checked = !!data.auto_approve;
+    }
     if (data.channels && Array.isArray(data.channels)) {
         channelList = data.channels;
         // If active channel was deleted, switch to general
@@ -1451,6 +1735,9 @@ function saveSettings() {
     const newHistory = histVal === 'all' ? 'all' : (parseInt(histVal) || 50);
     const newContrast = document.getElementById('setting-contrast').value;
     const newRulesRefresh = document.getElementById('setting-rules-refresh').value;
+    const newRouting = document.getElementById('setting-routing').value;
+    const newProjectDir = document.getElementById('setting-project-dir').value.trim();
+    const newAutoApprove = document.getElementById('setting-auto-approve').checked;
 
     if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({
@@ -1462,6 +1749,9 @@ function saveSettings() {
                 history_limit: newHistory,
                 contrast: newContrast,
                 rules_refresh_interval: parseInt(newRulesRefresh) || 0,
+                routing_default: newRouting,
+                project_dir: newProjectDir,
+                auto_approve: newAutoApprove,
             }
         }));
     }
@@ -1484,7 +1774,7 @@ function setupSettingsKeys() {
     }
 
     // Auto-save on change for selects, escape to close
-    for (const id of ['setting-font', 'setting-history', 'setting-contrast', 'setting-rules-refresh']) {
+    for (const id of ['setting-font', 'setting-history', 'setting-contrast', 'setting-rules-refresh', 'setting-routing']) {
         const el = document.getElementById(id);
         el.addEventListener('change', () => {
             // Apply contrast immediately (don't wait for server round-trip)
@@ -1499,7 +1789,134 @@ function setupSettingsKeys() {
             }
         });
     }
+
+    // Auto-save on change for checkbox
+    const autoApproveEl = document.getElementById('setting-auto-approve');
+    autoApproveEl.addEventListener('change', () => saveSettings());
+    autoApproveEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') toggleSettings();
+    });
+
+    // Browse project directory
+    document.getElementById('browse-project-dir').addEventListener('click', openFolderPicker);
+
+    // Start all agents
+    document.getElementById('start-all-agents-btn').addEventListener('click', startAllAgents);
+
+    // Stop all agents
+    document.getElementById('stop-all-agents-btn').addEventListener('click', stopAllAgents);
 }
+
+let _folderPickerCurrentPath = '';
+
+function openFolderPicker() {
+    _folderPickerCurrentPath = '';
+    document.getElementById('folder-picker-modal').classList.remove('hidden');
+    loadFolderPicker('');
+}
+
+function closeFolderPicker() {
+    document.getElementById('folder-picker-modal').classList.add('hidden');
+}
+
+function loadFolderPicker(path) {
+    const listEl = document.getElementById('folder-picker-list');
+    const breadcrumbEl = document.getElementById('folder-picker-breadcrumb');
+    listEl.innerHTML = 'Loading...';
+    fetch('/api/browse?path=' + encodeURIComponent(path), {
+        headers: { 'X-Session-Token': SESSION_TOKEN }
+    })
+        .then(r => r.json())
+        .then(data => {
+            if (data.error) {
+                listEl.innerHTML = '<span class="folder-picker-error">' + (data.error || 'Error') + '</span>';
+                return;
+            }
+            _folderPickerCurrentPath = data.path || '';
+            breadcrumbEl.textContent = data.path || 'Root';
+            listEl.innerHTML = '';
+            if (data.parent) {
+                const parentItem = document.createElement('div');
+                parentItem.className = 'folder-picker-item';
+                parentItem.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16"><path d="M10 12L6 8l4-4" stroke="currentColor" stroke-width="2" fill="none"/></svg><span>..</span>';
+                parentItem.onclick = () => loadFolderPicker(data.parent);
+                listEl.appendChild(parentItem);
+            }
+            const dirs = data.directories || [];
+            dirs.forEach(d => {
+                const item = document.createElement('div');
+                item.className = 'folder-picker-item';
+                item.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16"><path d="M2 4h4l2 2h6v6H2z" stroke="currentColor" stroke-width="1.2" fill="none"/></svg><span>' + (d.name || d.path) + '</span>';
+                item.onclick = () => loadFolderPicker(d.path);
+                listEl.appendChild(item);
+            });
+        })
+        .catch(() => {
+            listEl.innerHTML = '<span class="folder-picker-error">Failed to load</span>';
+        });
+}
+
+function selectCurrentFolder() {
+    document.getElementById('setting-project-dir').value = _folderPickerCurrentPath;
+    const display = document.getElementById('project-dir-display');
+    display.textContent = _folderPickerCurrentPath || 'Not selected';
+    display.title = _folderPickerCurrentPath || '';
+    closeFolderPicker();
+    saveSettings();
+}
+
+function startAllAgents() {
+    const btn = document.getElementById('start-all-agents-btn');
+    btn.disabled = true;
+    btn.textContent = 'Starting...';
+    saveSettings();
+    setTimeout(() => {
+        fetch('/api/agents/start', {
+            method: 'POST',
+            headers: { 'X-Session-Token': SESSION_TOKEN }
+        })
+        .then(r => r.json())
+        .then(data => {
+            btn.disabled = false;
+            btn.textContent = 'Start all agents';
+            if (data.started && data.started.length > 0) {
+                console.log('Started agents:', data.started);
+            }
+        })
+        .catch(() => {
+            btn.disabled = false;
+            btn.textContent = 'Start all agents';
+        });
+    }, 300);
+}
+
+function stopAllAgents() {
+    const btn = document.getElementById('stop-all-agents-btn');
+    btn.disabled = true;
+    btn.textContent = 'Stopping...';
+    fetch('/api/agents/stop', {
+        method: 'POST',
+        headers: { 'X-Session-Token': SESSION_TOKEN }
+    })
+        .then(r => {
+            if (!r.ok) throw new Error(r.statusText);
+            return r.json();
+        })
+        .then(data => {
+            btn.disabled = false;
+            btn.textContent = 'Stop all agents';
+            if (data.error) console.error('Stop agents:', data.error);
+        })
+        .catch(err => {
+            btn.disabled = false;
+            btn.textContent = 'Stop all agents';
+            console.error('Stop agents failed:', err);
+        });
+}
+
+window.closeFolderPicker = closeFolderPicker;
+window.selectCurrentFolder = selectCurrentFolder;
+window.openFolderPicker = openFolderPicker;
 
 // --- Keyboard shortcuts ---
 
@@ -1509,6 +1926,8 @@ function setupKeyboardShortcuts() {
         const modalOpen = modal && !modal.classList.contains('hidden');
 
         if (e.key === 'Escape') {
+            const folderModal = document.getElementById('folder-picker-modal');
+            if (folderModal && !folderModal.classList.contains('hidden')) { closeFolderPicker(); return; }
             const nameModal = document.getElementById('agent-name-modal');
             if (nameModal && !nameModal.classList.contains('hidden')) { _closeAgentNameModal(); return; }
             const convertModal = document.getElementById('convert-job-modal');

--- a/static/index.html
+++ b/static/index.html
@@ -21,8 +21,8 @@
                 </a>
                 <span class="subtitle" id="room-subtitle"></span>
             </div>
+            <div id="agent-status"></div>
             <div class="header-right">
-                <div id="agent-status"></div>
                 <button class="settings-btn" id="jobs-toggle" onclick="toggleJobsPanel()" title="Jobs">
                     <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                         <rect x="3" y="2" width="10" height="12" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
@@ -53,6 +53,26 @@
         </header>
 
         <div id="settings-bar" class="hidden">
+            <div class="settings-section-label">Setup</div>
+            <div class="settings-field">
+                <label>Project directory</label>
+                <div class="project-dir-row">
+                    <button type="button" id="browse-project-dir" class="browse-btn">Browse</button>
+                    <span id="project-dir-display" class="project-dir-display">Not selected</span>
+                    <input type="hidden" id="setting-project-dir">
+                </div>
+            </div>
+            <div class="settings-field">
+                <label for="setting-auto-approve">Auto-approve</label>
+                <input type="checkbox" id="setting-auto-approve" title="Skip permission prompts — agents run without asking. Restart agents to apply.">
+                <span class="settings-hint">Restart agents to apply</span>
+            </div>
+            <div class="settings-field settings-agent-buttons">
+                <button type="button" id="start-all-agents-btn" class="start-agents-btn">Start all agents</button>
+                <button type="button" id="stop-all-agents-btn" class="stop-agents-btn">Stop all agents</button>
+            </div>
+            <div class="settings-divider"></div>
+            <div class="settings-section-label">Appearance</div>
             <div class="settings-field">
                 <label for="setting-username">Name</label>
                 <input type="text" id="setting-username" placeholder="your name" maxlength="20">
@@ -94,6 +114,13 @@
                     <option value="10" selected>Every 10 triggers</option>
                     <option value="20">Every 20 triggers</option>
                     <option value="50">Every 50 triggers</option>
+                </select>
+            </div>
+            <div class="settings-field">
+                <label for="setting-routing">Routing</label>
+                <select id="setting-routing" title="Who receives messages without @mentions">
+                    <option value="none">Only @mentions</option>
+                    <option value="all">All agents</option>
                 </select>
             </div>
             <div class="settings-divider"></div>
@@ -160,7 +187,9 @@
                             <button class="job-toggle archived" data-status="archived" onclick="toggleJobStatus('archived')" title="Closed">CLOSED</button>
                         </div>
                     </div>
-                    <div class="jobs-conv-messages" id="jobs-conv-messages"></div>
+                    <div class="jobs-conv-scroll" id="jobs-conv-scroll">
+                        <div class="jobs-conv-messages" id="jobs-conv-messages"></div>
+                    </div>
                     <div class="jobs-conv-input">
                         <div id="job-mention-menu" class="mention-menu hidden"></div>
                         <div id="job-attachments" class="job-attachments"></div>
@@ -227,6 +256,21 @@
 
     <div id="dropzone" class="hidden">
         <div class="dropzone-inner">Drop image here</div>
+    </div>
+
+    <div id="folder-picker-modal" class="folder-picker-modal hidden">
+        <div class="folder-picker-dialog">
+            <div class="folder-picker-header">
+                <h3>Select project directory</h3>
+                <button type="button" class="folder-picker-close" onclick="closeFolderPicker()" aria-label="Close">&times;</button>
+            </div>
+            <div class="folder-picker-breadcrumb" id="folder-picker-breadcrumb"></div>
+            <div class="folder-picker-list" id="folder-picker-list"></div>
+            <div class="folder-picker-actions">
+                <button type="button" class="folder-picker-select-btn" id="folder-picker-select-btn" onclick="selectCurrentFolder()">Select this folder</button>
+                <button type="button" class="folder-picker-cancel-btn" onclick="closeFolderPicker()">Cancel</button>
+            </div>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/static/jobs.css
+++ b/static/jobs.css
@@ -529,12 +529,16 @@ body.archive-no-select * {
     font-size: 11px;
 }
 
-.jobs-conv-messages {
+.jobs-conv-scroll {
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 8px 0;
     min-height: 0;
+    -webkit-overflow-scrolling: touch;
+}
+
+.jobs-conv-messages {
+    padding: 8px 0;
 }
 
 .job-msg {

--- a/static/jobs.js
+++ b/static/jobs.js
@@ -903,8 +903,9 @@ async function openJobConversation(jobId) {
         briefEl = document.createElement('div');
         briefEl.className = 'job-brief-card';
         briefEl.innerHTML = `<div class="job-brief-text">${window.renderMarkdown(job.body)}</div>`;
+        const scrollContainer = document.getElementById('jobs-conv-scroll');
         const messagesContainer = document.getElementById('jobs-conv-messages');
-        messagesContainer.parentNode.insertBefore(briefEl, messagesContainer);
+        scrollContainer.insertBefore(briefEl, messagesContainer);
     }
 
     // Load messages before showing the view
@@ -970,7 +971,8 @@ async function loadJobMessages(jobId) {
             appendJobMessage(msg);
         }
 
-        container.scrollTop = container.scrollHeight;
+        const scrollEl = document.getElementById('jobs-conv-scroll');
+        if (scrollEl) scrollEl.scrollTop = scrollEl.scrollHeight;
         return msgs;
     } catch (e) {
         container.innerHTML = '<div class="jobs-empty">Failed to load messages.</div>';
@@ -1419,8 +1421,8 @@ function handleJobEvent(action, data) {
         // If we're viewing this job, append the message. Otherwise count unread.
         if (isViewingThis) {
             appendJobMessage(data.message);
-            const container = document.getElementById('jobs-conv-messages');
-            if (container) container.scrollTop = container.scrollHeight;
+            const scrollEl = document.getElementById('jobs-conv-scroll');
+            if (scrollEl) scrollEl.scrollTop = scrollEl.scrollHeight;
             markJobRead(data.job_id);
         } else if (!isSelfMessage) {
             jobUnread[data.job_id] = (jobUnread[data.job_id] || 0) + 1;

--- a/static/style.css
+++ b/static/style.css
@@ -149,8 +149,8 @@ body.high-contrast {
 /* --- Header --- */
 
 header {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
     padding: 12px 16px;
     background: var(--bg-header);
@@ -224,13 +224,14 @@ header h1 {
     display: flex;
     align-items: center;
     gap: 12px;
+    justify-content: flex-end;
 }
 
 #agent-status {
     display: flex;
     gap: 12px;
     overflow-x: auto;
-    max-width: 60vw;
+    justify-content: center;
     scrollbar-width: none;
 }
 #agent-status::-webkit-scrollbar { display: none; }
@@ -247,7 +248,151 @@ header h1 {
     transition: background 0.2s, border-color 0.2s;
     cursor: pointer;
     flex-shrink: 0;
+    position: relative;
 }
+
+/* Kill × button — hidden by default, shown on pill hover */
+.pill-kill {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    margin-left: 2px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.12);
+    border: none;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 11px;
+    line-height: 1;
+    cursor: pointer;
+    flex-shrink: 0;
+    padding: 0;
+    transition: background 0.15s, color 0.15s;
+}
+.status-pill:hover .pill-kill {
+    display: flex;
+}
+.pill-kill:hover {
+    background: rgba(239, 68, 68, 0.5);
+    color: #fff;
+}
+
+/* Spawn + button — always visible at the end of the pills row */
+.pill-spawn-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: transparent;
+    border: 1px dashed rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.35);
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.pill-spawn-btn:hover {
+    border-color: rgba(255, 255, 255, 0.5);
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.07);
+}
+
+/* Spawn modal */
+.spawn-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 8000;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.spawn-modal.hidden { display: none; }
+
+.spawn-dialog {
+    background: var(--bg-secondary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    width: 360px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+}
+.spawn-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 4px;
+}
+.spawn-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+.spawn-optional {
+    font-weight: 400;
+    opacity: 0.6;
+}
+.spawn-agent-select {
+    padding: 7px 10px;
+    border-radius: var(--radius-md);
+    background: var(--bg-input);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: var(--text-primary);
+    font-size: 13px;
+    cursor: pointer;
+}
+.spawn-guidance {
+    padding: 8px 10px;
+    border-radius: var(--radius-md);
+    background: var(--bg-input);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: inherit;
+    resize: vertical;
+    min-height: 72px;
+}
+.spawn-guidance::placeholder { color: rgba(255, 255, 255, 0.3); }
+.spawn-guidance:focus, .spawn-agent-select:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.3);
+}
+.spawn-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 4px;
+}
+.spawn-cancel {
+    padding: 7px 14px;
+    border-radius: var(--radius-md);
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: var(--text-secondary);
+    font-size: 13px;
+    cursor: pointer;
+}
+.spawn-cancel:hover { background: rgba(255, 255, 255, 0.07); }
+.spawn-confirm {
+    padding: 7px 16px;
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.spawn-confirm:hover { background: rgba(255, 255, 255, 0.2); }
+.spawn-confirm:disabled { opacity: 0.5; cursor: default; }
 
 .status-dot {
     width: 8px;
@@ -321,6 +466,144 @@ header h1 {
 
 @keyframes spin-border {
     to { --border-angle: 360deg; }
+}
+
+/* --- Terminal webcam popover --- */
+
+.term-popover {
+    position: fixed;
+    z-index: 9000;
+    width: 520px;
+    min-height: 280px;
+    max-height: 70vh;
+    background: #0d0d0d;
+    border: 1px solid var(--agent-color, #4ade80);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    resize: both;
+}
+
+.term-popover.hidden {
+    display: none;
+}
+
+.term-popover .term-title {
+    padding: 8px 12px;
+    font-size: 12px;
+    color: var(--agent-color, #4ade80);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    flex-shrink: 0;
+}
+
+.term-popover .term-screen {
+    flex: 1;
+    min-height: 180px;
+    margin: 0;
+    padding: 10px 12px;
+    font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, monospace;
+    font-size: 11px;
+    line-height: 1.5;
+    color: #e0e0e0;
+    background: #0d0d0d;
+    overflow-y: auto;
+    overflow-x: auto;
+    white-space: pre;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+}
+
+.term-popover .term-screen::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+.term-popover .term-screen::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 3px;
+}
+.term-popover .term-screen::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.term-load-more {
+    display: block;
+    width: 100%;
+    padding: 4px 12px;
+    font-size: 11px;
+    font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, monospace;
+    background: rgba(255, 255, 255, 0.05);
+    border: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.4);
+    cursor: pointer;
+    text-align: center;
+    flex-shrink: 0;
+}
+.term-load-more:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.term-popover .term-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    flex-shrink: 0;
+}
+
+.term-popover .term-action-btn {
+    padding: 4px 10px;
+    font-size: 11px;
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--agent-color, #4ade80);
+    color: var(--agent-color, #4ade80);
+    cursor: pointer;
+}
+
+.term-popover .term-action-btn:hover {
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.term-popover .term-input-row {
+    display: flex;
+    gap: 8px;
+    padding: 8px 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    flex-shrink: 0;
+}
+
+.term-popover .term-input-row input {
+    flex: 1;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-family: inherit;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: var(--radius-md);
+    color: #e0e0e0;
+}
+
+.term-popover .term-input-row input::placeholder {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.term-popover .term-send-btn {
+    padding: 6px 12px;
+    font-size: 12px;
+    border-radius: var(--radius-md);
+    background: var(--agent-color, #4ade80);
+    color: #0d0d0d;
+    border: none;
+    cursor: pointer;
+}
+
+.term-popover .term-send-btn:hover {
+    opacity: 0.9;
 }
 
 .settings-btn {
@@ -2364,6 +2647,188 @@ pre:hover .code-copy-btn { opacity: 1; }
 }
 
 .agent-name-modal.hidden { display: none; }
+
+/* --- Setup section --- */
+.settings-section-label {
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-semibold);
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin: var(--space-sm) 0 var(--space-xs) 0;
+}
+.settings-section-label:first-child { margin-top: 0; }
+.project-dir-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+}
+.project-dir-row .browse-btn {
+    padding: 6px 12px;
+    font-size: var(--fs-sm);
+    background: var(--accent);
+    color: var(--text-on-accent);
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    font-family: inherit;
+}
+.project-dir-row .browse-btn:hover { background: var(--accent-hover); }
+.project-dir-display {
+    font-size: var(--fs-sm);
+    color: var(--text-dim);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 180px;
+}
+.settings-agent-buttons {
+    display: flex;
+    gap: var(--space-sm);
+}
+.start-agents-btn {
+    flex: 1;
+    padding: 10px 16px;
+    font-size: var(--fs-base);
+    font-weight: var(--fw-medium);
+    background: var(--success);
+    color: #0a0a12;
+    border: none;
+    border-radius: var(--radius-lg);
+    cursor: pointer;
+    font-family: inherit;
+}
+.start-agents-btn:hover { background: #4ade80; filter: brightness(1.05); }
+.start-agents-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.stop-agents-btn {
+    flex: 1;
+    padding: 10px 16px;
+    font-size: var(--fs-base);
+    font-weight: var(--fw-medium);
+    background: var(--danger);
+    color: var(--text-on-accent);
+    border: none;
+    border-radius: var(--radius-lg);
+    cursor: pointer;
+    font-family: inherit;
+}
+.stop-agents-btn:hover { background: #dc2626; filter: brightness(1.05); }
+.stop-agents-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.settings-hint {
+    font-size: var(--fs-xs);
+    color: var(--text-dim);
+    margin-left: var(--space-sm);
+}
+.settings-field input[type="checkbox"] + .settings-hint { display: inline; }
+
+/* --- Folder picker modal --- */
+.folder-picker-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    animation: fadeIn 0.15s ease-out;
+}
+.folder-picker-modal.hidden { display: none; }
+.folder-picker-dialog {
+    background: var(--bg-header);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    padding: 20px 24px;
+    min-width: 420px;
+    max-width: 520px;
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    animation: modal-slide-in 0.2s ease-out;
+}
+.folder-picker-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-md);
+}
+.folder-picker-header h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text);
+}
+.folder-picker-close {
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    font-size: 24px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 4px;
+}
+.folder-picker-close:hover { color: var(--text); }
+.folder-picker-breadcrumb {
+    font-size: var(--fs-sm);
+    color: var(--text-dim);
+    margin-bottom: var(--space-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.folder-picker-list {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 200px;
+    max-height: 320px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-input);
+    padding: var(--space-xs);
+}
+.folder-picker-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: var(--fs-base);
+    color: var(--text);
+}
+.folder-picker-item:hover { background: var(--accent-soft); }
+.folder-picker-item svg {
+    flex-shrink: 0;
+    color: var(--text-dim);
+}
+.folder-picker-actions {
+    display: flex;
+    gap: var(--space-sm);
+    padding-top: var(--space-md);
+}
+.folder-picker-select-btn {
+    padding: 8px 18px;
+    background: var(--accent);
+    color: var(--text-on-accent);
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: var(--fs-sm);
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+}
+.folder-picker-select-btn:hover { background: var(--accent-hover); }
+.folder-picker-cancel-btn {
+    padding: 8px 18px;
+    background: var(--white-06);
+    color: var(--text);
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: var(--fs-sm);
+    cursor: pointer;
+    font-family: inherit;
+}
+.folder-picker-cancel-btn:hover { background: var(--white-08); }
+.folder-picker-error { color: var(--error-color); font-size: var(--fs-sm); }
 
 .agent-name-dialog {
     background: var(--bg-header);

--- a/wrapper.py
+++ b/wrapper.py
@@ -23,6 +23,7 @@ import shutil
 import sys
 import threading
 import time
+import urllib.request
 from pathlib import Path
 
 ROOT = Path(__file__).parent
@@ -38,9 +39,14 @@ def _write_json_mcp_settings(config_file: Path, url: str, transport: str = "http
                               *, token: str = "") -> Path:
     """Write/merge a settings-style JSON file with nested mcpServers config.
 
-    Preserves existing servers in the file — only updates the agentchattr entry."""
+    Preserves existing servers in the file — only updates the agentchattr entry.
+
+    Gemini CLI 0.32+ expects:
+      - "httpUrl" key (not "url") for streamable-http transport
+      - "url" key for SSE transport
+      - "trust": true to skip per-call approval prompts
+    """
     config_file.parent.mkdir(parents=True, exist_ok=True)
-    # Read existing file to preserve other servers
     existing: dict = {}
     if config_file.exists():
         try:
@@ -48,7 +54,11 @@ def _write_json_mcp_settings(config_file: Path, url: str, transport: str = "http
         except Exception:
             pass
     servers = existing.get("mcpServers", {})
-    entry: dict = {"type": transport, "url": url}
+    # Gemini CLI uses "httpUrl" for streamable-http, "url" for SSE
+    if transport in ("http", "streamable-http"):
+        entry: dict = {"httpUrl": url, "trust": True}
+    else:
+        entry = {"url": url, "trust": True}
     if token:
         entry["headers"] = {"Authorization": f"Bearer {token}"}
     servers[SERVER_NAME] = entry
@@ -113,7 +123,7 @@ _BUILTIN_DEFAULTS: dict[str, dict] = {
     "gemini": {
         "mcp_inject": "env",
         "mcp_env_var": "GEMINI_CLI_SYSTEM_SETTINGS_PATH",
-        "mcp_transport": "sse",
+        "mcp_transport": "http",  # streamable-http; SSE (port 8201) has blocking issues in 0.32.x
     },
     "codex": {
         "mcp_inject": "proxy_flag",
@@ -124,6 +134,13 @@ _BUILTIN_DEFAULTS: dict[str, dict] = {
         "mcp_flag": "--mcp-config-file",
         "mcp_transport": "http",
     },
+}
+
+_YOLO_FLAGS: dict[str, list[str]] = {
+    "claude": ["--dangerously-skip-permissions"],
+    "codex": ["--dangerously-bypass-approvals-and-sandbox"],
+    "gemini": ["--yolo"],
+    "kimi": ["--yolo"],
 }
 
 _VALID_INJECT_MODES = {"settings_file", "env", "flag", "proxy_flag"}
@@ -222,6 +239,41 @@ def _apply_mcp_inject(
         launch_args = expanded.split()
 
     return launch_args, inject_env, settings_path
+
+
+def _ensure_gemini_folder_trusted(project_dir: Path) -> None:
+    """Add project_dir as TRUST_FOLDER in ~/.gemini/trustedFolders.json.
+
+    Gemini CLI blocks ALL MCPs (including system-settings ones) for untrusted
+    folders. A more-specific TRUST_FOLDER entry overrides any parent-level
+    DO_NOT_TRUST rule, so we always write the exact cwd we're launching in.
+    Respects GEMINI_CLI_TRUSTED_FOLDERS_PATH env override if set.
+    """
+    import os as _os
+    trusted_path_env = _os.environ.get("GEMINI_CLI_TRUSTED_FOLDERS_PATH", "")
+    if trusted_path_env:
+        trusted_file = Path(trusted_path_env)
+    else:
+        trusted_file = Path.home() / ".gemini" / "trustedFolders.json"
+
+    try:
+        data: dict = {}
+        if trusted_file.exists():
+            try:
+                data = json.loads(trusted_file.read_text("utf-8"))
+            except Exception:
+                data = {}
+
+        folder_key = str(project_dir)
+        if data.get(folder_key) == "TRUST_FOLDER":
+            return  # already trusted — nothing to do
+
+        data[folder_key] = "TRUST_FOLDER"
+        trusted_file.parent.mkdir(parents=True, exist_ok=True)
+        trusted_file.write_text(json.dumps(data, indent=2) + "\n", "utf-8")
+        print(f"  Trusted folder for Gemini MCPs: {folder_key}")
+    except Exception as exc:
+        print(f"  Warning: could not update Gemini trusted folders: {exc}")
 
 
 def _build_provider_launch(
@@ -479,6 +531,21 @@ def main():
     assigned_token = registration["token"]
     print(f"  Registered as: {assigned_name} (slot {registration.get('slot', '?')})")
 
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{server_port}/api/settings", timeout=3
+        ) as r:
+            ui_settings = json.loads(r.read().decode())
+        pd = ui_settings.get("project_dir", "").strip()
+        if pd and Path(pd).is_dir():
+            cwd = pd
+        if ui_settings.get("auto_approve"):
+            for flag in _YOLO_FLAGS.get(agent, []):
+                if flag not in extra:
+                    extra.insert(0, flag)
+    except Exception:
+        pass
+
     proxy = None
     proxy_url = None
 
@@ -586,6 +653,14 @@ def main():
     command = resolved
 
     project_dir = (ROOT / cwd).resolve()
+
+    # Gemini: ensure the project directory is trusted so MCPs are allowed.
+    # Gemini blocks ALL MCPs for untrusted folders — even system-settings ones.
+    # We write TRUST_FOLDER for the specific cwd, which overrides any parent
+    # DO_NOT_TRUST rule in ~/.gemini/trustedFolders.json.
+    if agent == "gemini" or inject_cfg.get("mcp_inject") == "env":
+        _ensure_gemini_folder_trusted(project_dir)
+
     launch_args, env, inject_env, mcp_settings_path = _build_provider_launch(
         agent=agent,
         agent_cfg=agent_cfg,


### PR DESCRIPTION
## Summary

### Terminal webcam popover
- Hover any agent status pill to see a live tmux screen capture of that agent's session
- Scrollable terminal output with auto-scroll-to-bottom (pauses when you scroll up) and a "Load more history" button (50 → 500 lines on demand)
- Action buttons auto-detected from terminal output (y/n prompts, untrusted folder, action required, press enter to continue)
- Freeform key input field + Send button for arbitrary input
- Popover is resizable via drag and centers itself horizontally under the hovered pill
- tmux pane history is cleared on agent re-registration so a server restart never surfaces stale output from a previous session

### Agent spawn / kill
- `POST /api/agents/{agent}/spawn` — launches `wrapper.py` headlessly, polls the registry until the new instance appears, then injects optional guidance into its queue file
- `POST /api/agents/{name}/kill` — kills the agent's tmux session; the wrapper detects the dead session and deregisters cleanly
- `chat_spawn` MCP tool — agents can now spawn sibling instances with guidance, e.g. *"spawn a gemini to review auth.py and report back in #general"*
- UI: `×` kill button on each pill (hidden until hover), `+` spawn button opens a modal with an agent picker and guidance textarea

### Gemini MCP fixes (0.32.x)
- Switch Gemini transport from SSE → streamable-HTTP (port 8200); SSE had known blocking/hanging issues in 0.32.x
- Write `httpUrl` key instead of `url` — required by the Gemini CLI 0.32 schema for HTTP transport
- Add `"trust": true` to MCP server config to skip per-call tool confirmations
- Auto-trust the project directory in `~/.gemini/trustedFolders.json` on server startup and whenever the project dir setting changes; Gemini CLI 0.32 blocks **all** MCPs (including system-settings ones) for untrusted folders — a more-specific `TRUST_FOLDER` entry overrides any parent `DO_NOT_TRUST` rule

### Header layout
- Agent status pills row centered via CSS grid (`1fr auto 1fr`) so it stays centered and never truncates when many instances are running

### Auto-approve / project dir
- Wrapper fetches UI settings at startup to apply `project_dir` (cwd) and `auto_approve` (`--yolo` / `--dangerously-skip-permissions`) flags
- `_auto_trust_project_dir()` called on settings change and server boot

## Test plan
- [ ] Hover an agent pill → terminal popover appears with live output
- [ ] Scroll up in popover → auto-scroll pauses; click "Load more history" to fetch deeper scrollback
- [ ] Restart server while agents are running → popover shows only fresh output (no pre-restart history)
- [ ] Click `+` → spawn modal opens with agent list and guidance field; spawning a second Gemini produces `gemini-2` pill
- [ ] An agent calls `chat_spawn("gemini", "review src/auth.py")` → new instance appears and processes the guidance
- [ ] Click `×` on a pill → confirmation prompt → agent session killed, pill disappears
- [ ] Gemini with `project_dir` set → MCP tools available (`chat_read`, `chat_send`) without "folder is untrusted" blocking them

Made with [Cursor](https://cursor.com)