### PR TITLE
feat: add /schedule command, inline decision cards, and role setting from status pill

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,11 +2,13 @@
 
 import asyncio
 import json
+import logging
+import os
 import re as _re
+import subprocess
 import sys
 import threading
 import uuid
-import logging
 from pathlib import Path
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, UploadFile, File
@@ -18,6 +20,7 @@ from store import MessageStore
 from rules import RuleStore
 from summaries import SummaryStore
 from jobs import JobStore
+from schedules import ScheduleStore, parse_schedule_spec
 from router import Router
 from agents import AgentTrigger
 from registry import RuntimeRegistry
@@ -33,6 +36,7 @@ store: MessageStore | None = None
 rules: RuleStore | None = None
 summaries: SummaryStore | None = None
 jobs: JobStore | None = None
+schedules: ScheduleStore | None = None
 router: Router | None = None
 agents: AgentTrigger | None = None
 registry: RuntimeRegistry | None = None
@@ -51,7 +55,11 @@ room_settings: dict = {
     "font": "sans",
     "channels": ["general"],
     "history_limit": "all",
+    "custom_roles": [],
     "contrast": "normal",
+    "routing_default": "none",
+    "project_dir": "",
+    "auto_approve": False,
 }
 
 # Channel validation
@@ -60,6 +68,73 @@ MAX_CHANNELS = 8
 
 # Agent hats (persisted to data/hats.json)
 agent_hats: dict[str, str] = {}  # { agent_name: svg_string }
+
+
+# ---------------------------------------------------------------------------
+# Auto-trust helpers — called whenever project_dir is set in settings
+# ---------------------------------------------------------------------------
+
+def _tmux_rename_session(old: str, new: str) -> None:
+    """Rename tmux session agentchattr-{old} → agentchattr-{new} (no-op on Windows or if not found)."""
+    if sys.platform == "win32":
+        return
+    try:
+        subprocess.run(
+            ["tmux", "rename-session", "-t", f"agentchattr-{old}", f"agentchattr-{new}"],
+            capture_output=True, timeout=2,
+        )
+    except Exception:
+        pass
+
+
+def _gemini_trust_folder(folder: Path) -> None:
+    """Write TRUST_FOLDER for *folder* into ~/.gemini/trustedFolders.json.
+
+    Gemini CLI blocks ALL MCPs (even system-settings ones) for untrusted
+    folders.  A more-specific TRUST_FOLDER entry overrides any parent
+    DO_NOT_TRUST rule, so we always write the exact path we're working in.
+    Respects the GEMINI_CLI_TRUSTED_FOLDERS_PATH env override if set.
+    """
+    trusted_path_env = os.environ.get("GEMINI_CLI_TRUSTED_FOLDERS_PATH", "")
+    trusted_file = Path(trusted_path_env) if trusted_path_env else Path.home() / ".gemini" / "trustedFolders.json"
+    try:
+        data: dict = {}
+        if trusted_file.exists():
+            try:
+                data = json.loads(trusted_file.read_text("utf-8"))
+            except Exception:
+                data = {}
+        folder_key = str(folder.resolve())
+        if data.get(folder_key) == "TRUST_FOLDER":
+            return
+        data[folder_key] = "TRUST_FOLDER"
+        trusted_file.parent.mkdir(parents=True, exist_ok=True)
+        trusted_file.write_text(json.dumps(data, indent=2) + "\n", "utf-8")
+        logging.getLogger(__name__).info("Gemini: trusted folder %s", folder_key)
+    except Exception as exc:
+        logging.getLogger(__name__).warning("Could not update Gemini trusted folders: %s", exc)
+
+
+def _auto_trust_project_dir(project_dir_str: str) -> None:
+    """Trust *project_dir_str* for every agent that requires explicit folder trust.
+
+    Currently handles:
+      - Gemini CLI  → ~/.gemini/trustedFolders.json
+    Add additional agents here as needed.
+    """
+    if not project_dir_str:
+        return
+    folder = Path(project_dir_str)
+    if not folder.is_dir():
+        return
+
+    # Gemini: always trust — MCPs are blocked for untrusted folders
+    agents_cfg = config.get("agents", {})
+    for agent_name, agent_cfg in agents_cfg.items():
+        cmd = agent_cfg.get("command", agent_name)
+        if cmd == "gemini" or agent_name == "gemini" or agent_cfg.get("mcp_inject") == "env":
+            _gemini_trust_folder(folder)
+            break  # only need to write once per directory
 
 
 def _hats_path() -> Path:
@@ -135,6 +210,8 @@ def _load_settings():
         room_settings["channels"] = ["general"]
     elif "general" not in room_settings["channels"]:
         room_settings["channels"].insert(0, "general")
+    # Re-apply folder trust on startup so agents always launch into a trusted dir
+    _auto_trust_project_dir(room_settings.get("project_dir", ""))
 
 
 def _save_settings():
@@ -184,7 +261,7 @@ def _install_security_middleware(token: str, cfg: dict):
             if path == "/" or path.startswith(("/static/", "/uploads/", "/api/roles")):
                 return await call_next(request)
 
-            # Agent registration/heartbeat: loopback only (no remote agent minting).
+            # Agent registration/heartbeat/settings: loopback only (wrappers need settings at startup).
             if path.startswith(("/api/register", "/api/deregister/", "/api/heartbeat/")):
                 client_ip = request.client.host if request.client else ""
                 if client_ip not in ("127.0.0.1", "::1", "localhost"):
@@ -193,6 +270,10 @@ def _install_security_middleware(token: str, cfg: dict):
                         status_code=403,
                     )
                 return await call_next(request)
+            if path == "/api/settings" and request.method == "GET":
+                client_ip = request.client.host if request.client else ""
+                if client_ip in ("127.0.0.1", "::1", "localhost"):
+                    return await call_next(request)
 
             # --- Origin check (blocks cross-origin / DNS-rebinding attacks) ---
             origin = request.headers.get("origin")
@@ -227,7 +308,7 @@ def _install_security_middleware(token: str, cfg: dict):
 
 
 def configure(cfg: dict, session_token: str = ""):
-    global store, rules, summaries, jobs, router, agents, registry, session_store, session_engine, config
+    global store, rules, summaries, jobs, schedules, router, agents, registry, session_store, session_engine, config
     config = cfg
     # --- Security: store the session token and install middleware ---
     _install_security_middleware(session_token, cfg)
@@ -265,6 +346,9 @@ def configure(cfg: dict, session_token: str = ""):
     jobs = JobStore(str(jobs_path))
     jobs.on_change(_on_job_change)
 
+    schedules = ScheduleStore(str(Path(data_dir) / "schedules.json"))
+    schedules.on_change(_on_schedule_change)
+
     max_hops = cfg.get("routing", {}).get("max_agent_hops", 4)
 
     # Registry: single source of truth for all live agent state
@@ -298,9 +382,15 @@ def configure(cfg: dict, session_token: str = ""):
     _load_settings()
     _load_hats()
 
+    # Wire spawn function into mcp_bridge so agents can call chat_spawn
+    import mcp_bridge as _mb
+    _mb._spawn_fn = _spawn_agent
+
     # Apply saved loop guard setting
     if "max_agent_hops" in room_settings:
         router.max_hops = room_settings["max_agent_hops"]
+    if "routing_default" in room_settings:
+        router.default_mention = room_settings["routing_default"]
 
     # Background thread: check for wrapper recovery flag files
     _data_dir = Path(data_dir)
@@ -313,6 +403,8 @@ def configure(cfg: dict, session_token: str = ""):
     def _background_checks():
         import time as _time
         import mcp_bridge
+
+        nonlocal _posted_leave, _known_online, _known_active
 
         while True:
             _time.sleep(3)
@@ -359,6 +451,13 @@ def configure(cfg: dict, session_token: str = ""):
                     with mcp_bridge._presence_lock:
                         last_seen = mcp_bridge._presence.get(name, 0)
                     if last_seen > 0 and now - last_seen > _CRASH_TIMEOUT:
+                        # Re-check under lock to avoid TOCTOU: a heartbeat could have
+                        # arrived between read and deregister, which would incorrectly
+                        # kill a live agent.
+                        with mcp_bridge._presence_lock:
+                            last_seen = mcp_bridge._presence.get(name, 0)
+                        if last_seen <= 0 or now - last_seen <= _CRASH_TIMEOUT:
+                            continue
                         log.info(f"Crash timeout: deregistering {name} (no heartbeat for {_CRASH_TIMEOUT}s)")
                         result = registry.deregister(name)
                         if result:
@@ -368,6 +467,7 @@ def configure(cfg: dict, session_token: str = ""):
                             if renamed:
                                 mcp_bridge.migrate_identity(renamed["old"], renamed["new"])
                                 store.rename_sender(renamed["old"], renamed["new"])
