### PR TITLE
feat: add MiniMax as built-in API agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/platform-Windows-blue) ![macOS](https://img.shields.io/badge/platform-macOS-lightgrey) ![Linux](https://img.shields.io/badge/platform-Linux-orange) ![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-green) [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/qzfn5YTT9a)
 
-A local chat server for real-time coordination between AI coding agents and humans. Ships with built-in support for **Claude Code**, **Codex**, **Gemini CLI**, **Kimi**, **Qwen**, and **Kilo CLI** — and any MCP-compatible agent can join.
+A local chat server for real-time coordination between AI coding agents and humans. Ships with built-in support for **Claude Code**, **Codex**, **Gemini CLI**, **Kimi**, **Qwen**, **Kilo CLI**, and **[MiniMax](https://platform.minimax.io)** — and any MCP-compatible agent can join.
 
 Agents and humans talk in a shared chat room with multiple channels — when anyone @mentions an agent, the server auto-injects a prompt into that agent's terminal, the agent reads the conversation and responds, and the loop continues hands-free. No copy-pasting between ugly terminals. No manual prompting.
 
@@ -22,6 +22,7 @@ Agents and humans talk in a shared chat room with multiple channels — when any
 - `start_qwen.bat` — starts Qwen (and the server if it's not already running)
 - `start_kilo.bat` — starts Kilo (and the server if it's not already running)
 - `start_kilo.bat provider/model` — starts Kilo with a specific model (e.g. `start_kilo.bat anthropic/claude-sonnet-4-20250514`)
+- `start_minimax.bat` — starts MiniMax (requires `MINIMAX_API_KEY` env var)
 
 On first launch, the script auto-creates a virtual environment, installs Python dependencies, and configures MCP. Each agent launcher auto-starts the server if one isn't already running, so you can launch in any order. Run multiple launchers for multiple agents — they share the same server.
 
@@ -33,7 +34,7 @@ On first launch, the script auto-creates a virtual environment, installs Python 
 
 **2. Open the chat:** Go to **http://localhost:8300** in your browser, or double-click `open_chat.html`.
 
-**3. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, `@kimi`, `@qwen`, or `@kilo` in your message, or use the toggle buttons above the input. The agent will wake up, read the chat, and respond.
+**3. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, `@kimi`, `@qwen`, `@kilo`, or `@minimax` in your message, or use the toggle buttons above the input. The agent will wake up, read the chat, and respond.
 
 > **Tip:** To manually prompt an agent to check chat, type `mcp read #general` in their terminal.
 
@@ -58,6 +59,7 @@ Open a terminal in the `macos-linux` folder (right-click → "Open Terminal Here
 - `sh start_qwen.sh` — starts Qwen (and the server if it's not already running)
 - `sh start_kilo.sh` — starts Kilo (and the server if it's not already running)
 - `sh start_kilo.sh provider/model` — starts Kilo with a specific model (e.g. `sh start_kilo.sh anthropic/claude-sonnet-4-20250514`)
+- `sh start_minimax.sh` — starts MiniMax (requires `MINIMAX_API_KEY` env var)
 
 On first launch, the script auto-creates a virtual environment, installs Python dependencies, and configures MCP. Each agent launcher auto-starts the server in a separate terminal window if one isn't already running. The agent opens inside a **tmux** session. Detach with `Ctrl+B, D` — the agent keeps running in the background. Reattach with `tmux attach -t agentchattr-claude`.
 
@@ -69,7 +71,7 @@ On first launch, the script auto-creates a virtual environment, installs Python 
 
 **3. Open the chat:** Go to **http://localhost:8300** or open `open_chat.html`.
 
-**4. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, `@kimi`, `@qwen`, or `@kilo` in your message, or use the toggle buttons above the input. The agent will wake up, read the chat, and respond.
+**4. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, `@kimi`, `@qwen`, `@kilo`, or `@minimax` in your message, or use the toggle buttons above the input. The agent will wake up, read the chat, and respond.
 
 ---
 
@@ -387,6 +389,15 @@ cwd = ".."
 color = "#f7f677"
 label = "Kilo"
 
+[agents.minimax]
+type = "api"
+base_url = "https://api.minimax.io/v1"
+model = "MiniMax-M2.5"
+color = "#2fe898"
+label = "MiniMax"
+api_key_env = "MINIMAX_API_KEY"
+temperature = 1.0
+
 [routing]
 default = "none"            # "none" = only @mentions trigger agents
 max_agent_hops = 4          # pause after N agent-to-agent messages
@@ -428,6 +439,31 @@ Connect any local model with an OpenAI-compatible API (Ollama, llama-server, LM 
    ```
 
 The wrapper registers with the server, watches for @mentions, reads recent chat context, calls your model's `/v1/chat/completions` endpoint, and posts the response back. `config.local.toml` is gitignored so your local endpoints stay out of the repo.
+
+### MiniMax (cloud API)
+
+[MiniMax](https://platform.minimax.io) is a built-in cloud API agent. It uses the MiniMax-M2.5 model (204,800 token context window) via MiniMax's OpenAI-compatible endpoint. To use it:
+
+1. Get an API key at [platform.minimax.io](https://platform.minimax.io)
+
+2. Set the environment variable:
+   ```bash
+   export MINIMAX_API_KEY=your-key-here
+   ```
+
+3. Launch:
+   ```bash
+   # Windows
+   windows\start_minimax.bat
+
+   # Mac/Linux
+   sh macos-linux/start_minimax.sh
+
+   # Or directly
+   python wrapper_api.py minimax
+   ```
+
+Available models: `MiniMax-M2.5` (default), `MiniMax-M2.5-highspeed` (faster). China mainland users can change `base_url` to `https://api.minimaxi.com/v1` in `config.toml`.
 
 ## Architecture
 

--- a/config.local.toml.example
+++ b/config.local.toml.example
@@ -37,3 +37,18 @@
 # model = "local-model"
 # color = "#06b6d4"
 # label = "LM Studio"
+
+# --- Example: MiniMax (cloud API) ---
+# MiniMax offers OpenAI-compatible endpoints. Get an API key at https://platform.minimax.io
+# Set MINIMAX_API_KEY in your environment before launching.
+# Available models: MiniMax-M2.5, MiniMax-M2.5-highspeed
+# China mainland users: change base_url to https://api.minimaxi.com/v1
+#
+# [agents.minimax]
+# type = "api"
+# base_url = "https://api.minimax.io/v1"
+# model = "MiniMax-M2.5"
+# color = "#2fe898"
+# label = "MiniMax"
+# api_key_env = "MINIMAX_API_KEY"
+# temperature = 1.0

--- a/config.toml
+++ b/config.toml
@@ -47,6 +47,15 @@ cwd = ".."
 color = "#f7f677"
 label = "Kilo"
 
+[agents.minimax]
+type = "api"
+base_url = "https://api.minimax.io/v1"
+model = "MiniMax-M2.5"
+color = "#2fe898"
+label = "MiniMax"
+api_key_env = "MINIMAX_API_KEY"
+temperature = 1.0
+
 [routing]
 # "none" = only route on explicit @mention. "all" = route to all agents by default.
 default = "none"

--- a/macos-linux/start_minimax.sh
+++ b/macos-linux/start_minimax.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env sh
+# agentchattr — starts server (if not running) + MiniMax API agent wrapper
+# Usage: sh start_minimax.sh
+# Requires MINIMAX_API_KEY environment variable.
+cd "$(dirname "$0")/.."
+
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+else
+    echo "Python 3 is required but was not found on PATH."
+    exit 1
+fi
+
+ensure_venv() {
+    if [ -d ".venv" ] && [ ! -x ".venv/bin/python" ]; then
+        echo "Recreating .venv for this platform..."
+        rm -rf .venv
+    fi
+
+    if [ ! -x ".venv/bin/python" ]; then
+        echo "Creating virtual environment..."
+        "$PYTHON_BIN" -m venv .venv || {
+            echo "Error: failed to create .venv with $PYTHON_BIN."
+            exit 1
+        }
+        .venv/bin/python -m pip install -q -r requirements.txt || {
+            echo "Error: failed to install Python dependencies."
+            exit 1
+        }
+    fi
+}
+
+is_server_running() {
+    lsof -i :8300 -sTCP:LISTEN >/dev/null 2>&1 || \
+    ss -tlnp 2>/dev/null | grep -q ':8300 '
+}
+
+# Check API key
+if [ -z "$MINIMAX_API_KEY" ]; then
+    echo "Error: MINIMAX_API_KEY environment variable is not set."
+    echo "Get an API key at https://platform.minimax.io"
+    echo "Then: export MINIMAX_API_KEY=your-key-here"
+    exit 1
+fi
+
+ensure_venv
+
+if ! is_server_running; then
+    if [ "$(uname -s)" = "Darwin" ]; then
+        osascript -e "tell app \"Terminal\" to do script \"cd '$(pwd)' && .venv/bin/python run.py\"" > /dev/null 2>&1
+    else
+        if command -v gnome-terminal >/dev/null 2>&1; then
+            gnome-terminal -- sh -c "cd '$(pwd)' && .venv/bin/python run.py; printf 'Press Enter to close... '; read _"
+        elif command -v xterm >/dev/null 2>&1; then
+            xterm -e sh -c "cd '$(pwd)' && .venv/bin/python run.py" &
+        else
+            .venv/bin/python run.py > data/server.log 2>&1 &
+        fi
+    fi
+
+    i=0
+    while [ "$i" -lt 30 ]; do
+        if is_server_running; then
+            break
+        fi
+        sleep 0.5
+        i=$((i + 1))
+    done
+fi
+
+.venv/bin/python wrapper_api.py minimax

--- a/windows/start_minimax.bat
+++ b/windows/start_minimax.bat
@@ -1,0 +1,42 @@
+@echo off
+REM agentchattr — starts server (if not running) + MiniMax API agent wrapper
+REM Usage: start_minimax.bat
+REM Requires MINIMAX_API_KEY environment variable.
+cd /d "%~dp0.."
+
+REM Auto-create venv and install deps on first run
+if not exist ".venv" (
+    python -m venv .venv
+    .venv\Scripts\pip install -q -r requirements.txt >nul 2>nul
+)
+call .venv\Scripts\activate.bat
+
+REM Check API key
+if "%MINIMAX_API_KEY%"=="" (
+    echo.
+    echo   Error: MINIMAX_API_KEY environment variable is not set.
+    echo   Get an API key at https://platform.minimax.io
+    echo   Then: set MINIMAX_API_KEY=your-key-here
+    echo.
+    pause
+    exit /b 1
+)
+
+REM Start server if not already running, then wait for it
+netstat -ano | findstr :8300 | findstr LISTENING >nul 2>&1
+if %errorlevel% neq 0 (
+    start "agentchattr server" cmd /c "python run.py"
+)
+:wait_server
+netstat -ano | findstr :8300 | findstr LISTENING >nul 2>&1
+if %errorlevel% neq 0 (
+    timeout /t 1 /nobreak >nul
+    goto :wait_server
+)
+
+python wrapper_api.py minimax
+if %errorlevel% neq 0 (
+    echo.
+    echo   Agent exited unexpectedly. Check the output above.
+    pause
+)

--- a/wrapper_api.py
+++ b/wrapper_api.py
@@ -74,6 +74,14 @@ def main():
     model = agent_cfg.get("model", "")
     api_key_env = agent_cfg.get("api_key_env", "")
     api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+    temperature = agent_cfg.get("temperature")
+    if temperature is not None:
+        temperature = float(temperature)
+        # Clamp: some providers (e.g. MiniMax) require temperature in (0.0, 1.0]
+        if temperature <= 0:
+            temperature = 0.01
+        if temperature > 2.0:
+            temperature = 2.0
     context_messages = int(agent_cfg.get("context_messages", 20))
     system_prompt = agent_cfg.get("system_prompt",
         f"You are {agent_cfg.get('label', agent)}, a helpful AI assistant participating "
@@ -211,6 +219,8 @@ def main():
         payload = {"messages": messages}
         if model:
             payload["model"] = model
+        if temperature is not None:
+            payload["temperature"] = temperature
         body = json.dumps(payload).encode()
 
         headers = {"Content-Type": "application/json"}


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as a built-in cloud API agent, alongside existing CLI agents (Claude Code, Codex, Gemini, etc.).

**MiniMax-M2.5** is a high-performance LLM with a 204,800 token context window, available via an OpenAI-compatible API endpoint.

### Changes

- **`config.toml`** — added `[agents.minimax]` with `type = "api"`, default model `MiniMax-M2.5`, and `MINIMAX_API_KEY` env var support
- **`wrapper_api.py`** — added optional `temperature` config field with clamping (MiniMax requires temperature in `(0, 1.0]`)
- **`config.local.toml.example`** — added MiniMax example with both models and China mainland URL option
- **`windows/start_minimax.bat`** / **`macos-linux/start_minimax.sh`** — dedicated launcher scripts with API key validation
- **`README.md`** — added MiniMax to supported agents list, quickstart sections, configuration example, and dedicated setup instructions

### Usage

```bash
# Set API key
export MINIMAX_API_KEY=your-key-here

# Launch (any platform)
python wrapper_api.py minimax

# Or use the dedicated launchers
sh macos-linux/start_minimax.sh      # Mac/Linux
windows\start_minimax.bat            # Windows
```

### Available Models

| Model | Description |
|-------|-------------|
| `MiniMax-M2.5` (default) | Peak performance, 204K context |
| `MiniMax-M2.5-highspeed` | Same performance, faster response |

China mainland users can change `base_url` to `https://api.minimaxi.com/v1` in `config.toml`.

## Test Plan

- [x] Config parsing verified (`config.toml` loads correctly with MiniMax agent)
- [x] Python syntax check passed (`wrapper_api.py`)
- [x] API integration tested — both `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` respond correctly via `/v1/chat/completions`
- [x] Launcher scripts created following existing patterns (`start_kilo.bat`/`.sh`)
- [x] Temperature clamping logic verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)