### PR TITLE
fix: Gemini CLI 0.32.x MCP compatibility

### DIFF
--- a/wrapper.py
+++ b/wrapper.py
@@ -55,13 +55,21 @@ def _write_json_mcp_settings(config_file: Path, url: str, transport: str = "http
     servers = existing.get("mcpServers", {})
     # Gemini CLI uses "httpUrl" for streamable-http, "url" for SSE
     if transport in ("http", "streamable-http"):
-        entry: dict = {"httpUrl": url, "trust": True}
+        entry: dict = {"type": "http", "httpUrl": url, "trust": True}
     else:
-        entry = {"url": url, "trust": True}
+        entry = {"type": transport, "url": url, "trust": True}
     if token:
         entry["headers"] = {"Authorization": f"Bearer {token}"}
     servers[SERVER_NAME] = entry
     existing["mcpServers"] = servers
+
+    # Enable folder trust so ~/.gemini/trustedFolders.json is respected
+    security = existing.get("security", {})
+    folder_trust = security.get("folderTrust", {})
+    folder_trust["enabled"] = True
+    security["folderTrust"] = folder_trust
+    existing["security"] = security
+
     config_file.write_text(json.dumps(existing, indent=2) + "\n", "utf-8")
     return config_file
 


### PR DESCRIPTION
## Summary
- Gemini CLI 0.32+ switched from SSE to streamable-HTTP and blocks all MCPs for untrusted folders
- Uses `httpUrl` key instead of `url` for HTTP transport in settings files
- Adds `trust: true` to MCP server entries to skip per-call approval prompts
- Switches Gemini default transport from SSE to HTTP
- Auto-trusts project directory in `~/.gemini/trustedFolders.json` at launch

Extracted from #33 — just the Gemini MCP fix, nothing else.

## Credit
Author: @BlazingFV (Ahmed Ashraf) — commit authorship preserved.

## Test plan
- [ ] Launch Gemini wrapper on macOS — verify MCP tools are available without manual folder trust
- [ ] Verify other agents (Claude, Codex, Kimi) still get correct MCP config
- [ ] Check `~/.gemini/trustedFolders.json` gets the correct entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)