### PR TITLE
feat: upgrade MiniMax default model from M2.5 to M2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ label = "Kilo"
 [agents.minimax]
 type = "api"
 base_url = "https://api.minimax.io/v1"
-model = "MiniMax-M2.5"
+model = "MiniMax-M2.7"
 color = "#2fe898"
 label = "MiniMax"
 api_key_env = "MINIMAX_API_KEY"
@@ -458,7 +458,7 @@ The wrapper registers with the server, watches for @mentions, reads recent chat 
 
 ### MiniMax (cloud API)
 
-[MiniMax](https://platform.minimax.io) is a built-in cloud API agent. It uses the MiniMax-M2.5 model (204,800 token context window) via MiniMax's OpenAI-compatible endpoint. To use it:
+[MiniMax](https://platform.minimax.io) is a built-in cloud API agent. It uses the MiniMax-M2.7 model via MiniMax's OpenAI-compatible endpoint. To use it:
 
 1. Get an API key at [platform.minimax.io](https://platform.minimax.io)
 
@@ -479,7 +479,7 @@ The wrapper registers with the server, watches for @mentions, reads recent chat 
    python wrapper_api.py minimax
    ```
 
-Available models: `MiniMax-M2.5` (default), `MiniMax-M2.5-highspeed` (faster). China mainland users can change `base_url` to `https://api.minimaxi.com/v1` in `config.toml`.
+Available models: `MiniMax-M2.7` (default), `MiniMax-M2.7-highspeed` (faster), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`. China mainland users can change `base_url` to `https://api.minimaxi.com/v1` in `config.toml`.
 
 ## Architecture
 

--- a/config.local.toml.example
+++ b/config.local.toml.example
@@ -41,13 +41,13 @@
 # --- Example: MiniMax (cloud API) ---
 # MiniMax offers OpenAI-compatible endpoints. Get an API key at https://platform.minimax.io
 # Set MINIMAX_API_KEY in your environment before launching.
-# Available models: MiniMax-M2.5, MiniMax-M2.5-highspeed
+# Available models: MiniMax-M2.7 (default), MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
 # China mainland users: change base_url to https://api.minimaxi.com/v1
 #
 # [agents.minimax]
 # type = "api"
 # base_url = "https://api.minimax.io/v1"
-# model = "MiniMax-M2.5"
+# model = "MiniMax-M2.7"
 # color = "#2fe898"
 # label = "MiniMax"
 # api_key_env = "MINIMAX_API_KEY"

--- a/config.toml
+++ b/config.toml
@@ -50,7 +50,7 @@ label = "Kilo"
 [agents.minimax]
 type = "api"
 base_url = "https://api.minimax.io/v1"
-model = "MiniMax-M2.5"
+model = "MiniMax-M2.7"
 color = "#2fe898"
 label = "MiniMax"
 api_key_env = "MINIMAX_API_KEY"


### PR DESCRIPTION
## Summary
- Upgrade default MiniMax model from M2.5 to M2.7
- Document new MiniMax-M2.7-highspeed variant
- Older M2.5/M2.5-highspeed models remain available

## Changes
- **config.toml**: Default model updated to `MiniMax-M2.7`
- **config.local.toml.example**: Updated example and available models list
- **README.md**: Updated model references and available models documentation

## Test plan
- [x] Verified `MiniMax-M2.7` responds correctly via API
- [x] Verified `MiniMax-M2.7-highspeed` responds correctly via API
- [x] Config file parses correctly with new model name
- [ ] Manual test: `python wrapper_api.py minimax` connects and responds