+                                _tmux_rename_session(renamed["old"], renamed["new"])
                                 if _event_loop:
                                     rename_event = json.dumps({
                                         "type": "agent_renamed",
@@ -443,14 +543,53 @@ def configure(cfg: dict, session_token: str = ""):
                 _known_online.clear()
                 _known_online.update(currently_online)
             except Exception:
-                pass
+                log.exception("background check error")
 
     threading.Thread(target=_background_checks, daemon=True).start()
+
+    def _schedule_runner():
+        import time as _time
+        while True:
+            _time.sleep(30)
+            try:
+                if not schedules:
+                    continue
+                due = schedules.run_due()
+                for s in due:
+                    prompt = s.get("prompt", "")
+                    targets = s.get("targets", [])
+                    channel = s.get("channel", "general")
+                    if not prompt or not targets:
+                        schedules.mark_run(s["id"])
+                        continue
+                    # Add system message so timeline shows the scheduled run
+                    mention_str = " ".join(f"@{t}" for t in targets)
+                    store.add(
+                        "system",
+                        f"Scheduled: {mention_str} — {prompt[:80]}{'…' if len(prompt) > 80 else ''}",
+                        msg_type="system",
+                        channel=channel,
+                    )
+                    for name in targets:
+                        if registry and registry.is_registered(name):
+                            agents.trigger_sync(name, f"user: {prompt}", channel=channel)
+                        else:
+                            # Trigger anyway — queue file will be picked up when agent starts
+                            agents.trigger_sync(name, f"user: {prompt}", channel=channel)
+                    schedules.mark_run(s["id"])
+            except Exception:
+                log.exception("schedule runner error")
+
+    threading.Thread(target=_schedule_runner, daemon=True).start()
 
 
 # --- Store → WebSocket bridge ---
 
 _event_loop = None  # set by run.py after starting the event loop
+
+# Per-family spawn cooldown: {base_name: last_spawn_timestamp}
+_spawn_last: dict[str, float] = {}
+_SPAWN_COOLDOWN = 10.0  # seconds between spawns of the same agent family
 
 
 def set_event_loop(loop):
@@ -500,6 +639,20 @@ def _on_job_change(action: str, data: dict):
     except RuntimeError:
         pass
     asyncio.run_coroutine_threadsafe(broadcast_job(action, data), _event_loop)
+
+
+def _on_schedule_change(action: str, schedule: dict):
+    """Called from any thread when a schedule changes."""
+    if _event_loop is None:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+        if loop is _event_loop:
+            asyncio.ensure_future(broadcast_schedule(action, schedule))
+            return
+    except RuntimeError:
+        pass
+    asyncio.run_coroutine_threadsafe(broadcast_schedule(action, schedule), _event_loop)
 
 
 def _on_session_change(action: str, session: dict):
@@ -897,6 +1050,17 @@ async def broadcast_session(action: str, session: dict):
     ws_clients.difference_update(dead)
 
 
+async def broadcast_schedule(action: str, schedule: dict):
+    payload = json.dumps({"type": "schedule", "action": action, "data": schedule})
+    dead = set()
+    for client in list(ws_clients):
+        try:
+            await client.send_text(payload)
+        except Exception:
+            dead.add(client)
+    ws_clients.difference_update(dead)
+
+
 async def broadcast_hats():
     data = json.dumps({"type": "hats", "data": agent_hats})
     dead = set()
@@ -961,8 +1125,14 @@ async def websocket_endpoint(websocket: WebSocket):
 
     # Send base agent colors (used for message coloring, no pills)
     base_colors = {}
+    srv_max = config.get("server", {}).get("max_instances", 3)
     for name, cfg in config.get("agents", {}).items():
-        base_colors[name] = {"color": cfg.get("color", "#888"), "label": cfg.get("label", name)}
+        base_colors[name] = {
+            "color": cfg.get("color", "#888"),
+            "label": cfg.get("label", name),
+            "spawnable": bool(cfg.get("command") and cfg.get("type") != "api"),
+            "max_instances": int(cfg.get("max_instances", srv_max)),
+        }
     await websocket.send_text(json.dumps({"type": "base_colors", "data": base_colors}))
 
     # Send todos {msg_id: status}
@@ -976,6 +1146,9 @@ async def websocket_endpoint(websocket: WebSocket):
 
     # Send jobs
     await websocket.send_text(json.dumps({"type": "jobs", "data": jobs.list_all()}))
+
+    # Send schedules
+    await websocket.send_text(json.dumps({"type": "schedules", "data": schedules.list_all()}))
 
     # Send pending instances (so late-connecting browsers still see the naming lightbox)
     if registry:
@@ -1032,6 +1205,46 @@ async def websocket_endpoint(websocket: WebSocket):
                         router.continue_routing()
                         store.add("system", "Resuming agent conversation...", msg_type="system", channel=channel)
                         await broadcast_status()
+                        continue
+                    if cmd == "/schedules":
+                        # Client will open Schedules panel; send full list
+                        await websocket.send_text(json.dumps({"type": "schedules", "data": schedules.list_all()}))
+                        continue
+                    if cmd == "/schedule":
+                        # Parse: /schedule @claude "prompt" every 1h
+                        prompt_match = _re.search(r'"([^"]*)"', text)
+                        spec_match = _re.search(
+                            r'(every\s+\d+\s*(?:m|min|h|hr|d|day)s?|daily\s+at\s+\d{1,2}:\d{2})',
+                            text, _re.IGNORECASE
+                        )
+                        targets = router.parse_mentions(text) if router else []
+                        if not targets:
+                            targets = list(registry.get_all_names()) if registry else []
+                        prompt = prompt_match.group(1).strip() if prompt_match else ""
+                        spec = spec_match.group(1).strip() if spec_match else ""
+                        if not prompt or not spec:
+                            store.add("system", "Usage: /schedule @agent \"prompt\" every 1h (or daily at 09:00)", msg_type="system", channel=channel)
+                        else:
+                            interval_sec, daily_at = parse_schedule_spec(spec)
+                            if interval_sec is None and daily_at is None:
+                                store.add("system", f"Invalid schedule spec: {spec}", msg_type="system", channel=channel)
+                            else:
+                                schedules.create(
+                                    prompt=prompt, targets=targets, channel=channel,
+                                    interval_seconds=interval_sec, daily_at=daily_at,
+                                )
+                                store.add("system", f"Scheduled: {' '.join('@'+t for t in targets)} \"{prompt}\" ({spec})", msg_type="system", channel=channel)
+                        continue
+                    if cmd == "/unschedule":
+                        sid = cmd_parts[1] if len(cmd_parts) > 1 else ""
+                        if not sid:
+                            store.add("system", "Usage: /unschedule <id> (get id from Schedules panel)", msg_type="system", channel=channel)
+                        else:
+                            removed = schedules.delete(sid)
+                            if removed:
+                                store.add("system", f"Cancelled schedule {sid}", msg_type="system", channel=channel)
+                            else:
+                                store.add("system", f"Schedule {sid} not found", msg_type="system", channel=channel)
                         continue
                     # Broadcast slash commands — expand without storing the raw command.
                     # _handle_new_message will store the expanded version.
@@ -1191,6 +1404,19 @@ async def websocket_endpoint(websocket: WebSocket):
                             room_settings["history_limit"] = max(1, min(val_int, 10000))
                         except (ValueError, TypeError):
                             pass
+                if "routing_default" in new and new["routing_default"] in ("none", "all"):
+                    room_settings["routing_default"] = new["routing_default"]
+                    router.default_mention = new["routing_default"]
+                if "project_dir" in new and isinstance(new["project_dir"], str):
+                    room_settings["project_dir"] = new["project_dir"].strip()
+                    _auto_trust_project_dir(room_settings["project_dir"])
+                if "auto_approve" in new:
+                    room_settings["auto_approve"] = bool(new["auto_approve"])
+                if "custom_roles" in new and isinstance(new["custom_roles"], list):
+                    room_settings["custom_roles"] = [
+                        str(r).strip() for r in new["custom_roles"]
+                        if isinstance(r, str) and r.strip()
+                    ][:20]
                 _save_settings()
                 await broadcast_settings()
 
@@ -1402,6 +1628,345 @@ async def get_settings():
     return room_settings
 
 
+@app.get("/api/terminal/{agent_name}")
+async def get_terminal(agent_name: str, lines: int = 50):
+    """Capture tmux pane output for an agent's terminal. Mac/Linux only.
+
+    Query param `lines` controls how many lines back to capture (default 50,
+    max 500). Scrollback is cleared on each agent registration so only content
+    from the *current* session is ever returned.
+    """
+    if sys.platform == "win32":
+        return {"available": False}
+    session_name = f"agentchattr-{agent_name}"
+    history = max(1, min(int(lines), 500))
+    try:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-t", session_name, "-p", "-S", f"-{history}"],
+            capture_output=True,
+            timeout=2,
+        )
+        if result.returncode != 0:
+            return {"available": False}
+        raw = result.stdout.decode("utf-8", errors="replace")
+        out_lines = raw.strip().split("\n")
+        return {"available": True, "lines": out_lines, "raw": raw}
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return {"available": False}
+
+
+@app.post("/api/terminal/{agent_name}/input")
+async def send_terminal_input(agent_name: str, request: Request):
+    """Send keystrokes to an agent's tmux session. Mac/Linux only."""
+    if sys.platform == "win32":
+        return JSONResponse({"error": "not supported on Windows"}, status_code=400)
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid JSON"}, status_code=400)
+    text = body.get("text", "")
+    enter = body.get("enter", True)
+    session_name = f"agentchattr-{agent_name}"
+    try:
+        if text:
+            subprocess.run(
+                ["tmux", "send-keys", "-t", session_name, "-l", text],
+                capture_output=True,
+                timeout=2,
+            )
+        if enter:
+            subprocess.run(
+                ["tmux", "send-keys", "-t", session_name, "Enter"],
+                capture_output=True,
+                timeout=2,
+            )
+        return {"ok": True}
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+def _browse_roots() -> list[dict]:
+    """Return platform-specific root entries for directory browser."""
+    roots = []
+    if sys.platform == "darwin":
+        for name, p in [("Users", "/Users"), ("Volumes", "/Volumes")]:
+            if Path(p).exists():
+                roots.append({"name": name, "path": p})
+    elif sys.platform == "win32":
+        import string
+        for letter in string.ascii_uppercase:
+            p = f"{letter}:\\"
+            if Path(p).exists():
+                roots.append({"name": p, "path": p})
+    else:
+        for name, p in [("home", "/home"), ("mnt", "/mnt"), ("root", "/")]:
+            if Path(p).exists():
+                roots.append({"name": name, "path": p})
+    return roots
+
+
+@app.get("/api/browse")
+async def browse_directories(path: str = ""):
+    """List directories for folder picker. path='' returns roots."""
+    if not path or path in ("/", "\\"):
+        return {"path": "", "directories": _browse_roots(), "parent": None}
+    try:
+        p = Path(path).resolve()
+        if not p.is_dir():
+            return JSONResponse({"error": "not a directory"}, status_code=400)
+        parent = str(p.parent) if p.parent != p else None
+        dirs = []
+        for child in sorted(p.iterdir()):
+            if child.is_dir() and not child.name.startswith("."):
+                dirs.append({"name": child.name, "path": str(child.resolve())})
+        return {"path": str(p), "directories": dirs, "parent": parent}
+    except (OSError, PermissionError) as e:
+        return JSONResponse({"error": str(e)}, status_code=403)
+
+
+@app.post("/api/agents/start")
+async def start_all_agents():
+    """Launch all CLI agents in separate Terminal windows (server must already be running)."""
+    ROOT = Path(__file__).parent
+    start_script = ROOT / "macos-linux" / "start_all.sh"
+    if not start_script.exists():
+        return JSONResponse({"error": "start_all.sh not found"}, status_code=500)
+    try:
+        agents_cfg = config.get("agents", {})
+        cli_agents = [k for k, v in agents_cfg.items() if v.get("command") and v.get("type") != "api"]
+        subprocess.Popen(
+            ["sh", str(start_script)],
+            cwd=str(ROOT),
+            start_new_session=True,
+        )
+        return JSONResponse({"started": cli_agents, "message": "Launching agents in Terminal windows..."})
+    except Exception as e:
+        log.warning("Failed to start agents: %s", e)
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@app.post("/api/agents/stop")
+async def stop_all_agents():
+    """Kill all agent tmux sessions and wrapper processes (does not stop the server).
+
+    On Mac/Linux, kills agentchattr-* tmux sessions first — this terminates the
+    agent CLIs (claude, codex, gemini, etc.) inside them. Then kills wrapper.py
+    processes. Without killing tmux sessions, agent processes would linger as
+    orphans in Activity Monitor.
+    """
+    try:
+        sessions_killed = 0
+        if sys.platform != "win32":
+            try:
+                r = subprocess.run(
+                    ["tmux", "list-sessions", "-F", "#{session_name}"],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if r.returncode == 0 and r.stdout:
+                    for line in r.stdout.strip().splitlines():
+                        name = line.strip()
+                        if name.startswith("agentchattr-"):
+                            subprocess.run(
+                                ["tmux", "kill-session", "-t", name],
+                                capture_output=True, timeout=2,
+                            )
+                            sessions_killed += 1
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                pass
+
+        import psutil
+        wrappers_killed = 0
+        my_pid = os.getpid()
+        for proc in psutil.process_iter(["pid", "cmdline", "name"]):
+            try:
+                if proc.info["pid"] == my_pid:
+                    continue
+                cmdline = proc.info.get("cmdline") or []
+                cmdstr = " ".join(str(c) for c in cmdline)
+                if "wrapper.py" in cmdstr and "run.py" not in cmdstr:
+                    proc.kill()
+                    wrappers_killed += 1
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+
+        total = sessions_killed + wrappers_killed
+        return JSONResponse({"ok": True, "message": f"Stopped {total} agent(s)"})
+    except ImportError:
+        return JSONResponse({"error": "psutil not installed"}, status_code=500)
+    except Exception as e:
+        log.warning("Failed to stop agents: %s", e)
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+def _spawn_agent(agent: str, guidance: str = "", label: str = "") -> dict:
+    """Spawn a new wrapper instance for *agent*.  Runs synchronously (blocks up to 12s).
+
+    Launches wrapper.py headlessly: tmux attach-session silently fails without a
+    tty, so the wrapper enters its monitor loop and stays alive until the agent
+    tmux session is killed.  Returns {ok, name} or {error}.
+    """
+    import time as _time
+
+    ROOT = Path(__file__).parent
+    agents_cfg = config.get("agents", {})
+
+    if agent not in agents_cfg:
+        return {"error": f"unknown agent: {agent}"}
+    cfg = agents_cfg[agent]
+    if cfg.get("type") == "api":
+        return {"error": f"'{agent}' is an API agent and cannot be spawned"}
+    if not cfg.get("command"):
+        return {"error": f"'{agent}' has no command configured"}
+
+    # --- Instance cap ---
+    max_instances = int(cfg.get("max_instances", config.get("server", {}).get("max_instances", 3)))
+    if registry:
+        current = registry.get_instances_for(agent)
+        if len(current) >= max_instances:
+            return {"error": f"max instances reached for '{agent}' ({max_instances}). Kill one first."}
+
+    # --- Spawn cooldown (prevents agents from firing chat_spawn in a tight loop) ---
+    now_ts = _time.time()
+    last = _spawn_last.get(agent, 0.0)
+    if now_ts - last < _SPAWN_COOLDOWN:
+        wait = round(_SPAWN_COOLDOWN - (now_ts - last), 1)
+        return {"error": f"spawn cooldown active for '{agent}' — wait {wait}s"}
+    _spawn_last[agent] = now_ts
+
+    before = set(registry.get_all_names()) if registry else set()
+
+    spawn_log = ROOT / config.get("server", {}).get("data_dir", "data") / f"spawn-{agent}.log"
+    spawn_log.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(spawn_log, "a", encoding="utf-8") as log_f:
+            subprocess.Popen(
+                [sys.executable, str(ROOT / "wrapper.py"), agent] + (["--label", label] if label else []),
+                cwd=str(ROOT),
+                start_new_session=True,
+                stdin=subprocess.DEVNULL,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+            )
+    except Exception as exc:
+        return {"error": f"failed to start wrapper: {exc}"}
+
+    # Poll registry until the new instance appears (max 12 s)
+    deadline = _time.time() + 12
+    new_name = None
+    while _time.time() < deadline:
+        if registry:
+            new_names = [
+                n for n in set(registry.get_all_names()) - before
+                if (inst := registry.get_instance(n)) and inst.get("base") == agent
+            ]
+            if new_names:
+                new_name = new_names[0]
+                break
+        _time.sleep(0.3)
+
+    if not new_name:
+        return {"error": "timed out waiting for agent to register — check spawn log"}
+
+    if guidance and guidance.strip():
+        data_dir = ROOT / config.get("server", {}).get("data_dir", "data")
+        queue_file = data_dir / f"{new_name}_queue.jsonl"
+        try:
+            queue_file.write_text(json.dumps({"prompt": guidance.strip()}) + "\n", "utf-8")
+        except Exception as exc:
+            log.warning("Could not write guidance for %s: %s", new_name, exc)
+
+    return {"ok": True, "name": new_name}
+
+
+@app.post("/api/agents/{agent}/spawn")
+async def spawn_agent(agent: str, request: Request):
+    """Spawn a new instance of *agent*.  Body: {guidance?, label?}."""
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    guidance = (body.get("guidance") or "").strip()
+    raw_label = (body.get("label") or "").strip()
+    # Reject labels that look like auto-generated slot IDs (e.g. "codex-3") to
+    # prevent agents from passing their own name as a label and creating confusing
+    # lowercase-hyphenated pills.  A valid custom label must contain a space or
+    # have at least one uppercase letter (e.g. "Code Reviewer", "Backend").
+    import re as _re
+    _slot_id_pattern = _re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+    label = "" if _slot_id_pattern.match(raw_label) else raw_label[:64]
+    loop = asyncio.get_event_loop()
+    result = await loop.run_in_executor(None, _spawn_agent, agent, guidance, label)
+    if "error" in result:
+        return JSONResponse(result, status_code=400)
+    return JSONResponse(result)
+
+
+@app.post("/api/agents/{name}/kill")
+async def kill_agent(name: str):
+    """Kill a specific agent instance by its canonical name.
+
+    Kills the agent's tmux session, immediately deregisters the instance
+    (clearing the grace-period reservation so the slot is reusable right
+    away), and broadcasts the change.  The wrapper will also call
+    /api/deregister on its own but that call will be a harmless no-op.
+    """
+    if not registry or not registry.is_registered(name):
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    # Kill tmux sessions
+    killed_sessions = []
+    if sys.platform != "win32":
+        main_session = f"agentchattr-{name}"
+        for session in [main_session, f"agentchattr-wrapper-{name}"]:
+            r = subprocess.run(["tmux", "kill-session", "-t", session],
+                               capture_output=True, timeout=3)
+            if r.returncode == 0:
+                killed_sessions.append(session)
+        # Confirm main session is actually dead before deregistering
+        try:
+            check = subprocess.run(
+                ["tmux", "has-session", "-t", main_session],
+                capture_output=True, timeout=1,
+            )
+            if check.returncode == 0:
+                return JSONResponse(
+                    {"error": "session still alive after kill — retry"},
+                    status_code=500,
+                )
+        except subprocess.TimeoutExpired:
+            return JSONResponse(
+                {"error": "tmux unresponsive — retry later"},
+                status_code=500,
+            )
+
+    # Eagerly deregister so the slot is freed immediately (wrapper's own
+    # deregister call will be a harmless not-found after this).
+    import mcp_bridge as _mb
+    result = registry.deregister(name)
+    if result:
+        _mb.purge_identity(name)
+        registry.clean_renames_for(name)
+        # Release the grace-period reservation so the next spawn reuses the slot.
+        registry.release_slot(name)
+        # Handle rename-back (e.g. codex-2 killed → codex-1 renamed to codex).
+        renamed = result.get("_renamed_back")
+        if renamed:
+            _mb.migrate_identity(renamed["old"], renamed["new"])
+            store.rename_sender(renamed["old"], renamed["new"])
+            _tmux_rename_session(renamed["old"], renamed["new"])
+            if _event_loop:
+                asyncio.run_coroutine_threadsafe(
+                    _broadcast(json.dumps({
+                        "type": "agent_renamed",
+                        "old_name": renamed["old"],
+                        "new_name": renamed["new"],
+                    })),
+                    _event_loop,
+                )
+
+    return JSONResponse({"ok": True, "name": name, "sessions_killed": killed_sessions})
+
+
 @app.delete("/api/hat/{agent_name}")
 async def delete_hat(agent_name: str):
     """Remove an agent's hat (called by the trash-can UI)."""
@@ -1514,6 +2079,46 @@ async def resolve_rule_proposal(msg_id: int, request: Request):
     updated = store.update_message(msg_id, {"metadata": meta})
     if updated:
         # Broadcast the updated message so all clients re-render the card
+        payload = json.dumps({"type": "edit", "message": updated})
+        dead = set()
+        for client in list(ws_clients):
+            try:
+                await client.send_text(payload)
+            except Exception:
+                dead.add(client)
+        ws_clients.difference_update(dead)
+    return updated or {"ok": True}
+
+
+@app.patch("/api/messages/{msg_id}/resolve")
+async def resolve_decision(msg_id: int, request: Request):
+    """Resolve a decision message with the chosen option. Sends the choice as a chat message."""
+    msg = store.get_by_id(msg_id)
+    if not msg:
+        return JSONResponse({"error": "message not found"}, status_code=404)
+    if msg.get("type") != "decision":
+        return JSONResponse({"error": "not a decision message"}, status_code=400)
+    meta = msg.get("metadata", {})
+    if meta.get("status") == "resolved":
+        return JSONResponse({"error": "already resolved"}, status_code=400)
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid json"}, status_code=400)
+    choice = body.get("choice", "").strip()
+    if not choice:
+        return JSONResponse({"error": "choice required"}, status_code=400)
+    choices = meta.get("choices", [])
+    if choice not in choices:
+        return JSONResponse({"error": "invalid choice"}, status_code=400)
+    meta["status"] = "resolved"
+    meta["resolved_choice"] = choice
+    updated = store.update_message(msg_id, {"metadata": meta})
+    if updated:
+        # Send the choice as a normal chat message so agents see it
+        channel = msg.get("channel", "general")
+        sender = room_settings.get("username", "user")
+        store.add(sender, choice, channel=channel, reply_to=msg_id)
         payload = json.dumps({"type": "edit", "message": updated})
         dead = set()
         for client in list(ws_clients):
@@ -1696,7 +2301,6 @@ async def post_job_message(job_id: int, request: Request):
                 targets.append(t)
         targets = list(dict.fromkeys(targets))
 
-        import mcp_bridge
         chat_msg = f"{sender}: {text}" if text else ""
         for target in targets:
             if registry:
@@ -1754,6 +2358,59 @@ async def delete_job(job_id: int, request: Request):
         result = jobs.delete(job_id)
     else:
         result = jobs.update_status(job_id, "archived")
+    if result is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return result
+
+
+# --- Schedules API ---
+
+@app.get("/api/schedules")
+async def get_schedules():
+    """List all schedules."""
+    return schedules.list_all()
+
+
+@app.post("/api/schedules")
+async def create_schedule(request: Request):
+    """Create a new schedule."""
+    body = await request.json()
+    prompt = (body.get("prompt") or "").strip()
+    targets = body.get("targets", [])
+    channel = (body.get("channel") or "general").strip()
+    interval_seconds = body.get("interval_seconds")
+    daily_at = body.get("daily_at")
+    if not prompt:
+        return JSONResponse({"error": "prompt required"}, status_code=400)
+    if not isinstance(targets, list):
+        targets = []
+    targets = [str(t).strip().lstrip("@") for t in targets if t]
+    if not targets:
+        targets = list(registry.get_all_names()) if registry else []
+    if interval_seconds is None and not daily_at:
+        interval_seconds = 3600
+    if daily_at:
+        interval_seconds = 86400
+    s = schedules.create(
+        prompt=prompt, targets=targets, channel=channel,
+        interval_seconds=interval_seconds, daily_at=daily_at,
+    )
+    return s
+
+
+@app.delete("/api/schedules/{schedule_id}")
+async def delete_schedule(schedule_id: str):
+    """Cancel/delete a schedule."""
+    result = schedules.delete(schedule_id)
+    if result is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return {"ok": True, "deleted": result}
+
+
+@app.patch("/api/schedules/{schedule_id}/toggle")
+async def toggle_schedule(schedule_id: str):
+    """Pause or resume a schedule."""
+    result = schedules.toggle(schedule_id)
     if result is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     return result
@@ -1852,6 +2509,8 @@ async def register_agent(request: Request):
     if renamed:
         mcp_bridge.migrate_identity(renamed["old"], renamed["new"])
         store.rename_sender(renamed["old"], renamed["new"])
+        # Keep the tmux session name in sync so the terminal webcam can find it.
+        _tmux_rename_session(renamed["old"], renamed["new"])
         if _event_loop:
             rename_event = json.dumps({
                 "type": "agent_renamed",
@@ -1896,6 +2555,7 @@ async def deregister_agent(name: str, request: Request):
     if renamed:
         mcp_bridge.migrate_identity(renamed["old"], renamed["new"])
         store.rename_sender(renamed["old"], renamed["new"])
+        _tmux_rename_session(renamed["old"], renamed["new"])
         if _event_loop:
             rename_event = json.dumps({
                 "type": "agent_renamed",

--- a/mcp_bridge.py
+++ b/mcp_bridge.py
@@ -110,7 +110,10 @@ _MCP_INSTRUCTIONS = (
     "This prevents over-use of the jobs feature for vague requests.\n\n"
     "To post a suggestion (Accept/Dismiss card) in a job, prefix your message with [suggestion]: "
     "chat_send(job_id=N, message='[suggestion] I recommend we refactor the auth module'). "
-    "The human can Accept (triggers you with context) or Dismiss."
+    "The human can Accept (triggers you with context) or Dismiss.\n\n"
+    "Use chat_ask when you need explicit human input (yes/no, multiple choice). "
+    "Example: chat_ask(question='Want me to build it?', choices=['Yes, build it', 'No', 'Tell me more']). "
+    "The human sees clickable buttons and their choice is sent back as a chat message.\n\n"
 )
 
 # --- Tool implementations (shared between both servers) ---
@@ -224,7 +227,8 @@ def chat_send(
         # Handle image attachment for job messages
         job_attachments = None
         if image_path:
-            import shutil, uuid
+            import shutil
+            import uuid
             src = Path(image_path)
             if not src.exists():
                 return f"Image not found: {image_path}"
@@ -275,7 +279,6 @@ def chat_send(
     if image_path:
         import shutil
         import uuid
-        from pathlib import Path
         src = Path(image_path)
         if not src.exists():
             return f"Image not found: {image_path}"
@@ -339,6 +342,51 @@ def chat_propose_job(
     with _presence_lock:
         _presence[sender] = time.time()
     return f"Proposed job (msg_id={msg['id']}): {title}"
+
+
+def chat_ask(
+    sender: str,
+    question: str,
+    choices: list[str],
+    context: str = "",
+    channel: str = "general",
+    ctx: Context | None = None,
+) -> str:
+    """Ask the human a multiple-choice question. Posts a decision card in the timeline
+    with clickable buttons. Use when you need explicit yes/no or structured feedback
+    (e.g. "Want me to build it?" → choices: ["Yes, build it", "No", "Tell me more"]).
+
+    Args:
+        question: The question text (markdown supported)
+        choices: List of choice strings (e.g. ["Yes", "No", "Tell me more"])
+        context: Optional extra context shown with the question
+        channel: Channel to post in (default: general)
+    """
+    sender, err = _resolve_tool_identity(sender, ctx, field_name="sender", required=True)
+    if err:
+        return err
+    if registry and registry.is_pending(sender):
+        return "Error: identity not confirmed. Call chat_claim(sender=your_base_name) to get your identity."
+    if not question.strip():
+        return "Error: question is required."
+    if not choices or not isinstance(choices, list):
+        return "Error: choices must be a non-empty list of strings."
+    choices = [str(c).strip() for c in choices if str(c).strip()][:10]
+    if not choices:
+        return "Error: at least one choice is required."
+    text = question.strip()[:500]
+    if context.strip():
+        text = f"{text}\n\n{context.strip()[:200]}"
+    msg = store.add(
+        sender, text,
+        msg_type="decision",
+        channel=channel,
+        metadata={"question": question.strip(), "choices": choices, "status": "pending"},
+    )
+    _update_cursor(sender, [msg], channel)
+    with _presence_lock:
+        _presence[sender] = time.time()
+    return f"Asked (msg_id={msg['id']}): {question[:60]}..."
 
 
 def _resolve_attachments(attachments: list[dict]) -> list[dict]:
@@ -847,9 +895,41 @@ def chat_summary(
     return f"Unknown action: {action}. Valid actions: read, write."
 
 
+_spawn_fn = None  # set by app.configure() → _spawn_agent
+
+
+def chat_spawn(
+    agent: str,
+    guidance: str = "",
+    label: str = "",
+    ctx: Context | None = None,
+) -> str:
+    """Spawn a new instance of an agent, optionally with initial guidance.
+
+    Args:
+        agent: base agent name to spawn (e.g. "gemini", "claude", "codex")
+        guidance: first prompt injected into the new instance's queue
+        label: optional custom display label for the new instance
+
+    Returns the assigned name (e.g. "gemini-2") on success, or an error string.
+    This call blocks up to ~12 seconds while waiting for the instance to register.
+    """
+    if _spawn_fn is None:
+        return "Error: spawn is not available in this environment."
+    result = _spawn_fn(agent, guidance, label)
+    if "error" in result:
+        return f"Error: {result['error']}"
+    name = result.get("name", "?")
+    if guidance:
+        snippet = guidance[:80] + ("…" if len(guidance) > 80 else "")
+        return f"Spawned {name}. Guidance injected: '{snippet}'"
+    return f"Spawned {name}."
+
+
 _ALL_TOOLS = [
     chat_send, chat_read, chat_resync, chat_join, chat_who, chat_rules, chat_decision,
-    chat_channels, chat_set_hat, chat_claim, chat_summary, chat_propose_job,
+    chat_channels, chat_set_hat, chat_claim, chat_summary, chat_propose_job, chat_ask,
+    chat_spawn,
 ]
 
 

--- a/schedules.py
+++ b/schedules.py
@@ -1,0 +1,227 @@
+"""Schedule store — recurring prompts fired without human intervention."""
+
+import json
+import re
+import time
+import threading
+import uuid
+from pathlib import Path
+
+
+# Interval parsing: "every 30m", "every 1h", "every 2h", "daily at 09:00"
+_INTERVAL_RE = re.compile(
+    r"every\s+(\d+)\s*(m|min|h|hr|d|day)s?\b",
+    re.IGNORECASE
+)
+_DAILY_RE = re.compile(
+    r"daily\s+at\s+(\d{1,2}):(\d{2})\b",
+    re.IGNORECASE
+)
+
+
+def parse_schedule_spec(spec: str) -> tuple[int | None, str | None]:
+    """Parse natural-language schedule spec.
+    Returns (interval_seconds, None) for intervals, or (None, cron_expr) for daily.
+    Returns (None, None) if unparseable.
+    """
+    spec = spec.strip()
+    m = _INTERVAL_RE.search(spec)
+    if m:
+        val = int(m.group(1))
+        unit = m.group(2).lower()
+        if unit in ("m", "min"):
+            secs = val * 60
+        elif unit in ("h", "hr"):
+            secs = val * 3600
+        elif unit in ("d", "day"):
+            secs = val * 86400
+        else:
+            return (None, None)
+        if secs < 60:
+            secs = 60  # minimum 1 minute
+        return (secs, None)
+
+    dm = _DAILY_RE.search(spec)
+    if dm:
+        hour = int(dm.group(1)) % 24
+        minute = int(dm.group(2)) % 60
+        # Store as "HH:MM" for daily; we compute next_run from current time
+        return (86400, f"{hour:02d}:{minute:02d}")  # interval=1 day, time hint
+
+    return (None, None)
+
+
+def compute_next_run(
+    interval_seconds: int,
+    last_run: float | None,
+    daily_at: str | None = None,
+) -> float:
+    """Compute next run timestamp. daily_at is "HH:MM" for daily schedules."""
+    now = time.time()
+    if last_run is None:
+        if daily_at:
+            # First run: today at HH:MM, or tomorrow if already past
+            parts = daily_at.split(":")
+            hour, minute = int(parts[0]), int(parts[1])
+            from datetime import datetime
+            today = datetime.fromtimestamp(now)
+            target = today.replace(hour=hour, minute=minute, second=0, microsecond=0)
+            ts = target.timestamp()
+            if ts <= now:
+                from datetime import timedelta
+                target = target + timedelta(days=1)
+                ts = target.timestamp()
+            return ts
+        return now
+    if daily_at:
+        from datetime import datetime, timedelta
+        last_dt = datetime.fromtimestamp(last_run)
+        parts = daily_at.split(":")
+        hour, minute = int(parts[0]), int(parts[1])
+        next_dt = last_dt.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if next_dt <= last_dt:
+            next_dt = next_dt + timedelta(days=1)
+        return next_dt.timestamp()
+    return last_run + interval_seconds
+
+
+class ScheduleStore:
+    def __init__(self, path: str):
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._schedules: list[dict] = []
+        self._lock = threading.Lock()
+        self._callbacks: list = []
+        self._load()
+
+    def _load(self):
+        if not self._path.exists():
+            return
+        try:
+            raw = json.loads(self._path.read_text("utf-8"))
+            if isinstance(raw, list):
+                self._schedules = raw
+        except (json.JSONDecodeError, TypeError):
+            self._schedules = []
+
+    def _save(self):
+        self._path.write_text(
+            json.dumps(self._schedules, indent=2, ensure_ascii=False) + "\n",
+            "utf-8",
+        )
+
+    def on_change(self, callback):
+        """Register callback(action, schedule) on any change."""
+        self._callbacks.append(callback)
+
+    def _fire(self, action: str, schedule: dict):
+        for cb in self._callbacks:
+            try:
+                cb(action, schedule)
+            except Exception:
+                pass
+
+    def list_all(self, active_only: bool = False) -> list[dict]:
+        with self._lock:
+            result = list(self._schedules)
+        if active_only:
+            result = [s for s in result if s.get("active", True)]
+        return result
+
+    def get(self, schedule_id: str) -> dict | None:
+        with self._lock:
+            for s in self._schedules:
+                if s.get("id") == schedule_id:
+                    return dict(s)
+            return None
+
+    def create(
+        self,
+        prompt: str,
+        targets: list[str],
+        channel: str = "general",
+        interval_seconds: int | None = None,
+        daily_at: str | None = None,
+    ) -> dict:
+        """Create a schedule. Either interval_seconds or daily_at must be set."""
+        schedule_id = str(uuid.uuid4())[:8]
+        now = time.time()
+        last_run = None
+        if daily_at:
+            interval_seconds = 86400
+        next_run = compute_next_run(
+            interval_seconds or 86400,
+            last_run,
+            daily_at=daily_at,
+        )
+        with self._lock:
+            s = {
+                "id": schedule_id,
+                "prompt": prompt.strip()[:500],
+                "targets": [t.strip().lstrip("@") for t in targets if t.strip()],
+                "channel": channel or "general",
+                "interval_seconds": interval_seconds or 86400,
+                "daily_at": daily_at,
+                "next_run": next_run,
+                "created_at": now,
+                "last_run": None,
+                "active": True,
+            }
+            self._schedules.append(s)
+            self._save()
+        self._fire("create", s)
+        return dict(s)
+
+    def run_due(self) -> list[dict]:
+        """Return list of schedules that are due (next_run <= now). Does not update."""
+        now = time.time()
+        with self._lock:
+            due = [s for s in self._schedules if s.get("active") and s.get("next_run", 0) <= now]
+        return [dict(s) for s in due]
+
+    def mark_run(self, schedule_id: str) -> dict | None:
+        """Mark schedule as run, advance next_run. Returns updated schedule."""
+        with self._lock:
+            for s in self._schedules:
+                if s.get("id") != schedule_id:
+                    continue
+                now = time.time()
+                s["last_run"] = now
+                s["next_run"] = compute_next_run(
+                    s.get("interval_seconds", 3600),
+                    now,
+                    daily_at=s.get("daily_at"),
+                )
+                self._save()
+                result = dict(s)
+                break
+            else:
+                return None
+        self._fire("update", result)
+        return result
+
+    def delete(self, schedule_id: str) -> dict | None:
+        with self._lock:
+            for i, s in enumerate(self._schedules):
+                if s.get("id") == schedule_id:
+                    removed = self._schedules.pop(i)
+                    self._save()
+                    result = dict(removed)
+                    break
+            else:
+                return None
+        self._fire("delete", result)
+        return result
+
+    def toggle(self, schedule_id: str) -> dict | None:
+        with self._lock:
+            for s in self._schedules:
+                if s.get("id") == schedule_id:
+                    s["active"] = not s.get("active", True)
+                    self._save()
+                    result = dict(s)
+                    break
+            else:
+                return None
+        self._fire("update", result)
+        return result

--- a/static/chat.js
+++ b/static/chat.js
@@ -5,6 +5,7 @@
 const SESSION_TOKEN = window.__SESSION_TOKEN__ || "";
 
 let ws = null;
+let _reconnectDelay = 2000;   // exponential backoff: 2s, 4s, 8s, 16s, 30s (cap)
 let pendingAttachments = [];
 let autoScroll = true;
 let reconnectTimer = null;
@@ -23,6 +24,8 @@ let activeChannel = localStorage.getItem('agentchattr-channel') || 'general';
 let channelList = ['general'];
 let channelUnread = {};  // { channelName: count }
 let agentHats = {};  // { agent_name: svg_string }
+let schedulesData = [];  // scheduled tasks from server
+window.customRoles = [];  // saved custom roles from settings
 
 // Expose globals that extracted modules (sessions.js, jobs.js) read via window.*
 // Using defineProperty so live values are always returned.
@@ -355,6 +358,7 @@ function connectWebSocket() {
 
     ws.onopen = () => {
         console.log('WebSocket connected');
+        _reconnectDelay = 2000;  // reset backoff on successful connect
         if (reconnectTimer) {
             clearTimeout(reconnectTimer);
             reconnectTimer = null;
@@ -464,6 +468,12 @@ function connectWebSocket() {
             applySettings(event.data);
         } else if (event.type === 'delete') {
             handleDeleteBroadcast(event.ids);
+        } else if (event.type === 'schedules') {
+            schedulesData = event.data || [];
+            renderSchedulesList();
+            updateSchedulesBadge();
+        } else if (event.type === 'schedule') {
+            handleScheduleEvent(event.action, event.data);
         } else if (event.type === 'rules' || event.type === 'decisions') {
             rules = event.data || [];
             renderRulesPanel();
@@ -562,11 +572,13 @@ function connectWebSocket() {
             location.reload();
             return;
         }
-        console.log('Disconnected, reconnecting in 2s...');
+        const delay = _reconnectDelay;
+        _reconnectDelay = Math.min(_reconnectDelay * 2, 30000);
+        console.log(`Disconnected, reconnecting in ${delay / 1000}s...`);
         soundEnabled = false;  // suppress sounds during reconnect history replay
         const loader = document.getElementById('loading-indicator');
         if (loader) loader.classList.remove('hidden');
-        reconnectTimer = setTimeout(connectWebSocket, 2000);
+        reconnectTimer = setTimeout(connectWebSocket, delay);
     };
 
     ws.onerror = (err) => {
@@ -696,6 +708,39 @@ function appendMessage(msg) {
                 `}
             </div>
             ${!isPending ? `<div class="msg-actions"><button class="reply-btn" onclick="startReply(${msg.id}, event)">reply</button><button class="delete-btn" onclick="deleteClick(${msg.id}, event)" title="Delete">del</button></div>` : ''}`;
+    } else if (msg.type === 'decision') {
+        el.classList.add('proposal-msg', 'decision-msg');
+        const meta = msg.metadata || {};
+        const question = meta.question || msg.text || '';
+        const choices = meta.choices || [];
+        const status = meta.status || 'pending';
+        const resolvedChoice = meta.resolved_choice || '';
+        const color = getColor(msg.sender);
+        const isPending = status === 'pending';
+        const questionHtml = renderMarkdown(question);
+        const choiceButtons = choices.map(c => {
+            const safe = escapeHtml(c).replace(/"/g, '&quot;');
+            return `<button class="decision-choice" data-msg-id="${msg.id}" data-choice="${safe}">${escapeHtml(c)}</button>`;
+        }).join('');
+        el.innerHTML = `
+            <div class="proposal-card decision-card ${isPending ? '' : 'proposal-resolved'}">
+                <div class="proposal-header">
+                    <span class="proposal-pill decision-pill">Question</span>
+                    <span class="proposal-author" style="color: ${color}">${escapeHtml(msg.sender)}</span>
+                </div>
+                <div class="decision-question">${questionHtml}</div>
+                ${isPending ? `
+                    <div class="decision-choices">${choiceButtons}</div>
+                ` : `
+                    <div class="proposal-status-resolved">✓ You chose: ${escapeHtml(resolvedChoice)}</div>
+                `}
+            </div>
+            ${!isPending ? `<div class="msg-actions"><button class="reply-btn" onclick="startReply(${msg.id}, event)">reply</button><button class="delete-btn" onclick="deleteClick(${msg.id}, event)" title="Delete">del</button></div>` : ''}`;
+        if (isPending) {
+            el.querySelectorAll('.decision-choice').forEach(btn => {
+                btn.addEventListener('click', () => resolveDecision(parseInt(btn.dataset.msgId), btn.dataset.choice));
+            });
+        }
     } else if (window._messageRenderers && window._messageRenderers[msg.type]) {
         window._messageRenderers[msg.type](el, msg);
     } else if (msg.type === 'system' || msg.sender === 'system') {
@@ -1055,7 +1100,193 @@ document.addEventListener('keydown', (e) => {
     }
 });
 
+// --- Terminal webcam popover ---
+
+let _termPopoverCloseTimer = null;
+let _termPopoverPollInterval = null;
+
+function stripAnsi(str) {
+    return (str || '').replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function detectActions(raw) {
+    const actions = [];
+    const r = (raw || '').toLowerCase();
+    if (/\(y\/n\)|y\/n\?|\[y\/n\]/i.test(r)) {
+        actions.push({ label: 'Yes', keys: 'y', enter: true });
+        actions.push({ label: 'No', keys: 'n', enter: true });
+    }
+    if (/action required/i.test(r)) {
+        actions.push({ label: 'Accept', keys: '', enter: true });
+    }
+    if (/untrusted|folder is untrusted|trust folder/i.test(r)) {
+        actions.push({ label: 'Trust folder', keys: '1', enter: true });
+    }
+    if (/press .* to continue|press enter|continue/i.test(r)) {
+        actions.push({ label: 'Enter', keys: '', enter: true });
+    }
+    return actions;
+}
+
+async function fetchTerminal(name, lines = 50) {
+    const resp = await fetch(`/api/terminal/${encodeURIComponent(name)}?lines=${lines}`, {
+        headers: { 'X-Session-Token': SESSION_TOKEN },
+    });
+    return resp.json();
+}
+
+async function sendInput(name, text, enter) {
+    const resp = await fetch(`/api/terminal/${encodeURIComponent(name)}/input`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Session-Token': SESSION_TOKEN },
+        body: JSON.stringify({ text: text || '', enter: enter !== false }),
+    });
+    return resp.json();
+}
+
+function schedulePopoverClose() {
+    if (_termPopoverCloseTimer) clearTimeout(_termPopoverCloseTimer);
+    _termPopoverCloseTimer = setTimeout(() => {
+        _termPopoverCloseTimer = null;
+        if (_termPopoverPollInterval) {
+            clearInterval(_termPopoverPollInterval);
+            _termPopoverPollInterval = null;
+        }
+        const popover = document.getElementById('term-popover');
+        if (popover) popover.classList.add('hidden');
+    }, 250);
+}
+
+function showTerminalPopover(name, pillEl) {
+    if (_termPopoverCloseTimer) {
+        clearTimeout(_termPopoverCloseTimer);
+        _termPopoverCloseTimer = null;
+    }
+    let popover = document.getElementById('term-popover');
+    if (!popover) {
+        popover = document.createElement('div');
+        popover.id = 'term-popover';
+        popover.className = 'term-popover hidden';
+        popover.innerHTML = `
+            <div class="term-title"></div>
+            <pre class="term-screen"></pre>
+            <div class="term-actions"></div>
+            <div class="term-input-row">
+                <input type="text" class="term-input" placeholder="Type or send keys..." spellcheck="false" autocomplete="off" />
+                <button type="button" class="term-send-btn">Send</button>
+            </div>`;
+        popover.addEventListener('mouseenter', () => {
+            if (_termPopoverCloseTimer) clearTimeout(_termPopoverCloseTimer);
+            _termPopoverCloseTimer = null;
+        });
+        popover.addEventListener('mouseleave', schedulePopoverClose);
+        document.body.appendChild(popover);
+    }
+    const cfg = agentConfig[name] || {};
+    const label = cfg.label || name;
+    const color = cfg.color || '#4ade80';
+    popover.style.setProperty('--agent-color', color);
+    popover.querySelector('.term-title').textContent = `${label} — terminal`;
+    popover.querySelector('.term-screen').textContent = 'Loading...';
+    popover.querySelector('.term-actions').innerHTML = '';
+    popover.querySelector('.term-input').value = '';
+    popover.classList.remove('hidden');
+
+    const rect = pillEl.getBoundingClientRect();
+    const popoverHeight = 320;
+    const above = rect.top > popoverHeight + 20;
+    popover.style.top = above ? `${rect.top - popoverHeight - 8}px` : `${rect.bottom + 8}px`;
+    const popoverWidth = 520;
+    const leftRaw = rect.left + rect.width / 2 - popoverWidth / 2;
+    popover.style.left = `${Math.min(Math.max(8, leftRaw), window.innerWidth - popoverWidth - 8)}px`;
+
+    const inputEl = popover.querySelector('.term-input');
+    const sendBtn = popover.querySelector('.term-send-btn');
+    sendBtn.onclick = () => {
+        const text = inputEl.value;
+        if (!text) return;
+        sendInput(name, text, true).catch(() => {});
+        inputEl.value = '';
+    };
+    inputEl.onkeydown = (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            sendBtn.click();
+        }
+    };
+
+    popover.dataset.agentName = name;
+    // Lines requested from the server — starts small, grows when user loads more
+    let fetchLines = 50;
+
+    async function poll() {
+        const screenEl = popover.querySelector('.term-screen');
+        const actionsEl = popover.querySelector('.term-actions');
+        try {
+            const data = await fetchTerminal(name, fetchLines);
+            if (!popover.classList.contains('hidden') && popover.dataset.agentName === name) {
+                if (data.available) {
+                    const display = stripAnsi(data.raw || '');
+                    const atBottom = screenEl.scrollHeight - screenEl.scrollTop - screenEl.clientHeight < 40;
+                    screenEl.textContent = display || '(no output)';
+                    if (atBottom) screenEl.scrollTop = screenEl.scrollHeight;
+
+                    // "Load more" button — appears when user has scrolled to the top
+                    // and there might be more history available
+                    const hasMore = (data.lines || []).length >= fetchLines && fetchLines < 500;
+                    let loadMoreBtn = screenEl.nextElementSibling?.classList?.contains('term-load-more')
+                        ? screenEl.nextElementSibling
+                        : null;
+                    if (hasMore && !loadMoreBtn) {
+                        loadMoreBtn = document.createElement('button');
+                        loadMoreBtn.className = 'term-load-more';
+                        loadMoreBtn.textContent = '↑ Load more history';
+                        loadMoreBtn.onclick = () => {
+                            fetchLines = Math.min(fetchLines + 100, 500);
+                            poll();
+                        };
+                        screenEl.insertAdjacentElement('afterend', loadMoreBtn);
+                    } else if (!hasMore && loadMoreBtn) {
+                        loadMoreBtn.remove();
+                    }
+
+                    const actions = detectActions(data.raw);
+                    actionsEl.innerHTML = '';
+                    actions.forEach(a => {
+                        const btn = document.createElement('button');
+                        btn.className = 'term-action-btn';
+                        btn.textContent = a.label;
+                        btn.onclick = () => sendInput(name, a.keys, a.enter).then(() => poll()).catch(() => {});
+                        actionsEl.appendChild(btn);
+                    });
+                } else {
+                    screenEl.textContent = 'No tmux session (Mac/Linux only)';
+                    actionsEl.innerHTML = '';
+                }
+            }
+        } catch (err) {
+            if (!popover.classList.contains('hidden') && popover.dataset.agentName === name) {
+                screenEl.textContent = 'Connection lost';
+                actionsEl.innerHTML = '';
+            }
+        }
+    }
+
+    poll();
+    if (_termPopoverPollInterval) clearInterval(_termPopoverPollInterval);
+    _termPopoverPollInterval = setInterval(poll, 1500);
+}
+
 function buildStatusPills() {
+    // Close term popover and stop polling when pills are rebuilt (e.g. agent
+    // registered/deregistered) — prevents orphaned popover and stale intervals.
+    if (_termPopoverPollInterval) {
+        clearInterval(_termPopoverPollInterval);
+        _termPopoverPollInterval = null;
+    }
+    const popover = document.getElementById('term-popover');
+    if (popover) popover.classList.add('hidden');
+
     const container = document.getElementById('agent-status');
     container.innerHTML = '';
     for (const [name, cfg] of Object.entries(agentConfig)) {
@@ -1063,20 +1294,277 @@ function buildStatusPills() {
         pill.className = 'status-pill';
         if (cfg.state === 'pending') pill.classList.add('pending');
         pill.id = `status-${name}`;
-        pill.title = `@${name}`;  // Tooltip: canonical name for manual @-typing
+        pill.title = `@${name}`;
         pill.style.setProperty('--agent-color', cfg.color || '#4ade80');
-        pill.innerHTML = `<span class="status-dot"></span><span class="status-label">${escapeHtml(cfg.label || name)}</span>`;
-        // Left-click to rename or name pending instance
-        pill.addEventListener('click', () => {
+        pill.innerHTML = `
+            <span class="status-dot"></span>
+            <span class="status-label">${escapeHtml(cfg.label || name)}</span>
+            <button class="pill-kill" title="Kill ${escapeHtml(name)}" aria-label="Kill ${escapeHtml(name)}">×</button>`;
+        pill.querySelector('.pill-kill').addEventListener('click', (e) => {
+            e.stopPropagation();
+            killAgent(name);
+        });
+        pill.addEventListener('click', (e) => {
+            e.stopPropagation();
             const mode = cfg.state === 'pending' ? 'pending' : 'rename';
-            showAgentNameModal({
+            showPillPopover(pill, {
                 name, label: cfg.label || name, color: cfg.color || '#888',
                 base: cfg.base || '', mode,
             });
         });
+        pill.addEventListener('mouseenter', () => showTerminalPopover(name, pill));
+        pill.addEventListener('mouseleave', schedulePopoverClose);
         container.appendChild(pill);
     }
+
+    // Spawn button — always at the end of the pills row
+    const spawnBtn = document.createElement('button');
+    spawnBtn.className = 'pill-spawn-btn';
+    spawnBtn.title = 'Spawn agent instance';
+    spawnBtn.textContent = '+';
+    spawnBtn.addEventListener('click', showSpawnModal);
+    container.appendChild(spawnBtn);
+
     enableDragScroll(container);
+}
+
+const ROLE_PRESETS = [
+    { label: 'Planner', emoji: '📋' },
+    { label: 'Designer', emoji: '✨' },
+    { label: 'Architect', emoji: '🏛️' },
+    { label: 'Builder', emoji: '🔨' },
+    { label: 'Reviewer', emoji: '🔍' },
+    { label: 'Researcher', emoji: '🔬' },
+    { label: 'Red Team', emoji: '🛡️' },
+    { label: 'Wry', emoji: '🍸' },
+    { label: 'Unhinged', emoji: '🤪' },
+    { label: 'Hype', emoji: '🎉' },
+];
+
+function showPillPopover(pillEl, opts) {
+    if (opts.mode === 'pending') _nameModalActive = true;
+    // Hide terminal popover when showing pill popover
+    const termPopover = document.getElementById('term-popover');
+    if (termPopover) termPopover.classList.add('hidden');
+    if (_termPopoverPollInterval) {
+        clearInterval(_termPopoverPollInterval);
+        _termPopoverPollInterval = null;
+    }
+
+    document.querySelectorAll('.pill-popover').forEach(p => p.remove());
+
+    const popover = document.createElement('div');
+    popover.className = 'pill-popover';
+    popover.style.setProperty('--agent-color', opts.color);
+
+    const currentRole = (_agentRoles[opts.name] || '').toLowerCase();
+    const roleChipsHtml = ROLE_PRESETS.map(p =>
+        `<button class="role-preset-chip pill-role-chip ${currentRole === p.label.toLowerCase() ? 'active' : ''}" data-role="${escapeHtml(p.label)}">${p.emoji} ${escapeHtml(p.label)}</button>`
+    ).join('');
+    const customRoles = (window.customRoles || []).map(r =>
+        `<button class="role-preset-chip pill-role-chip ${currentRole === r.toLowerCase() ? 'active' : ''}" data-role="${escapeHtml(r)}">${escapeHtml(r)}</button>`
+    ).join('');
+
+    popover.innerHTML = `
+        <div class="pill-popover-section">
+            <label class="pill-popover-label">${opts.mode === 'pending' ? 'Name this agent' : 'Rename'}</label>
+            <div class="pill-popover-rename-row">
+                <input type="text" class="pill-popover-input" value="${escapeHtml(opts.label)}" maxlength="24" spellcheck="false" />
+                <button class="pill-popover-confirm">${opts.mode === 'pending' ? 'Confirm' : 'Rename'}</button>
+            </div>
+        </div>
+        <div class="pill-popover-section">
+            <label class="pill-popover-label">Role</label>
+            <div class="pill-popover-roles">
+                <button class="role-preset-chip pill-role-chip ${!currentRole ? 'active' : ''}" data-role="">None</button>
+                ${roleChipsHtml}
+                ${customRoles}
+            </div>
+            <div class="pill-popover-custom-row">
+                <input type="text" class="pill-popover-custom-input" placeholder="Custom role..." maxlength="30" />
+            </div>
+        </div>
+    `;
+
+    const inputEl = popover.querySelector('.pill-popover-input');
+    const confirmBtn = popover.querySelector('.pill-popover-confirm');
+    const customInput = popover.querySelector('.pill-popover-custom-input');
+
+    const closePopover = () => {
+        popover.remove();
+        document.removeEventListener('click', outsideClickHandler, true);
+        if (opts.mode === 'pending') {
+            _nameModalActive = false;
+            setTimeout(_showNextPendingName, 200);
+        }
+    };
+
+    const outsideClickHandler = (e) => {
+        if (!popover.contains(e.target) && !(pillEl && pillEl.contains(e.target))) {
+            closePopover();
+        }
+    };
+
+    confirmBtn.addEventListener('click', () => {
+        const label = inputEl.value.trim();
+        if (!label) return;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+            if (opts.mode === 'pending') {
+                ws.send(JSON.stringify({ type: 'name_pending', name: opts.name, label }));
+            } else {
+                ws.send(JSON.stringify({ type: 'rename_agent', name: opts.name, label }));
+            }
+        }
+        closePopover();
+    });
+
+    inputEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') { confirmBtn.click(); e.preventDefault(); }
+        if (e.key === 'Escape') { closePopover(); e.preventDefault(); }
+    });
+
+    popover.querySelectorAll('.pill-role-chip').forEach(chip => {
+        chip.addEventListener('click', () => {
+            const role = chip.dataset.role || '';
+            _setRole(opts.name, role);
+            closePopover();
+        });
+    });
+
+    customInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            const val = customInput.value.trim();
+            if (val) { _setRole(opts.name, val); closePopover(); }
+            e.preventDefault();
+        }
+        if (e.key === 'Escape') { closePopover(); e.preventDefault(); }
+    });
+
+    document.body.appendChild(popover);
+
+    if (pillEl) {
+        const rect = pillEl.getBoundingClientRect();
+        popover.style.top = `${rect.bottom + 8}px`;
+        popover.style.left = `${Math.min(rect.left, window.innerWidth - 280)}px`;
+    } else {
+        popover.style.top = '50%';
+        popover.style.left = '50%';
+        popover.style.transform = 'translate(-50%, -50%)';
+    }
+
+    setTimeout(() => document.addEventListener('click', outsideClickHandler, true), 0);
+    inputEl.focus();
+}
+
+// --- Spawn modal ---
+
+function _spawnInstanceCount(base) {
+    return Object.values(agentConfig).filter(c => c.base === base).length;
+}
+
+function showSpawnModal() {
+    const spawnableAgents = Object.entries(baseColors)
+        .filter(([, cfg]) => cfg.spawnable)
+        .sort(([a], [b]) => a.localeCompare(b));
+
+    if (spawnableAgents.length === 0) {
+        alert('No spawnable agents configured.');
+        return;
+    }
+
+    let modal = document.getElementById('spawn-modal');
+    if (!modal) {
+        modal = document.createElement('div');
+        modal.id = 'spawn-modal';
+        modal.className = 'spawn-modal hidden';
+        modal.innerHTML = `
+            <div class="spawn-dialog">
+                <h3 class="spawn-title">Spawn agent</h3>
+                <label class="spawn-label">Agent</label>
+                <select class="spawn-agent-select"></select>
+                <p class="spawn-cap-note"></p>
+                <label class="spawn-label">Guidance <span class="spawn-optional">(optional)</span></label>
+                <textarea class="spawn-guidance" rows="3" placeholder="Initial instructions for this instance…" spellcheck="false"></textarea>
+                <div class="spawn-actions">
+                    <button class="spawn-cancel">Cancel</button>
+                    <button class="spawn-confirm">Spawn</button>
+                </div>
+            </div>`;
+        modal.addEventListener('click', (e) => { if (e.target === modal) _closeSpawnModal(); });
+        modal.querySelector('.spawn-cancel').addEventListener('click', _closeSpawnModal);
+        document.body.appendChild(modal);
+    }
+
+    const select = modal.querySelector('.spawn-agent-select');
+    const capNote = modal.querySelector('.spawn-cap-note');
+    const confirmBtn = modal.querySelector('.spawn-confirm');
+
+    function _refreshCapState() {
+        const base = select.value;
+        const cfg = baseColors[base] || {};
+        const max = cfg.max_instances ?? 3;
+        const current = _spawnInstanceCount(base);
+        const atCap = current >= max;
+        capNote.textContent = atCap
+            ? `${current}/${max} instances running — kill one to spawn another`
+            : current > 0 ? `${current}/${max} instances running` : '';
+        capNote.style.color = atCap ? 'var(--color-warning, #f59e0b)' : 'var(--color-muted, #888)';
+        confirmBtn.disabled = atCap;
+    }
+
+    select.innerHTML = spawnableAgents
+        .map(([name, cfg]) => `<option value="${escapeHtml(name)}">${escapeHtml(cfg.label || name)}</option>`)
+        .join('');
+    modal.querySelector('.spawn-guidance').value = '';
+    modal.classList.remove('hidden');
+    select.focus();
+    _refreshCapState();
+
+    select.onchange = _refreshCapState;
+
+    confirmBtn.onclick = async () => {
+        const agent = select.value;
+        const guidance = modal.querySelector('.spawn-guidance').value.trim();
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = 'Spawning…';
+        try {
+            const res = await fetch(`/api/agents/${encodeURIComponent(agent)}/spawn`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Session-Token': SESSION_TOKEN },
+                body: JSON.stringify({ guidance }),
+            });
+            const data = await res.json();
+            if (data.error) throw new Error(data.error);
+            _closeSpawnModal();
+        } catch (err) {
+            confirmBtn.disabled = false;
+            confirmBtn.textContent = 'Spawn';
+            alert(`Spawn failed: ${err.message}`);
+        }
+    };
+}
+
+function _closeSpawnModal() {
+    const modal = document.getElementById('spawn-modal');
+    if (modal) modal.classList.add('hidden');
+}
+
+async function killAgent(name) {
+    if (!confirm(`Kill ${name}?`)) return;
+    const pill = document.getElementById(`status-${name}`);
+    const killBtn = pill?.querySelector('.pill-kill');
+    if (killBtn) killBtn.disabled = true;
+    try {
+        const res = await fetch(`/api/agents/${encodeURIComponent(name)}/kill`, {
+            method: 'POST',
+            headers: { 'X-Session-Token': SESSION_TOKEN },
+        });
+        const data = await res.json();
+        if (data.error) throw new Error(data.error);
+    } catch (err) {
+        if (killBtn) killBtn.disabled = false;
+        alert(`Kill failed: ${err.message}`);
+    }
 }
 
 // --- Agent naming lightbox ---
@@ -1090,7 +1578,8 @@ function _showNextPendingName() {
     // Only show if still pending in agentConfig
     const cfg = agentConfig[next.name];
     if (cfg && cfg.state === 'pending') {
-        showAgentNameModal({ ...next, mode: 'pending' });
+        const pillEl = document.getElementById(`status-${next.name}`);
+        showPillPopover(pillEl || null, { ...next, mode: 'pending' });
     } else {
         _showNextPendingName(); // skip stale entries
     }
@@ -1200,19 +1689,6 @@ function showBubbleRolePicker(btn, agentName) {
         p.remove();
     });
 
-    const ROLE_PRESETS = [
-        { label: 'Planner', emoji: '📋' },
-        { label: 'Designer', emoji: '✨' },
-        { label: 'Architect', emoji: '🏛️' },
-        { label: 'Builder', emoji: '🔨' },
-        { label: 'Reviewer', emoji: '🔍' },
-        { label: 'Researcher', emoji: '🔬' },
-        { label: 'Red Team', emoji: '🛡️' },
-        { label: 'Wry', emoji: '🍸' },
-        { label: 'Unhinged', emoji: '🤪' },
-        { label: 'Hype', emoji: '🎉' },
-    ];
-
     const currentRole = (_agentRoles[agentName] || '').toLowerCase();
     const picker = document.createElement('div');
     picker.className = 'bubble-role-picker';
@@ -1230,6 +1706,14 @@ function showBubbleRolePicker(btn, agentName) {
         chip.className = 'role-preset-chip' + (currentRole === preset.label.toLowerCase() ? ' active' : '');
         chip.textContent = `${preset.emoji} ${preset.label}`;
         chip.addEventListener('click', () => { _setRole(agentName, preset.label); closePicker(); });
+        picker.appendChild(chip);
+    }
+    for (const r of (window.customRoles || [])) {
+        if (!r || ROLE_PRESETS.some(p => p.label.toLowerCase() === r.toLowerCase())) continue;
+        const chip = document.createElement('button');
+        chip.className = 'role-preset-chip' + (currentRole === r.toLowerCase() ? ' active' : '');
+        chip.textContent = r;
+        chip.addEventListener('click', () => { _setRole(agentName, r); closePicker(); });
         picker.appendChild(chip);
     }
 
@@ -1315,6 +1799,21 @@ function _setRole(agentName, role) {
     // Optimistic update
     _agentRoles[agentName] = role;
     _syncBubbleRolePills(agentName);
+    // If custom role (not in presets), add to saved custom roles
+    if (role && !ROLE_PRESETS.some(p => p.label.toLowerCase() === role.toLowerCase())) {
+        _addCustomRole(role);
+    }
+}
+
+function _addCustomRole(role) {
+    const list = window.customRoles || [];
+    const lower = role.trim().toLowerCase();
+    if (list.some(r => r.toLowerCase() === lower)) return;
+    const updated = [...list, role.trim()].slice(-20);
+    window.customRoles = updated;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'update_settings', data: { custom_roles: updated } }));
+    }
 }
 
 // --- Status ---
@@ -1407,6 +1906,22 @@ function applySettings(data) {
     if (data.rules_refresh_interval !== undefined) {
         document.getElementById('setting-rules-refresh').value = String(data.rules_refresh_interval);
     }
+    if (data.routing_default) {
+        document.getElementById('setting-routing').value = data.routing_default;
+    }
+    if (data.project_dir !== undefined) {
+        const pd = data.project_dir;
+        document.getElementById('setting-project-dir').value = pd;
+        const display = document.getElementById('project-dir-display');
+        display.textContent = pd || 'Not selected';
+        display.title = pd || '';
+    }
+    if (data.auto_approve !== undefined) {
+        document.getElementById('setting-auto-approve').checked = !!data.auto_approve;
+    }
+    if (Array.isArray(data.custom_roles)) {
+        window.customRoles = data.custom_roles;
+    }
     if (data.channels && Array.isArray(data.channels)) {
         channelList = data.channels;
         // If active channel was deleted, switch to general
@@ -1451,6 +1966,9 @@ function saveSettings() {
     const newHistory = histVal === 'all' ? 'all' : (parseInt(histVal) || 50);
     const newContrast = document.getElementById('setting-contrast').value;
     const newRulesRefresh = document.getElementById('setting-rules-refresh').value;
+    const newRouting = document.getElementById('setting-routing').value;
+    const newProjectDir = document.getElementById('setting-project-dir').value.trim();
+    const newAutoApprove = document.getElementById('setting-auto-approve').checked;
 
     if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({
@@ -1462,6 +1980,9 @@ function saveSettings() {
                 history_limit: newHistory,
                 contrast: newContrast,
                 rules_refresh_interval: parseInt(newRulesRefresh) || 0,
+                routing_default: newRouting,
+                project_dir: newProjectDir,
+                auto_approve: newAutoApprove,
             }
         }));
     }
@@ -1484,7 +2005,7 @@ function setupSettingsKeys() {
     }
 
     // Auto-save on change for selects, escape to close
-    for (const id of ['setting-font', 'setting-history', 'setting-contrast', 'setting-rules-refresh']) {
+    for (const id of ['setting-font', 'setting-history', 'setting-contrast', 'setting-rules-refresh', 'setting-routing']) {
         const el = document.getElementById(id);
         el.addEventListener('change', () => {
             // Apply contrast immediately (don't wait for server round-trip)
@@ -1499,7 +2020,134 @@ function setupSettingsKeys() {
             }
         });
     }
+
+    // Auto-save on change for checkbox
+    const autoApproveEl = document.getElementById('setting-auto-approve');
+    autoApproveEl.addEventListener('change', () => saveSettings());
+    autoApproveEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') toggleSettings();
+    });
+
+    // Browse project directory
+    document.getElementById('browse-project-dir').addEventListener('click', openFolderPicker);
+
+    // Start all agents
+    document.getElementById('start-all-agents-btn').addEventListener('click', startAllAgents);
+
+    // Stop all agents
+    document.getElementById('stop-all-agents-btn').addEventListener('click', stopAllAgents);
 }
+
+let _folderPickerCurrentPath = '';
+
+function openFolderPicker() {
+    _folderPickerCurrentPath = '';
+    document.getElementById('folder-picker-modal').classList.remove('hidden');
+    loadFolderPicker('');
+}
+
+function closeFolderPicker() {
+    document.getElementById('folder-picker-modal').classList.add('hidden');
+}
+
+function loadFolderPicker(path) {
+    const listEl = document.getElementById('folder-picker-list');
+    const breadcrumbEl = document.getElementById('folder-picker-breadcrumb');
+    listEl.innerHTML = 'Loading...';
+    fetch('/api/browse?path=' + encodeURIComponent(path), {
+        headers: { 'X-Session-Token': SESSION_TOKEN }
+    })
+        .then(r => r.json())
+        .then(data => {
+            if (data.error) {
+                listEl.innerHTML = '<span class="folder-picker-error">' + (data.error || 'Error') + '</span>';
+                return;
+            }
+            _folderPickerCurrentPath = data.path || '';
+            breadcrumbEl.textContent = data.path || 'Root';
+            listEl.innerHTML = '';
+            if (data.parent) {
+                const parentItem = document.createElement('div');
+                parentItem.className = 'folder-picker-item';
+                parentItem.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16"><path d="M10 12L6 8l4-4" stroke="currentColor" stroke-width="2" fill="none"/></svg><span>..</span>';
+                parentItem.onclick = () => loadFolderPicker(data.parent);
+                listEl.appendChild(parentItem);
+            }
+            const dirs = data.directories || [];
+            dirs.forEach(d => {
+                const item = document.createElement('div');
+                item.className = 'folder-picker-item';
+                item.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16"><path d="M2 4h4l2 2h6v6H2z" stroke="currentColor" stroke-width="1.2" fill="none"/></svg><span>' + (d.name || d.path) + '</span>';
+                item.onclick = () => loadFolderPicker(d.path);
+                listEl.appendChild(item);
+            });
+        })
+        .catch(() => {
+            listEl.innerHTML = '<span class="folder-picker-error">Failed to load</span>';
+        });
+}
+
+function selectCurrentFolder() {
+    document.getElementById('setting-project-dir').value = _folderPickerCurrentPath;
+    const display = document.getElementById('project-dir-display');
+    display.textContent = _folderPickerCurrentPath || 'Not selected';
+    display.title = _folderPickerCurrentPath || '';
+    closeFolderPicker();
+    saveSettings();
+}
+
+function startAllAgents() {
+    const btn = document.getElementById('start-all-agents-btn');
+    btn.disabled = true;
+    btn.textContent = 'Starting...';
+    saveSettings();
+    setTimeout(() => {
+        fetch('/api/agents/start', {
+            method: 'POST',
+            headers: { 'X-Session-Token': SESSION_TOKEN }
+        })
+        .then(r => r.json())
+        .then(data => {
+            btn.disabled = false;
+            btn.textContent = 'Start all agents';
+            if (data.started && data.started.length > 0) {
+                console.log('Started agents:', data.started);
+            }
+        })
+        .catch(() => {
+            btn.disabled = false;
+            btn.textContent = 'Start all agents';
+        });
+    }, 300);
+}
+
+function stopAllAgents() {
+    const btn = document.getElementById('stop-all-agents-btn');
+    btn.disabled = true;
+    btn.textContent = 'Stopping...';
+    fetch('/api/agents/stop', {
+        method: 'POST',
+        headers: { 'X-Session-Token': SESSION_TOKEN }
+    })
+        .then(r => {
+            if (!r.ok) throw new Error(r.statusText);
+            return r.json();
+        })
+        .then(data => {
+            btn.disabled = false;
+            btn.textContent = 'Stop all agents';
+            if (data.error) console.error('Stop agents:', data.error);
+        })
+        .catch(err => {
+            btn.disabled = false;
+            btn.textContent = 'Stop all agents';
+            console.error('Stop agents failed:', err);
+        });
+}
+
+window.closeFolderPicker = closeFolderPicker;
+window.selectCurrentFolder = selectCurrentFolder;
+window.openFolderPicker = openFolderPicker;
 
 // --- Keyboard shortcuts ---
 
@@ -1509,6 +2157,8 @@ function setupKeyboardShortcuts() {
         const modalOpen = modal && !modal.classList.contains('hidden');
 
         if (e.key === 'Escape') {
+            const folderModal = document.getElementById('folder-picker-modal');
+            if (folderModal && !folderModal.classList.contains('hidden')) { closeFolderPicker(); return; }
             const nameModal = document.getElementById('agent-name-modal');
             if (nameModal && !nameModal.classList.contains('hidden')) { _closeAgentNameModal(); return; }
             const convertModal = document.getElementById('convert-job-modal');
@@ -1545,6 +2195,9 @@ const SLASH_COMMANDS = [
     { cmd: '/poetry haiku', desc: 'Agents write a haiku about the codebase', broadcast: true },
     { cmd: '/poetry limerick', desc: 'Agents write a limerick about the codebase', broadcast: true },
     { cmd: '/poetry sonnet', desc: 'Agents write a sonnet about the codebase', broadcast: true },
+    { cmd: '/schedule', desc: 'Schedule a recurring prompt (e.g. /schedule @claude "summarise" every 1h)', broadcast: false },
+    { cmd: '/schedules', desc: 'View scheduled tasks', broadcast: false },
+    { cmd: '/unschedule', desc: 'Cancel a scheduled task (e.g. /unschedule <id>)', broadcast: false },
     { cmd: '/summary', desc: 'Summarize recent messages — tag an agent (e.g. /summary @claude)', broadcast: false, needsMention: true },
     { cmd: '/summarise', desc: 'Summarize recent messages — tag an agent (e.g. /summarise @claude)', broadcast: false, needsMention: true, hidden: true },
     { cmd: '/continue', desc: 'Resume after loop guard pauses', broadcast: false },
@@ -1837,6 +2490,13 @@ function sendMessage() {
         ws.send(JSON.stringify(payload));
     }
 
+    if (text.trim().toLowerCase() === '/schedules') {
+        const panel = document.getElementById('schedules-panel');
+        if (panel && panel.classList.contains('hidden')) {
+            toggleSchedulesPanel();
+        }
+    }
+
     input.value = '';
     input.style.height = 'auto';
     clearAttachments();
@@ -2127,6 +2787,23 @@ let deleteMode = false;
 let deleteSelected = new Set();
 let deleteDragging = false;
 
+async function resolveDecision(msgId, choice) {
+    try {
+        const resp = await fetch(`/api/messages/${msgId}/resolve`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', 'X-Session-Token': SESSION_TOKEN },
+            body: JSON.stringify({ choice }),
+        });
+        if (!resp.ok) {
+            const err = await resp.json().catch(() => ({}));
+            console.error('Failed to resolve decision:', err.error || resp.status);
+        }
+    } catch (e) {
+        console.error('Failed to resolve decision:', e);
+    }
+}
+window.resolveDecision = resolveDecision;
+
 function deleteClick(msgId, event) {
     event.stopPropagation();
     enterDeleteMode(msgId);
@@ -2318,16 +2995,84 @@ function handleDeleteBroadcast(ids) {
     if (panel && !panel.classList.contains('hidden')) renderTodosPanel();
 }
 
-function togglePinsPanel() {
-    _preserveScroll(() => {
-        const panel = document.getElementById('pins-panel');
-        panel.classList.toggle('hidden');
-        document.getElementById('pins-toggle').classList.toggle('active', !panel.classList.contains('hidden'));
-        if (!panel.classList.contains('hidden')) {
-            renderTodosPanel();
-        }
-    });
+function toggleSchedulesPanel() {
+    const panel = document.getElementById('schedules-panel');
+    const toggle = document.getElementById('schedules-toggle');
+    if (!panel || !toggle) return;
+    panel.classList.toggle('hidden');
+    toggle.classList.toggle('active', !panel.classList.contains('hidden'));
+    if (!panel.classList.contains('hidden')) {
+        renderSchedulesList();
+    }
 }
+window.toggleSchedulesPanel = toggleSchedulesPanel;
+
+function renderSchedulesList() {
+    const list = document.getElementById('schedules-list');
+    if (!list) return;
+    list.innerHTML = '';
+    const active = schedulesData.filter(s => s.active !== false);
+    if (active.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'schedules-empty';
+        empty.textContent = 'No scheduled tasks. Use /schedule @agent "prompt" every 1h';
+        list.appendChild(empty);
+        return;
+    }
+    for (const s of active) {
+        const card = document.createElement('div');
+        card.className = 'schedule-card';
+        card.dataset.id = s.id;
+        const nextRun = s.next_run ? new Date(s.next_run * 1000).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' }) : '—';
+        const targets = (s.targets || []).map(t => `@${t}`).join(' ');
+        const promptPreview = (s.prompt || '').slice(0, 60) + ((s.prompt || '').length > 60 ? '…' : '');
+        card.innerHTML = `
+            <div class="schedule-prompt">${escapeHtml(promptPreview)}</div>
+            <div class="schedule-meta">${escapeHtml(targets)} · ${escapeHtml(nextRun)}</div>
+            <button class="schedule-cancel" data-schedule-id="${escapeHtml(s.id)}" title="Cancel">×</button>
+        `;
+        card.querySelector('.schedule-cancel').addEventListener('click', () => cancelSchedule(s.id));
+        list.appendChild(card);
+    }
+}
+
+function updateSchedulesBadge() {
+    const badge = document.getElementById('schedules-badge');
+    if (!badge) return;
+    const count = schedulesData.filter(s => s.active !== false).length;
+    badge.textContent = count;
+    badge.classList.toggle('hidden', count === 0);
+}
+
+async function cancelSchedule(id) {
+    try {
+        const resp = await fetch(`/api/schedules/${encodeURIComponent(id)}`, {
+            method: 'DELETE',
+            headers: { 'X-Session-Token': SESSION_TOKEN },
+        });
+        if (!resp.ok) throw new Error('Failed to cancel');
+    } catch (e) {
+        console.error('Failed to cancel schedule:', e);
+    }
+}
+window.cancelSchedule = cancelSchedule;
+
+function handleScheduleEvent(action, data) {
+    if (action === 'delete') {
+        schedulesData = schedulesData.filter(s => s.id !== data?.id);
+    } else if (action === 'create' || action === 'update') {
+        const idx = schedulesData.findIndex(s => s.id === data?.id);
+        if (idx >= 0) {
+            schedulesData[idx] = data;
+        } else {
+            schedulesData.push(data);
+        }
+    }
+    renderSchedulesList();
+    updateSchedulesBadge();
+}
+
+function togglePinsPanel() {
 
 function renderTodosPanel() {
     const list = document.getElementById('pins-list');

--- a/static/index.html
+++ b/static/index.html
@@ -21,8 +21,15 @@
                 </a>
                 <span class="subtitle" id="room-subtitle"></span>
             </div>
+            <div id="agent-status"></div>
             <div class="header-right">
-                <div id="agent-status"></div>
+                <button class="settings-btn" id="schedules-toggle" onclick="toggleSchedulesPanel()" title="Scheduled tasks">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                        <rect x="2" y="2" width="12" height="12" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
+                        <path d="M2 5h12M5 2v4M8 2v4M11 2v4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+                    </svg>
+                    <span class="schedules-badge hidden" id="schedules-badge">0</span>
+                </button>
                 <button class="settings-btn" id="jobs-toggle" onclick="toggleJobsPanel()" title="Jobs">
                     <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                         <rect x="3" y="2" width="10" height="12" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
@@ -53,6 +60,26 @@
         </header>
 
         <div id="settings-bar" class="hidden">
+            <div class="settings-section-label">Setup</div>
+            <div class="settings-field">
+                <label>Project directory</label>
+                <div class="project-dir-row">
+                    <button type="button" id="browse-project-dir" class="browse-btn">Browse</button>
+                    <span id="project-dir-display" class="project-dir-display">Not selected</span>
+                    <input type="hidden" id="setting-project-dir">
+                </div>
+            </div>
+            <div class="settings-field">
+                <label for="setting-auto-approve">Auto-approve</label>
+                <input type="checkbox" id="setting-auto-approve" title="Skip permission prompts — agents run without asking. Restart agents to apply.">
+                <span class="settings-hint">Restart agents to apply</span>
+            </div>
+            <div class="settings-field settings-agent-buttons">
+                <button type="button" id="start-all-agents-btn" class="start-agents-btn">Start all agents</button>
+                <button type="button" id="stop-all-agents-btn" class="stop-agents-btn">Stop all agents</button>
+            </div>
+            <div class="settings-divider"></div>
+            <div class="settings-section-label">Appearance</div>
             <div class="settings-field">
                 <label for="setting-username">Name</label>
                 <input type="text" id="setting-username" placeholder="your name" maxlength="20">
@@ -94,6 +121,13 @@
                     <option value="10" selected>Every 10 triggers</option>
                     <option value="20">Every 20 triggers</option>
                     <option value="50">Every 50 triggers</option>
+                </select>
+            </div>
+            <div class="settings-field">
+                <label for="setting-routing">Routing</label>
+                <select id="setting-routing" title="Who receives messages without @mentions">
+                    <option value="none">Only @mentions</option>
+                    <option value="all">All agents</option>
                 </select>
             </div>
             <div class="settings-divider"></div>
@@ -160,7 +194,9 @@
                             <button class="job-toggle archived" data-status="archived" onclick="toggleJobStatus('archived')" title="Closed">CLOSED</button>
                         </div>
                     </div>
-                    <div class="jobs-conv-messages" id="jobs-conv-messages"></div>
+                    <div class="jobs-conv-scroll" id="jobs-conv-scroll">
+                        <div class="jobs-conv-messages" id="jobs-conv-messages"></div>
+                    </div>
                     <div class="jobs-conv-input">
                         <div id="job-mention-menu" class="mention-menu hidden"></div>
                         <div id="job-attachments" class="job-attachments"></div>
@@ -178,6 +214,12 @@
                         </div>
                     </div>
                 </div>
+            </aside>
+            <aside id="schedules-panel" class="hidden">
+                <div class="schedules-header">
+                    <span>Scheduled tasks</span>
+                </div>
+                <div id="schedules-list"></div>
             </aside>
             <aside id="rules-panel" class="hidden">
                 <div class="rules-grip" id="rules-grip"></div>
@@ -227,6 +269,21 @@
 
     <div id="dropzone" class="hidden">
         <div class="dropzone-inner">Drop image here</div>
+    </div>
+
+    <div id="folder-picker-modal" class="folder-picker-modal hidden">
+        <div class="folder-picker-dialog">
+            <div class="folder-picker-header">
+                <h3>Select project directory</h3>
+                <button type="button" class="folder-picker-close" onclick="closeFolderPicker()" aria-label="Close">&times;</button>
+            </div>
+            <div class="folder-picker-breadcrumb" id="folder-picker-breadcrumb"></div>
+            <div class="folder-picker-list" id="folder-picker-list"></div>
+            <div class="folder-picker-actions">
+                <button type="button" class="folder-picker-select-btn" id="folder-picker-select-btn" onclick="selectCurrentFolder()">Select this folder</button>
+                <button type="button" class="folder-picker-cancel-btn" onclick="closeFolderPicker()">Cancel</button>
+            </div>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/static/style.css
+++ b/static/style.css
@@ -149,8 +149,8 @@ body.high-contrast {
 /* --- Header --- */
 
 header {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
     padding: 12px 16px;
     background: var(--bg-header);
@@ -224,13 +224,14 @@ header h1 {
     display: flex;
     align-items: center;
     gap: 12px;
+    justify-content: flex-end;
 }
 
 #agent-status {
     display: flex;
     gap: 12px;
     overflow-x: auto;
-    max-width: 60vw;
+    justify-content: center;
     scrollbar-width: none;
 }
 #agent-status::-webkit-scrollbar { display: none; }
@@ -247,7 +248,161 @@ header h1 {
     transition: background 0.2s, border-color 0.2s;
     cursor: pointer;
     flex-shrink: 0;
+    position: relative;
 }
+
+/* Kill × button — hidden by default, shown on pill hover */
+.pill-kill {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    margin-left: 2px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.12);
+    border: none;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 11px;
+    line-height: 1;
+    cursor: pointer;
+    flex-shrink: 0;
+    padding: 0;
+    transition: background 0.15s, color 0.15s;
+}
+.status-pill:hover .pill-kill {
+    display: flex;
+}
+.pill-kill:hover {
+    background: rgba(239, 68, 68, 0.5);
+    color: #fff;
+}
+.pill-kill:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+/* Spawn + button — always visible at the end of the pills row */
+.pill-spawn-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: transparent;
+    border: 1px dashed rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.35);
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.pill-spawn-btn:hover {
+    border-color: rgba(255, 255, 255, 0.5);
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.07);
+}
+
+/* Spawn modal */
+.spawn-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 8000;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.spawn-modal.hidden { display: none; }
+
+.spawn-dialog {
+    background: var(--bg-secondary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    width: 360px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+}
+.spawn-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 4px;
+}
+.spawn-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+.spawn-optional {
+    font-weight: 400;
+    opacity: 0.6;
+}
+.spawn-cap-note {
+    margin: -4px 0 6px;
+    font-size: 12px;
+    min-height: 16px;
+}
+.spawn-agent-select {
+    padding: 7px 10px;
+    border-radius: var(--radius-md);
+    background: var(--bg-input);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: var(--text-primary);
+    font-size: 13px;
+    cursor: pointer;
+}
+.spawn-guidance {
+    padding: 8px 10px;
+    border-radius: var(--radius-md);
+    background: var(--bg-input);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: inherit;
+    resize: vertical;
+    min-height: 72px;
+}
+.spawn-guidance::placeholder { color: rgba(255, 255, 255, 0.3); }
+.spawn-guidance:focus, .spawn-agent-select:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.3);
+}
+.spawn-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 4px;
+}
+.spawn-cancel {
+    padding: 7px 14px;
+    border-radius: var(--radius-md);
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: var(--text-secondary);
+    font-size: 13px;
+    cursor: pointer;
+}
+.spawn-cancel:hover { background: rgba(255, 255, 255, 0.07); }
+.spawn-confirm {
+    padding: 7px 16px;
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.spawn-confirm:hover { background: rgba(255, 255, 255, 0.2); }
+.spawn-confirm:disabled { opacity: 0.5; cursor: default; }
 
 .status-dot {
     width: 8px;
@@ -321,6 +476,144 @@ header h1 {
 
 @keyframes spin-border {
     to { --border-angle: 360deg; }
+}
+
+/* --- Terminal webcam popover --- */
+
+.term-popover {
+    position: fixed;
+    z-index: 9000;
+    width: 520px;
+    min-height: 280px;
+    max-height: 70vh;
+    background: #0d0d0d;
+    border: 1px solid var(--agent-color, #4ade80);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    resize: both;
+}
+
+.term-popover.hidden {
+    display: none;
+}
+
+.term-popover .term-title {
+    padding: 8px 12px;
+    font-size: 12px;
+    color: var(--agent-color, #4ade80);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    flex-shrink: 0;
+}
+
+.term-popover .term-screen {
+    flex: 1;
+    min-height: 180px;
+    margin: 0;
+    padding: 10px 12px;
+    font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, monospace;
+    font-size: 11px;
+    line-height: 1.5;
+    color: #e0e0e0;
+    background: #0d0d0d;
+    overflow-y: auto;
+    overflow-x: auto;
+    white-space: pre;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+}
+
+.term-popover .term-screen::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+.term-popover .term-screen::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 3px;
+}
+.term-popover .term-screen::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.term-load-more {
+    display: block;
+    width: 100%;
+    padding: 4px 12px;
+    font-size: 11px;
+    font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, monospace;
+    background: rgba(255, 255, 255, 0.05);
+    border: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.4);
+    cursor: pointer;
+    text-align: center;
+    flex-shrink: 0;
+}
+.term-load-more:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.term-popover .term-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    flex-shrink: 0;
+}
+
+.term-popover .term-action-btn {
+    padding: 4px 10px;
+    font-size: 11px;
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--agent-color, #4ade80);
+    color: var(--agent-color, #4ade80);
+    cursor: pointer;
+}
+
+.term-popover .term-action-btn:hover {
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.term-popover .term-input-row {
+    display: flex;
+    gap: 8px;
+    padding: 8px 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    flex-shrink: 0;
+}
+
+.term-popover .term-input-row input {
+    flex: 1;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-family: inherit;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: var(--radius-md);
+    color: #e0e0e0;
+}
+
+.term-popover .term-input-row input::placeholder {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.term-popover .term-send-btn {
+    padding: 6px 12px;
+    font-size: 12px;
+    border-radius: var(--radius-md);
+    background: var(--agent-color, #4ade80);
+    color: #0d0d0d;
+    border: none;
+    cursor: pointer;
+}
+
+.term-popover .term-send-btn:hover {
+    opacity: 0.9;
 }
 
 .settings-btn {
@@ -1453,6 +1746,99 @@ main#timeline {
     pointer-events: none;
 }
 
+#schedules-panel {
+    --panel-w: 300px;
+    width: var(--panel-w);
+    min-width: 220px;
+    max-width: 50vw;
+    flex-shrink: 0;
+    background: var(--bg-header);
+    border-left: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    margin-right: 0;
+    transition: margin-right 0.25s ease, opacity 0.2s ease;
+}
+
+#schedules-panel.hidden {
+    margin-right: calc(-1 * var(--panel-w));
+    opacity: 0;
+    pointer-events: none;
+}
+
+.schedules-header {
+    padding: var(--space-md) var(--space-lg);
+    font-size: var(--fs-sm);
+    font-weight: 600;
+    color: var(--text-dim);
+    border-bottom: 1px solid var(--border);
+}
+
+#schedules-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-sm);
+}
+
+.schedules-empty {
+    font-size: var(--fs-sm);
+    color: var(--text-dim);
+    padding: var(--space-lg);
+    text-align: center;
+}
+
+.schedule-card {
+    position: relative;
+    background: var(--white-03);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    padding: var(--space-md);
+    margin-bottom: var(--space-sm);
+}
+
+.schedule-prompt {
+    font-size: var(--fs-sm);
+    color: var(--text);
+    margin-bottom: 4px;
+}
+
+.schedule-meta {
+    font-size: 11px;
+    color: var(--text-dim);
+}
+
+.schedule-cancel {
+    position: absolute;
+    top: var(--space-sm);
+    right: var(--space-sm);
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    font-size: 18px;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+}
+.schedule-cancel:hover { color: var(--danger); }
+
+.schedules-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    font-size: 10px;
+    font-weight: 600;
+    background: var(--accent);
+    color: var(--text-on-accent);
+    border-radius: var(--radius-full);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 /* Full-height drag grip on left edge */
 .rules-grip,
 .jobs-grip {
@@ -1838,7 +2224,8 @@ main#timeline {
 .jobs-badge.hidden { display: none; }
 
 #rules-toggle,
-#jobs-toggle {
+#jobs-toggle,
+#schedules-toggle {
     position: relative;
 }
 
@@ -2115,6 +2502,104 @@ main#timeline {
     margin-top: 6px;
 }
 
+/* Decision card */
+.decision-pill { background: rgba(96, 165, 250, 0.2); color: var(--info); }
+.decision-question { font-size: 14px; color: var(--text); line-height: 1.4; margin: 6px 0; }
+.decision-question p { margin: 0 0 6px; }
+.decision-question p:last-child { margin-bottom: 0; }
+.decision-choices {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 8px;
+}
+.decision-choice {
+    background: var(--accent);
+    color: var(--text-on-accent);
+    border: none;
+    padding: 6px 14px;
+    border-radius: var(--radius-md);
+    font-size: 12px;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+.decision-choice:hover { opacity: 0.9; }
+
+/* Pill popover (rename + role) */
+.pill-popover {
+    position: fixed;
+    z-index: 1000;
+    min-width: 260px;
+    max-width: 320px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-md);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+.pill-popover-section {
+    margin-bottom: var(--space-md);
+}
+.pill-popover-section:last-child { margin-bottom: 0; }
+.pill-popover-label {
+    display: block;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+}
+.pill-popover-rename-row {
+    display: flex;
+    gap: 8px;
+}
+.pill-popover-input {
+    flex: 1;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 6px 10px;
+    font-size: 13px;
+    color: var(--text);
+    font-family: inherit;
+}
+.pill-popover-confirm {
+    background: var(--agent-color, var(--accent));
+    color: var(--text-on-accent);
+    border: none;
+    padding: 6px 14px;
+    border-radius: var(--radius-md);
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+}
+.pill-popover-roles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.pill-popover-roles .pill-role-chip {
+    font-size: 11px;
+    padding: 4px 10px;
+}
+.pill-popover-custom-row {
+    margin-top: 8px;
+}
+.pill-popover-custom-input {
+    width: 100%;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 6px 10px;
+    font-size: 12px;
+    color: var(--text);
+    font-family: inherit;
+}
+
 /* rule-proposal-card inherits .proposal-card purple styling */
 
 .rule-proposal-text {
@@ -2364,6 +2849,188 @@ pre:hover .code-copy-btn { opacity: 1; }
 }
 
 .agent-name-modal.hidden { display: none; }
+
+/* --- Setup section --- */
+.settings-section-label {
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-semibold);
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin: var(--space-sm) 0 var(--space-xs) 0;
+}
+.settings-section-label:first-child { margin-top: 0; }
+.project-dir-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+}
+.project-dir-row .browse-btn {
+    padding: 6px 12px;
+    font-size: var(--fs-sm);
+    background: var(--accent);
+    color: var(--text-on-accent);
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    font-family: inherit;
+}
+.project-dir-row .browse-btn:hover { background: var(--accent-hover); }
+.project-dir-display {
+    font-size: var(--fs-sm);
+    color: var(--text-dim);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 180px;
+}
+.settings-agent-buttons {
+    display: flex;
+    gap: var(--space-sm);
+}
+.start-agents-btn {
+    flex: 1;
+    padding: 10px 16px;
+    font-size: var(--fs-base);
+    font-weight: var(--fw-medium);
+    background: var(--success);
+    color: #0a0a12;
+    border: none;
+    border-radius: var(--radius-lg);
+    cursor: pointer;
+    font-family: inherit;
+}
+.start-agents-btn:hover { background: #4ade80; filter: brightness(1.05); }
+.start-agents-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.stop-agents-btn {
+    flex: 1;
+    padding: 10px 16px;
+    font-size: var(--fs-base);
+    font-weight: var(--fw-medium);
+    background: var(--danger);
+    color: var(--text-on-accent);
+    border: none;
+    border-radius: var(--radius-lg);
+    cursor: pointer;
+    font-family: inherit;
+}
+.stop-agents-btn:hover { background: #dc2626; filter: brightness(1.05); }
+.stop-agents-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.settings-hint {
+    font-size: var(--fs-xs);
+    color: var(--text-dim);
+    margin-left: var(--space-sm);
+}
+.settings-field input[type="checkbox"] + .settings-hint { display: inline; }
+
+/* --- Folder picker modal --- */
+.folder-picker-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    animation: fadeIn 0.15s ease-out;
+}
+.folder-picker-modal.hidden { display: none; }
+.folder-picker-dialog {
+    background: var(--bg-header);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    padding: 20px 24px;
+    min-width: 420px;
+    max-width: 520px;
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    animation: modal-slide-in 0.2s ease-out;
+}
+.folder-picker-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-md);
+}
+.folder-picker-header h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text);
+}
+.folder-picker-close {
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    font-size: 24px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 4px;
+}
+.folder-picker-close:hover { color: var(--text); }
+.folder-picker-breadcrumb {
+    font-size: var(--fs-sm);
+    color: var(--text-dim);
+    margin-bottom: var(--space-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.folder-picker-list {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 200px;
+    max-height: 320px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-input);
+    padding: var(--space-xs);
+}
+.folder-picker-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: var(--fs-base);
+    color: var(--text);
+}
+.folder-picker-item:hover { background: var(--accent-soft); }
+.folder-picker-item svg {
+    flex-shrink: 0;
+    color: var(--text-dim);
+}
+.folder-picker-actions {
+    display: flex;
+    gap: var(--space-sm);
+    padding-top: var(--space-md);
+}
+.folder-picker-select-btn {
+    padding: 8px 18px;
+    background: var(--accent);
+    color: var(--text-on-accent);
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: var(--fs-sm);
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+}
+.folder-picker-select-btn:hover { background: var(--accent-hover); }
+.folder-picker-cancel-btn {
+    padding: 8px 18px;
+    background: var(--white-06);
+    color: var(--text);
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: var(--fs-sm);
+    cursor: pointer;
+    font-family: inherit;
+}
+.folder-picker-cancel-btn:hover { background: var(--white-08); }
+.folder-picker-error { color: var(--error-color); font-size: var(--fs-sm); }
 
 .agent-name-dialog {
     background: var(--bg-header);


### PR DESCRIPTION
## Summary

Adds three UI/UX features: a `/schedule` command for recurring prompts, inline decision cards for agent-initiated yes/no choices, and role setting from the status pill with custom role persistence.

## Changes

### 1. `/schedule` command system

- **New `schedules.py`**: Schedule store with CRUD, JSON persistence in `data/schedules.json`, and natural-language interval parsing (`every 30m`, `every 1h`, `daily at 09:00`)
- **Slash commands**:
  - `/schedule @claude "summarise overnight" every 1h` — create a recurring schedule
  - `/schedule @claude "daily standup" daily at 09:00` — daily at a fixed time
  - `/schedules` — view all schedules (opens panel)
  - `/unschedule <id>` — cancel by ID
- **REST API**: `GET/POST/DELETE/PATCH /api/schedules`
- **Background runner**: Daemon thread polls every 30s, fires due prompts via `agents.trigger()`, advances `next_run`
- **Schedules panel**: Calendar icon in header, list of cards with prompt preview, targets, next-run time, cancel (×) button

### 2. Inline decision cards (`chat_ask`)

- **New MCP tool `chat_ask`**: Agents call `chat_ask(question, choices)` when they need structured human input (e.g. "Want me to build it?" → `["Yes, build it", "No", "Tell me more"]`)
- **New message type `decision`**: Renders as a bubble with markdown question + clickable choice buttons
- **`PATCH /api/messages/{id}/resolve`**: Stores chosen value, sends choice as a chat message so agents see it
- After selection: buttons replaced with "✓ You chose: X"

### 3. Role setting from status pill + custom roles

- **Pill popover**: Clicking a status pill opens a popover (replacing the modal) with:
  - **Rename** section — same as before
  - **Role** section — preset chips (Planner, Builder, Reviewer, etc.) + custom roles + custom text input
- **Custom role persistence**: Saved in `data/settings.json` under `custom_roles` array
- Custom roles appear in both pill popover and bubble header role picker
- Selecting a new custom role auto-saves it for future use

## Files changed

| File | Change |
|------|--------|
| `schedules.py` | **New** — schedule store + interval parsing |
| `app.py` | Schedule store, REST endpoints, slash commands, background runner, decision resolve endpoint, `custom_roles` in settings |
| `mcp_bridge.py` | New `chat_ask` MCP tool |
| `static/chat.js` | Schedules panel, decision message renderer, pill popover, custom roles loading |
| `static/index.html` | Schedules toggle button + panel |
| `static/style.css` | Schedules panel, decision cards, pill popover styles |
