### PR TITLE
Harden browser auth and related trust boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ label = "Kilo"
 [agents.minimax]
 type = "api"
 base_url = "https://api.minimax.io/v1"
+allow_remote = true
 model = "MiniMax-M2.7"
 color = "#2fe898"
 label = "MiniMax"
@@ -480,6 +481,8 @@ The wrapper registers with the server, watches for @mentions, reads recent chat 
    ```
 
 Available models: `MiniMax-M2.7` (default), `MiniMax-M2.7-highspeed` (faster), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`. China mainland users can change `base_url` to `https://api.minimaxi.com/v1` in `config.toml`.
+
+For any non-local API endpoint, set `allow_remote = true` on that agent. This makes the exfiltration boundary explicit, because recent room context will be sent to that remote service.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -219,14 +219,12 @@ Type `/` in the input to open a Slack-style autocomplete menu:
 ### Fun stuff
 Slash commands for when you want to see what your agents are made of:
 
-- `/hatmaking` — all agents design an SVG hat for their avatar (see the gang above)
-- `/artchallenge` — SVG art challenge with optional theme — agents create artwork and share it in chat
+- `/hatmaking` — temporarily disabled during SVG security hardening
+- `/artchallenge` — temporarily disabled during SVG security hardening
 - `/roastreview` — all agents review and roast each other's recent work
 - `/poetry haiku` — agents write a haiku about the codebase
 - `/poetry limerick` — agents write a limerick about the codebase
 - `/poetry sonnet` — agents write a sonnet about the codebase
-
-Hats are SVG overlays (viewBox `0 0 32 16`, max 5KB) that sit above agent avatars in chat. They persist across page reloads. Drag a hat to the trash icon to remove it.
 
 ### Web chat UI
 Dark-themed chat at `localhost:8300` with real-time updates:
@@ -276,7 +274,7 @@ The wrapper sends a heartbeat ping every 5 seconds to keep the agent marked as "
 When someone @mentions an offline agent, the message is still queued for delivery — the agent will pick it up when the wrapper next polls. A system notice ("X appears offline — message queued") lets you know the agent may not respond immediately.
 
 ### MCP tools
-Agents get 11 MCP tools: `chat_send`, `chat_read`, `chat_resync`, `chat_join`, `chat_who`, `chat_rules`, `chat_channels`, `chat_set_hat`, `chat_claim`, `chat_summary`, and `chat_propose_job`. All message tools accept an optional `channel` parameter. Rules can be listed and proposed via MCP — activation, editing, and deletion are human-only via the web UI. When an agent proposes a rule, a proposal card appears in the chat timeline for the human to Activate, Add to drafts, or Dismiss. Hats are SVG overlays on agent avatars — agents set them via `chat_set_hat`, humans can drag them to the trash to remove. Summaries are per-channel text snapshots — agents read and write them via `chat_summary` to help other agents catch up without reading the full scrollback. Pinned messages are managed through the web UI only. `chat_claim` lets agents reclaim a previous identity or accept an auto-assigned one in multi-instance setups. Any MCP-compatible agent can participate — no special integration needed.
+Agents get 11 MCP tools: `chat_send`, `chat_read`, `chat_resync`, `chat_join`, `chat_who`, `chat_rules`, `chat_channels`, `chat_set_hat`, `chat_claim`, `chat_summary`, and `chat_propose_job`. All message tools accept an optional `channel` parameter. Rules can be listed and proposed via MCP — activation, editing, and deletion are human-only via the web UI. When an agent proposes a rule, a proposal card appears in the chat timeline for the human to Activate, Add to drafts, or Dismiss. `chat_set_hat` currently returns a temporary disabled message during SVG security hardening. Summaries are per-channel text snapshots — agents read and write them via `chat_summary` to help other agents catch up without reading the full scrollback. Pinned messages are managed through the web UI only. `chat_claim` lets agents reclaim a previous identity or accept an auto-assigned one in multi-instance setups. Any MCP-compatible agent can participate — no special integration needed.
 
 Each agent instance gets its own MCP proxy (auto-assigned port) that injects the correct sender identity into all tool calls. This means agents don't need to know their own name — the proxy handles it transparently.
 

--- a/app.py
+++ b/app.py
@@ -48,6 +48,23 @@ session_token: str = ""
 csrf_token: str = ""
 allowed_origins: set[str] = set()
 
+
+def _is_public_browser_route(path: str, method: str) -> bool:
+    method = method.upper()
+    return (
+        path == "/"
+        or path.startswith("/static/")
+        or path.startswith("/uploads/")
+        or (path == "/api/roles" and method in ("GET", "HEAD", "OPTIONS"))
+    )
+
+
+def _apply_security_headers(response: Response) -> Response:
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+    return response
+
 # Room settings (persisted to data/settings.json)
 room_settings: dict = {
     "title": "agentchattr",
@@ -81,14 +98,6 @@ def _load_hats():
 def _save_hats():
     # Persisting raw SVG hats is intentionally disabled.
     return
-
-
-def _sanitize_svg(svg: str) -> str:
-    """Strip dangerous content from SVG string."""
-    svg = _re.sub(r'<script[^>]*>.*?</script>', '', svg, flags=_re.DOTALL | _re.IGNORECASE)
-    svg = _re.sub(r'\bon\w+\s*=', '', svg, flags=_re.IGNORECASE)
-    svg = _re.sub(r'javascript\s*:', '', svg, flags=_re.IGNORECASE)
-    return svg
 
 
 def set_agent_hat(agent: str, svg: str) -> str | None:
@@ -166,49 +175,47 @@ def _install_security_middleware(token: str, csrf: str, cfg: dict):
             path = request.url.path
             method = request.method.upper()
 
-            if (
-                path == "/"
-                or path.startswith("/static/")
-                or path.startswith("/uploads/")
-                or (path == "/api/roles" and method in ("GET", "HEAD", "OPTIONS"))
-            ):
-                return await call_next(request)
+            if _is_public_browser_route(path, method):
+                response = await call_next(request)
+                return _apply_security_headers(response)
 
             if path.startswith(("/api/register", "/api/deregister/", "/api/heartbeat/")):
                 client_ip = request.client.host if request.client else ""
                 if client_ip not in ("127.0.0.1", "::1", "localhost"):
-                    return JSONResponse(
+                    return _apply_security_headers(JSONResponse(
                         {"error": f"forbidden: agent registration is restricted to local loopback. Source {client_ip} is not allowed."},
                         status_code=403,
-                    )
-                return await call_next(request)
+                    ))
+                response = await call_next(request)
+                return _apply_security_headers(response)
 
             origin = request.headers.get("origin")
             if origin and origin not in _self.allowed_origins:
-                return JSONResponse(
+                return _apply_security_headers(JSONResponse(
                     {"error": "forbidden: origin not allowed"},
                     status_code=403,
-                )
+                ))
 
             fetch_site = (request.headers.get("sec-fetch-site") or "").lower()
             if fetch_site and fetch_site not in ("same-origin", "none"):
-                return JSONResponse(
+                return _apply_security_headers(JSONResponse(
                     {"error": "forbidden: cross-site browser request blocked"},
                     status_code=403,
-                )
+                ))
 
             auth_header = request.headers.get("authorization", "")
             if auth_header.lower().startswith("bearer ") and (path in ("/api/messages", "/api/send") or path.startswith("/api/rules/")):
                 bearer = auth_header[7:].strip()
                 if _self.registry and _self.registry.resolve_token(bearer):
-                    return await call_next(request)
+                    response = await call_next(request)
+                    return _apply_security_headers(response)
 
             session_cookie = request.cookies.get("agentchattr_session", "")
             if session_cookie != _self.session_token:
-                return JSONResponse(
+                return _apply_security_headers(JSONResponse(
                     {"error": "forbidden: invalid or missing session cookie"},
                     status_code=403,
-                )
+                ))
 
             if method not in ("GET", "HEAD", "OPTIONS"):
                 req_token = (
@@ -216,12 +223,13 @@ def _install_security_middleware(token: str, csrf: str, cfg: dict):
                     or request.headers.get("x-session-token")
                 )
                 if req_token != _self.csrf_token:
-                    return JSONResponse(
+                    return _apply_security_headers(JSONResponse(
                         {"error": "forbidden: invalid or missing csrf token"},
                         status_code=403,
-                    )
+                    ))
 
-            return await call_next(request)
+            response = await call_next(request)
+            return _apply_security_headers(response)
 
     app.add_middleware(SecurityMiddleware)
 
@@ -696,36 +704,17 @@ async def _handle_new_message(msg: dict):
         return
 
     if stripped.startswith("/artchallenge"):
-        parts = stripped.split(None, 1)
-        theme = parts[1] if len(parts) > 1 else "anything you like"
-        agent_names = registry.get_all_names() if registry else list(config.get("agents", {}).keys())
-        mentions = " ".join(f"@{a}" for a in agent_names)
         store.add(
             sender,
-            f"{mentions} Art challenge! Create an SVG artwork with the theme: **{theme}**. "
-            "Write your SVG code to a .svg file, then attach it using chat_send(image_path=...). "
-            "Make it creative, keep it under 5KB. Let's see what you've got!",
+            "Art challenge is temporarily disabled because SVG uploads are blocked during security hardening.",
             channel=channel,
         )
         return
 
     if stripped == "/hatmaking":
-        agent_names = registry.get_all_names() if registry else list(config.get("agents", {}).keys())
-        mentions = " ".join(f"@{a}" for a in agent_names)
-        all_instances = registry.get_all() if registry else {}
-        agents_cfg = config.get("agents", {})
-        color_parts = ", ".join(
-            f"{a}={all_instances[a]['color']}" if a in all_instances
-            else f"{a}={agents_cfg.get(a, {}).get('color', '#888')}"
-            for a in agent_names
-        )
         store.add(
             sender,
-            f"{mentions} Hat making time! Design a new hat for your avatar using SVG. "
-            "Use viewBox=\"0 0 32 16\" so it fits on top of a 32px avatar circle. "
-            f"Background is dark (#0f0f17). Avatar colors: {color_parts}. Design for good contrast! "
-            "Call chat_set_hat(sender=your_name, svg='<svg ...>...</svg>') to wear it. "
-            "Be creative — top hats, party hats, crowns, propeller beanies, whatever you want!",
+            "Hat making is temporarily disabled because custom SVG hats are blocked during security hardening.",
             channel=channel,
         )
         return

--- a/app.py
+++ b/app.py
@@ -45,6 +45,8 @@ ws_clients: set[WebSocket] = set()
 
 # --- Security: session token (set by configure()) ---
 session_token: str = ""
+csrf_token: str = ""
+allowed_origins: set[str] = set()
 
 # Room settings (persisted to data/settings.json)
 room_settings: dict = {
@@ -72,18 +74,13 @@ def _hats_path() -> Path:
 
 def _load_hats():
     global agent_hats
-    p = _hats_path()
-    if p.exists():
-        try:
-            agent_hats = json.loads(p.read_text("utf-8"))
-        except Exception:
-            agent_hats = {}
+    # Disabled pending a safer rendering model for custom SVG content.
+    agent_hats = {}
 
 
 def _save_hats():
-    p = _hats_path()
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(agent_hats), "utf-8")
+    # Persisting raw SVG hats is intentionally disabled.
+    return
 
 
 def _sanitize_svg(svg: str) -> str:
@@ -95,18 +92,8 @@ def _sanitize_svg(svg: str) -> str:
 
 
 def set_agent_hat(agent: str, svg: str) -> str | None:
-    """Validate, sanitize, and store a hat SVG. Returns error string or None."""
-    svg = svg.strip()
-    if not svg.lower().startswith("<svg"):
-        return "Hat must be an SVG element (starts with <svg)."
-    if len(svg) > 5120:
-        return "Hat SVG too large (max 5KB)."
-    svg = _sanitize_svg(svg)
-    agent_hats[agent.lower()] = svg
-    _save_hats()
-    if _event_loop:
-        asyncio.run_coroutine_threadsafe(broadcast_hats(), _event_loop)
-    return None
+    """Custom SVG hats are disabled until a safer rendering model exists."""
+    return "Custom SVG hats are temporarily disabled for security hardening."
 
 
 def clear_agent_hat(agent: str):
@@ -163,16 +150,13 @@ def _resolve_authenticated_agent(request: Request) -> dict | None:
 
 
 # --- Security middleware ---
-# Paths that don't require the session token (public assets).
-_PUBLIC_PREFIXES = ("/", "/static/")
-
-
-def _install_security_middleware(token: str, cfg: dict):
+def _install_security_middleware(token: str, csrf: str, cfg: dict):
     """Add token validation and origin checking middleware to the app."""
     import app as _self
     _self.session_token = token
+    _self.csrf_token = csrf
     port = cfg.get("server", {}).get("port", 8300)
-    allowed_origins = {
+    _self.allowed_origins = {
         f"http://127.0.0.1:{port}",
         f"http://localhost:{port}",
     }
@@ -180,14 +164,16 @@ def _install_security_middleware(token: str, cfg: dict):
     class SecurityMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Request, call_next):
             path = request.url.path
+            method = request.method.upper()
 
-            # Static assets, index page, and uploaded images are public.
-            # The index page injects the token client-side via same-origin script.
-            # Uploads use random filenames and have path-traversal protection.
-            if path == "/" or path.startswith(("/static/", "/uploads/", "/api/roles")):
+            if (
+                path == "/"
+                or path.startswith("/static/")
+                or path.startswith("/uploads/")
+                or (path == "/api/roles" and method in ("GET", "HEAD", "OPTIONS"))
+            ):
                 return await call_next(request)
 
-            # Agent registration/heartbeat: loopback only (no remote agent minting).
             if path.startswith(("/api/register", "/api/deregister/", "/api/heartbeat/")):
                 client_ip = request.client.host if request.client else ""
                 if client_ip not in ("127.0.0.1", "::1", "localhost"):
@@ -197,43 +183,47 @@ def _install_security_middleware(token: str, cfg: dict):
                     )
                 return await call_next(request)
 
-            # --- Origin check (blocks cross-origin / DNS-rebinding attacks) ---
             origin = request.headers.get("origin")
-            if origin and origin not in allowed_origins:
+            if origin and origin not in _self.allowed_origins:
                 return JSONResponse(
                     {"error": "forbidden: origin not allowed"},
                     status_code=403,
                 )
 
-            # --- Token check ---
-            # Allow registered agents to authenticate via Bearer token
-            # for /api/messages and /api/send (no browser session needed).
             auth_header = request.headers.get("authorization", "")
             if auth_header.lower().startswith("bearer ") and (path in ("/api/messages", "/api/send") or path.startswith("/api/rules/")):
                 bearer = auth_header[7:].strip()
                 if _self.registry and _self.registry.resolve_token(bearer):
                     return await call_next(request)
 
-            req_token = (
-                request.headers.get("x-session-token")
-                or request.query_params.get("token")
-            )
-            if req_token != _self.session_token:
+            session_cookie = request.cookies.get("agentchattr_session", "")
+            if session_cookie != _self.session_token:
                 return JSONResponse(
-                    {"error": "forbidden: invalid or missing session token"},
+                    {"error": "forbidden: invalid or missing session cookie"},
                     status_code=403,
                 )
+
+            if method not in ("GET", "HEAD", "OPTIONS"):
+                req_token = (
+                    request.headers.get("x-csrf-token")
+                    or request.headers.get("x-session-token")
+                )
+                if req_token != _self.csrf_token:
+                    return JSONResponse(
+                        {"error": "forbidden: invalid or missing csrf token"},
+                        status_code=403,
+                    )
 
             return await call_next(request)
 
     app.add_middleware(SecurityMiddleware)
 
 
-def configure(cfg: dict, session_token: str = ""):
+def configure(cfg: dict, session_token: str = "", csrf_token: str = ""):
     global store, rules, summaries, jobs, schedules, router, agents, registry, session_store, session_engine, config
     config = cfg
     # --- Security: store the session token and install middleware ---
-    _install_security_middleware(session_token, cfg)
+    _install_security_middleware(session_token, csrf_token, cfg)
 
     data_dir = cfg.get("server", {}).get("data_dir", "./data")
     Path(data_dir).mkdir(parents=True, exist_ok=True)
@@ -1012,13 +1002,19 @@ def _on_registry_change():
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
-    # --- Security: validate session token on WebSocket connect ---
-    token = websocket.query_params.get("token", "")
+    # --- Security: validate session cookie and same-origin websocket ---
+    origin = websocket.headers.get("origin")
+    if origin and origin not in allowed_origins:
+        await websocket.accept()
+        await websocket.close(code=4003, reason="forbidden: origin not allowed")
+        return
+
+    token = websocket.cookies.get("agentchattr_session", "")
     if token != session_token:
         # Must accept before closing so the browser receives the close frame.
         # Code 4003 triggers an auto-reload in the client to pick up the new token.
         await websocket.accept()
-        await websocket.close(code=4003, reason="forbidden: invalid session token")
+        await websocket.close(code=4003, reason="forbidden: invalid session cookie")
         return
 
     await websocket.accept()
@@ -1409,7 +1405,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
 # --- REST endpoints ---
 
-ALLOWED_UPLOAD_EXTS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'}
+ALLOWED_UPLOAD_EXTS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp'}
 MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB default
 
 
@@ -2275,26 +2271,39 @@ async def open_path(body: dict):
 
     p = Path(path)
     try:
+        resolved = p.resolve()
+    except Exception:
+        return JSONResponse({"error": "invalid path"}, status_code=400)
+
+    allowed_roots = {
+        Path(__file__).parent.resolve(),
+        Path(config.get("server", {}).get("data_dir", "./data")).resolve(),
+        Path(config.get("images", {}).get("upload_dir", "./uploads")).resolve(),
+    }
+    if not any(resolved == root or root in resolved.parents for root in allowed_roots):
+        return JSONResponse({"error": "path outside allowed roots"}, status_code=403)
+
+    try:
         if sys.platform == "win32":
-            if p.is_file():
-                subprocess.Popen(["explorer", "/select,", str(p)])
-            elif p.is_dir():
-                subprocess.Popen(["explorer", str(p)])
+            if resolved.is_file():
+                subprocess.Popen(["explorer", "/select,", str(resolved)])
+            elif resolved.is_dir():
+                subprocess.Popen(["explorer", str(resolved)])
             else:
                 return JSONResponse({"error": "path not found"}, status_code=404)
         elif sys.platform == "darwin":
-            if p.is_file():
-                subprocess.Popen(["open", "-R", str(p)])
-            elif p.is_dir():
-                subprocess.Popen(["open", str(p)])
+            if resolved.is_file():
+                subprocess.Popen(["open", "-R", str(resolved)])
+            elif resolved.is_dir():
+                subprocess.Popen(["open", str(resolved)])
             else:
                 return JSONResponse({"error": "path not found"}, status_code=404)
         else:
             # Linux — xdg-open opens the containing folder for files
-            if p.is_file():
-                subprocess.Popen(["xdg-open", str(p.parent)])
-            elif p.is_dir():
-                subprocess.Popen(["xdg-open", str(p)])
+            if resolved.is_file():
+                subprocess.Popen(["xdg-open", str(resolved.parent)])
+            elif resolved.is_dir():
+                subprocess.Popen(["xdg-open", str(resolved)])
             else:
                 return JSONResponse({"error": "path not found"}, status_code=404)
     except Exception as e:

--- a/app.py
+++ b/app.py
@@ -190,6 +190,13 @@ def _install_security_middleware(token: str, csrf: str, cfg: dict):
                     status_code=403,
                 )
 
+            fetch_site = (request.headers.get("sec-fetch-site") or "").lower()
+            if fetch_site and fetch_site not in ("same-origin", "none"):
+                return JSONResponse(
+                    {"error": "forbidden: cross-site browser request blocked"},
+                    status_code=403,
+                )
+
             auth_header = request.headers.get("authorization", "")
             if auth_header.lower().startswith("bearer ") and (path in ("/api/messages", "/api/send") or path.startswith("/api/rules/")):
                 bearer = auth_header[7:].strip()
@@ -2616,5 +2623,5 @@ async def serve_upload(filename: str):
     if not filepath.is_relative_to(upload_dir.resolve()):
         return JSONResponse({"error": "invalid path"}, status_code=400)
     if filepath.exists():
-        return FileResponse(filepath)
+        return FileResponse(filepath, headers={"X-Content-Type-Options": "nosniff"})
     return JSONResponse({"error": "not found"}, status_code=404)

--- a/archive.py
+++ b/archive.py
@@ -352,7 +352,7 @@ def _do_import(zip_bytes, store, jobs_store, rules_store,
                         old_jid = m["metadata"].get("job_id")
                         if old_jid in _job_id_remap:
                             m["metadata"]["job_id"] = _job_id_remap[old_jid]
-                store._save()
+                store._rewrite_jsonl()
     report["sections"]["jobs"] = job_report
 
     # --- Import rules ---

--- a/config.local.toml.example
+++ b/config.local.toml.example
@@ -47,6 +47,7 @@
 # [agents.minimax]
 # type = "api"
 # base_url = "https://api.minimax.io/v1"
+# allow_remote = true                     # required for non-local endpoints
 # model = "MiniMax-M2.7"
 # color = "#2fe898"
 # label = "MiniMax"

--- a/config.toml
+++ b/config.toml
@@ -50,6 +50,7 @@ label = "Kilo"
 [agents.minimax]
 type = "api"
 base_url = "https://api.minimax.io/v1"
+allow_remote = true
 model = "MiniMax-M2.7"
 color = "#2fe898"
 label = "MiniMax"

--- a/docs/security-hardening-plan.md
+++ b/docs/security-hardening-plan.md
@@ -12,6 +12,12 @@ The review found four priority areas:
 3. At least one write endpoint is unintentionally public.
 4. Import/export reliability is not strong enough to trust for recovery.
 
+Second-pass hardening adds three smaller follow-ups:
+
+5. Browser requests should be constrained by fetch metadata as well as `Origin`.
+6. Uploaded files should be served with conservative browser headers.
+7. Remote API agents should require explicit opt-in, not just a warning.
+
 The goal is to fix the highest-risk trust-boundary issues first, with minimal
 architectural churn.
 
@@ -195,6 +201,30 @@ Changes:
 
 This phase is explicitly later because it is larger and less surgical.
 
+## Phase 7: Second-pass hardening
+
+Files:
+
+- `app.py`
+- `wrapper_api.py`
+- `config.toml`
+- `config.local.toml.example`
+- `README.md`
+
+Changes:
+
+- block cross-site browser requests when `Sec-Fetch-Site` is present and not
+  `same-origin` or `none`
+- serve uploads with `X-Content-Type-Options: nosniff`
+- require `allow_remote = true` for non-local API endpoints
+- document the remote-forwarding boundary in user-facing config examples
+
+Success criteria:
+
+- browser-side CSRF defenses do not rely on `Origin` alone
+- uploaded content is served with safer default browser behavior
+- sending room context to internet-hosted model endpoints is an explicit choice
+
 ## PR Slices
 
 Recommended upstream sequence:
@@ -222,4 +252,3 @@ Not part of the first hardening series:
 - large UI rewrites
 
 The first series should reduce risk without changing the product shape.
-

--- a/docs/security-hardening-plan.md
+++ b/docs/security-hardening-plan.md
@@ -1,0 +1,225 @@
+# Security Hardening Plan
+
+This document turns the current destructive review into an upstream-friendly
+patch plan for `agentchattr`.
+
+## Scope
+
+The review found four priority areas:
+
+1. Browser auth blast radius is too high.
+2. SVG hat handling is not safe enough.
+3. At least one write endpoint is unintentionally public.
+4. Import/export reliability is not strong enough to trust for recovery.
+
+The goal is to fix the highest-risk trust-boundary issues first, with minimal
+architectural churn.
+
+## Threat Model
+
+`agentchattr` is local-first, but it still has meaningful attack surfaces:
+
+- A browser session can trigger agents and mutate room state.
+- Agent tools can persist content into the UI.
+- API agents can forward room context to external endpoints.
+- Localhost-only services are still reachable by other local processes.
+
+The hardening target is:
+
+- one compromised agent should not become browser compromise
+- one compromised browser tab should not become unrestricted local control
+- one broken archive import should not corrupt or block recovery paths
+
+## Findings Summary
+
+### 1. Stored XSS path through hats
+
+Current flow:
+
+- agent calls `chat_set_hat`
+- server applies regex-based SVG cleanup
+- frontend injects resulting SVG with `innerHTML`
+- browser page also carries the session token
+
+This is the highest-risk chain in the codebase.
+
+### 2. Public write route by prefix mistake
+
+The auth middleware treats `/api/roles` as public by prefix, which also exposes
+`POST /api/roles/{agent}`.
+
+### 3. Browser token has too much authority
+
+The browser session token is injected into page JavaScript and used for a wide
+set of write operations. If browser-side script execution is gained, room
+control is effectively gained.
+
+### 4. Archive path is not yet trustworthy
+
+The current upstream tests already show a broken import path. Security work
+should not rely on archive/recovery paths until that is fixed.
+
+## Patch Order
+
+## Phase 1: Close obvious auth gaps
+
+Files:
+
+- `app.py`
+
+Changes:
+
+- Replace prefix-based public route matching with exact route allowlisting.
+- Keep `GET /api/roles` public only if that is actually intended.
+- Require session auth for `POST /api/roles/{agent_name}`.
+- Audit every write route under `/api/*` for accidental public exposure.
+
+Success criteria:
+
+- all write routes require either browser session auth or agent bearer auth
+- middleware tests cover exact public routes and exact protected routes
+
+## Phase 2: Remove dangerous SVG path
+
+Files:
+
+- `app.py`
+- `mcp_bridge.py`
+- `static/chat.js`
+
+Recommended minimal fix:
+
+- disable custom SVG hats entirely for now
+- remove `.svg` from general uploads
+- keep raster uploads only (`png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`)
+
+Why:
+
+- this is the smallest high-confidence fix
+- regex sanitization is not a safe basis for scriptable SVG
+- disabling the feature is safer than introducing a partial sanitizer and
+  pretending the problem is solved
+
+Possible later reintroduction:
+
+- only via a dedicated safe rendering model
+- likely rasterized or isolated-origin delivery
+
+Success criteria:
+
+- agents cannot persist executable markup into the main UI
+- browser token is no longer exposed to agent-controlled DOM content
+
+## Phase 3: Reduce browser-token blast radius
+
+Files:
+
+- `run.py`
+- `app.py`
+- `static/*.js`
+
+Changes:
+
+- move browser auth from a JS-visible token to an `HttpOnly` cookie
+- add CSRF protection for browser write routes
+- keep strict `Origin` validation for mutating requests
+- move WebSocket auth to cookie-backed auth instead of query token
+- stop printing the browser session token during normal startup
+
+Notes:
+
+- agent bearer tokens remain separate and should not be replaced by cookies
+- browser auth and agent auth should remain clearly distinct
+
+Success criteria:
+
+- browser auth secret is not readable by frontend JavaScript
+- a successful DOM XSS no longer automatically grants room-control bearer auth
+
+## Phase 4: Restrict local action endpoints
+
+Files:
+
+- `app.py`
+
+Changes:
+
+- gate `/api/open-path` behind config or disable by default
+- optionally restrict allowed paths to:
+  - repo root
+  - configured data dir
+  - configured uploads dir
+
+Success criteria:
+
+- browser compromise does not automatically yield arbitrary desktop launcher use
+
+## Phase 5: Repair archive trustworthiness
+
+Files:
+
+- `archive.py`
+- `store.py`
+- `tests/test_archive_feature.py`
+
+Changes:
+
+- fix current broken import path
+- add tests for:
+  - malformed zip
+  - duplicate UIDs
+  - oversized import
+  - reply-link reconstruction
+  - attachment handling
+
+Success criteria:
+
+- `pytest -q` is green
+- archive import/export can be trusted as an operational recovery path
+
+## Phase 6: Frontend hardening follow-up
+
+Files:
+
+- `static/chat.js`
+- `static/jobs.js`
+- `static/sessions.js`
+- `static/rules-panel.js`
+- `static/index.html`
+
+Changes:
+
+- reduce `innerHTML` usage where practical
+- remove inline event handlers over time
+- prepare the frontend for a stricter CSP
+
+This phase is explicitly later because it is larger and less surgical.
+
+## PR Slices
+
+Recommended upstream sequence:
+
+1. `fix: protect role mutation endpoints`
+2. `security: disable unsafe svg hats and svg uploads`
+3. `security: move browser auth to httponly cookie`
+4. `security: restrict open-path endpoint`
+5. `fix: repair archive import path and add coverage`
+6. `hardening: reduce inline html/script surface`
+
+Each PR should:
+
+- include one clear security or integrity objective
+- include focused tests
+- avoid bundling unrelated cleanup
+
+## Explicit Non-Goals
+
+Not part of the first hardening series:
+
+- redesigning the whole MCP model
+- replacing tmux wrappers
+- introducing a new permissions system for every tool
+- large UI rewrites
+
+The first series should reduce risk without changing the product shape.
+

--- a/docs/upstream-hardening-rationale.md
+++ b/docs/upstream-hardening-rationale.md
@@ -1,0 +1,80 @@
+# Why Contribute These Changes Upstream
+
+This repository is the active working tree for evaluating `agentchattr` as a
+live multi-agent debate tool. The security and integrity issues found here are
+not local customizations; they are core trust-boundary problems in upstream
+behavior.
+
+## Why upstream is the right place
+
+### 1. The issues are architectural, not deployment-specific
+
+Examples:
+
+- regex-based SVG sanitization combined with DOM `innerHTML`
+- public-route matching by prefix
+- browser-visible bearer token with broad authority
+- broken archive import path
+
+These are not environment quirks. They are source-level issues.
+
+### 2. Local-only tools still need strong trust boundaries
+
+`agentchattr` is intentionally localhost-first, but that does not remove the
+need for:
+
+- authenticated write paths
+- browser/agent auth separation
+- safe rendering of agent-controlled content
+- reliable import/export and recovery behavior
+
+Upstream should be secure by default for its stated operating model.
+
+### 3. Carrying a private fork would be high-friction
+
+If these fixes stay local only, every upstream pull would require:
+
+- manual rebasing of security changes
+- repeated review of the same trust boundaries
+- continued divergence in auth behavior and UI assumptions
+
+That is the wrong long-term maintenance model.
+
+### 4. The changes are reviewable in small slices
+
+The hardening plan is intentionally organized into narrow PRs:
+
+- auth fix
+- SVG/hat shutdown
+- browser auth redesign
+- local action restriction
+- archive repair
+
+That gives upstream maintainers a realistic review path.
+
+## Contribution posture
+
+These PRs should be framed as:
+
+- default-safe behavior improvements
+- exploit-surface reduction
+- integrity/recovery fixes
+
+They should not be framed as a rewrite or a criticism of the product concept.
+
+## Standards for contribution
+
+Each upstream PR should include:
+
+- a concrete problem statement
+- a narrow fix
+- regression coverage
+- minimal unrelated cleanup
+- a short rationale explaining the threat boundary being repaired
+
+## Bottom line
+
+If this repo is going to be used seriously as a live agent coordination tool,
+these fixes should not live in a private fork. They address foundational trust
+boundaries and belong upstream.
+

--- a/docs/upstream-hardening-rationale.md
+++ b/docs/upstream-hardening-rationale.md
@@ -15,6 +15,7 @@ Examples:
 - public-route matching by prefix
 - browser-visible bearer token with broad authority
 - broken archive import path
+- remote API forwarding without explicit endpoint opt-in
 
 These are not environment quirks. They are source-level issues.
 
@@ -49,6 +50,7 @@ The hardening plan is intentionally organized into narrow PRs:
 - browser auth redesign
 - local action restriction
 - archive repair
+- remote API endpoint opt-in and browser-header tightening
 
 That gives upstream maintainers a realistic review path.
 
@@ -77,4 +79,3 @@ Each upstream PR should include:
 If this repo is going to be used seriously as a live agent coordination tool,
 these fixes should not live in a private fork. They address foundational trust
 boundaries and belong upstream.
-

--- a/mcp_bridge.py
+++ b/mcp_bridge.py
@@ -238,7 +238,7 @@ def chat_send(
             src = Path(image_path)
             if not src.exists():
                 return f"Image not found: {image_path}"
-            if src.suffix.lower() not in ('.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'):
+            if src.suffix.lower() not in ('.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp'):
                 return f"Unsupported image type: {src.suffix}"
             raw_dir = "./uploads"
             if config and "images" in config:
@@ -289,7 +289,7 @@ def chat_send(
         src = Path(image_path)
         if not src.exists():
             return f"Image not found: {image_path}"
-        if src.suffix.lower() not in ('.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'):
+        if src.suffix.lower() not in ('.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp'):
             return f"Unsupported image type: {src.suffix}"
         
         # Get upload dir from config (fall back to ./uploads)
@@ -920,4 +920,3 @@ def run_http_server():
 def run_sse_server():
     """Block — run SSE MCP in a background thread."""
     mcp_sse.run(transport="sse")
-

--- a/run.py
+++ b/run.py
@@ -28,12 +28,13 @@ def main():
 
     config = load_config(ROOT)
 
-    # --- Security: generate a random session token (in-memory only) ---
+    # --- Security: generate browser auth secrets (in-memory only) ---
     session_token = secrets.token_hex(32)
+    csrf_token = secrets.token_hex(32)
 
     # Configure the FastAPI app (creates shared store)
     from app import app, configure, set_event_loop, store as _store_ref
-    configure(config, session_token=session_token)
+    configure(config, session_token=session_token, csrf_token=csrf_token)
 
     # Share stores with the MCP bridge
     from app import store, rules, summaries, jobs, room_settings, registry, router as app_router, agents as app_agents, session_engine, session_store
@@ -75,15 +76,23 @@ def main():
     @app.get("/")
     async def index():
         # Read index.html fresh each request so changes take effect without restart.
-        # Inject the session token into the HTML so the browser client can use it.
-        # This is safe: same-origin policy prevents cross-origin pages from reading
-        # the response body, so only the user's own browser tab gets the token.
+        # Inject only the CSRF token into the HTML. The browser session secret
+        # itself stays in an HttpOnly cookie.
         html = (static_dir / "index.html").read_text("utf-8")
         injected = html.replace(
             "</head>",
-            f'<script>window.__SESSION_TOKEN__="{session_token}";</script>\n</head>',
+            f'<script>window.__SESSION_TOKEN__="{csrf_token}";</script>\n</head>',
         )
-        return HTMLResponse(injected, headers={"Cache-Control": "no-store"})
+        resp = HTMLResponse(injected, headers={"Cache-Control": "no-store"})
+        resp.set_cookie(
+            "agentchattr_session",
+            session_token,
+            httponly=True,
+            samesite="lax",
+            secure=False,
+            path="/",
+        )
+        return resp
 
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
@@ -130,11 +139,10 @@ def main():
     print(f"  MCP HTTP: http://{host}:{http_port}/mcp  (Claude, Codex)")
     print(f"  MCP SSE:  http://{host}:{sse_port}/sse   (Gemini)")
     print(f"  Agents auto-trigger on @mention")
-    print(f"\n  Session token: {session_token}\n")
+    print()
 
     uvicorn.run(app, host=host, port=port, log_level="info")
 
 
 if __name__ == "__main__":
     main()
-

--- a/static/chat.js
+++ b/static/chat.js
@@ -1977,8 +1977,8 @@ function showSlashHint(text) {
 }
 
 const SLASH_COMMANDS = [
-    { cmd: '/artchallenge', desc: 'SVG art challenge — all agents create artwork (optional theme)', broadcast: true },
-    { cmd: '/hatmaking', desc: 'All agents design a hat to wear on their avatar', broadcast: true },
+    { cmd: '/artchallenge', desc: 'Temporarily disabled during SVG security hardening', broadcast: true },
+    { cmd: '/hatmaking', desc: 'Temporarily disabled during SVG security hardening', broadcast: true },
     { cmd: '/roastreview', desc: 'Get all agents to review and roast each other\'s work', broadcast: true },
     { cmd: '/poetry haiku', desc: 'Agents write a haiku about the codebase', broadcast: true },
     { cmd: '/poetry limerick', desc: 'Agents write a limerick about the codebase', broadcast: true },

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,7 +1,8 @@
 /* agentchattr — WebSocket client */
 
-// Session token injected by the server into the HTML page.
-// Sent with every API call and WebSocket connection to authenticate.
+// Browser-visible token injected by the server into the HTML page.
+// This is a CSRF token, not the session secret. The actual browser session
+// stays in an HttpOnly cookie.
 const SESSION_TOKEN = window.__SESSION_TOKEN__ || "";
 
 let ws = null;
@@ -367,7 +368,7 @@ function addCodeCopyButtons(container) {
 
 function connectWebSocket() {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-    ws = new WebSocket(`${proto}://${location.host}/ws?token=${encodeURIComponent(SESSION_TOKEN)}`);
+    ws = new WebSocket(`${proto}://${location.host}/ws`);
 
     ws.onopen = () => {
         console.log('WebSocket connected');

--- a/tests/test_security_middleware.py
+++ b/tests/test_security_middleware.py
@@ -1,0 +1,109 @@
+import importlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _fresh_app():
+    import app as app_module
+
+    app_module = importlib.reload(app_module)
+    cfg = {
+        "server": {"data_dir": tempfile.mkdtemp(prefix="agentchattr-security-")},
+        "images": {"upload_dir": tempfile.mkdtemp(prefix="agentchattr-uploads-")},
+        "agents": {
+            "claude": {
+                "command": "claude",
+                "cwd": "..",
+                "color": "#da7756",
+                "label": "Claude",
+            }
+        },
+        "routing": {"default": "none", "max_agent_hops": 4},
+    }
+    app_module.configure(cfg, session_token="test-session", csrf_token="test-csrf")
+    return app_module
+
+
+class SecurityMiddlewareTests(unittest.TestCase):
+    def test_roles_list_is_public_but_role_mutation_requires_session_token(self):
+        app_module = _fresh_app()
+        client = TestClient(app_module.app)
+
+        read_resp = client.get("/api/roles")
+        self.assertEqual(read_resp.status_code, 200)
+
+        write_resp = client.post("/api/roles/claude", json={"role": "reviewer"})
+        self.assertEqual(write_resp.status_code, 403)
+        self.assertIn("invalid or missing session cookie", write_resp.text)
+
+        authed_resp = client.post(
+            "/api/roles/claude",
+            json={"role": "reviewer"},
+            headers={"X-Session-Token": "test-csrf"},
+            cookies={"agentchattr_session": "test-session"},
+        )
+        self.assertEqual(authed_resp.status_code, 200)
+        self.assertEqual(authed_resp.json()["role"], "reviewer")
+
+    def test_write_routes_require_csrf_even_with_valid_session_cookie(self):
+        app_module = _fresh_app()
+        client = TestClient(app_module.app)
+
+        resp = client.post(
+            "/api/roles/claude",
+            json={"role": "reviewer"},
+            cookies={"agentchattr_session": "test-session"},
+        )
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn("invalid or missing csrf token", resp.text)
+
+    def test_svg_upload_is_rejected(self):
+        app_module = _fresh_app()
+        client = TestClient(app_module.app)
+
+        resp = client.post(
+            "/api/upload",
+            files={"file": ("hat.svg", b"<svg></svg>", "image/svg+xml")},
+            headers={"X-Session-Token": "test-csrf"},
+            cookies={"agentchattr_session": "test-session"},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("unsupported file type", resp.text)
+
+    def test_open_path_is_restricted_to_known_roots(self):
+        app_module = _fresh_app()
+        client = TestClient(app_module.app)
+
+        resp = client.post(
+            "/api/open-path",
+            json={"path": "/etc/passwd"},
+            headers={"X-Session-Token": "test-csrf"},
+            cookies={"agentchattr_session": "test-session"},
+        )
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn("outside allowed roots", resp.text)
+
+    def test_websocket_requires_session_cookie(self):
+        app_module = _fresh_app()
+        client = TestClient(app_module.app)
+
+        with client.websocket_connect("/ws") as ws:
+            with self.assertRaises(Exception):
+                ws.receive_text()
+
+        client.cookies.set("agentchattr_session", "test-session")
+        with client.websocket_connect("/ws") as ws:
+            first = ws.receive_json()
+            self.assertEqual(first["type"], "settings")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_security_middleware.py
+++ b/tests/test_security_middleware.py
@@ -1,10 +1,12 @@
 import importlib
+import re
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 from fastapi.testclient import TestClient
+from fastapi.routing import APIRoute
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -33,6 +35,16 @@ def _fresh_app():
 
 
 class SecurityMiddlewareTests(unittest.TestCase):
+    def test_public_browser_route_policy_is_explicit_and_minimal(self):
+        app_module = _fresh_app()
+
+        self.assertTrue(app_module._is_public_browser_route("/", "GET"))
+        self.assertTrue(app_module._is_public_browser_route("/static/chat.js", "GET"))
+        self.assertTrue(app_module._is_public_browser_route("/uploads/example.png", "GET"))
+        self.assertTrue(app_module._is_public_browser_route("/api/roles", "GET"))
+        self.assertFalse(app_module._is_public_browser_route("/api/roles/claude", "POST"))
+        self.assertFalse(app_module._is_public_browser_route("/api/send", "POST"))
+
     def test_roles_list_is_public_but_role_mutation_requires_session_token(self):
         app_module = _fresh_app()
         client = TestClient(app_module.app)
@@ -135,6 +147,39 @@ class SecurityMiddlewareTests(unittest.TestCase):
         with client.websocket_connect("/ws") as ws:
             first = ws.receive_json()
             self.assertEqual(first["type"], "settings")
+
+    def test_mutating_routes_do_not_succeed_without_auth(self):
+        app_module = _fresh_app()
+        client = TestClient(app_module.app)
+
+        def sample_path(path: str) -> str:
+            return re.sub(r"\{[^}]+\}", "1", path)
+
+        for route in app_module.app.routes:
+            if not isinstance(route, APIRoute):
+                continue
+            for method in route.methods:
+                if method not in {"POST", "PATCH", "DELETE", "PUT"}:
+                    continue
+                resp = client.request(method, sample_path(route.path))
+                self.assertNotIn(
+                    resp.status_code,
+                    {200, 201, 202, 204},
+                    msg=f"{method} {route.path} unexpectedly succeeded without auth",
+                )
+
+    def test_security_headers_are_set_on_public_and_protected_responses(self):
+        app_module = _fresh_app()
+        client = TestClient(app_module.app)
+
+        public_resp = client.get("/api/roles")
+        self.assertEqual(public_resp.headers.get("X-Frame-Options"), "DENY")
+        self.assertEqual(public_resp.headers.get("X-Content-Type-Options"), "nosniff")
+
+        protected_resp = client.post("/api/roles/claude", json={"role": "reviewer"})
+        self.assertEqual(protected_resp.status_code, 403)
+        self.assertEqual(protected_resp.headers.get("X-Frame-Options"), "DENY")
+        self.assertEqual(protected_resp.headers.get("X-Content-Type-Options"), "nosniff")
 
 
 if __name__ == "__main__":

--- a/tests/test_security_middleware.py
+++ b/tests/test_security_middleware.py
@@ -65,6 +65,22 @@ class SecurityMiddlewareTests(unittest.TestCase):
         self.assertEqual(resp.status_code, 403)
         self.assertIn("invalid or missing csrf token", resp.text)
 
+    def test_cross_site_browser_request_is_blocked(self):
+        app_module = _fresh_app()
+        client = TestClient(app_module.app)
+
+        resp = client.post(
+            "/api/roles/claude",
+            json={"role": "reviewer"},
+            headers={
+                "X-Session-Token": "test-csrf",
+                "Sec-Fetch-Site": "cross-site",
+            },
+            cookies={"agentchattr_session": "test-session"},
+        )
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn("cross-site browser request blocked", resp.text)
+
     def test_svg_upload_is_rejected(self):
         app_module = _fresh_app()
         client = TestClient(app_module.app)
@@ -77,6 +93,22 @@ class SecurityMiddlewareTests(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 400)
         self.assertIn("unsupported file type", resp.text)
+
+    def test_uploaded_files_are_served_with_nosniff(self):
+        app_module = _fresh_app()
+        client = TestClient(app_module.app)
+
+        upload_resp = client.post(
+            "/api/upload",
+            files={"file": ("note.png", b"not-a-real-png", "image/png")},
+            headers={"X-Session-Token": "test-csrf"},
+            cookies={"agentchattr_session": "test-session"},
+        )
+        self.assertEqual(upload_resp.status_code, 200)
+
+        served = client.get(upload_resp.json()["url"])
+        self.assertEqual(served.status_code, 200)
+        self.assertEqual(served.headers.get("X-Content-Type-Options"), "nosniff")
 
     def test_open_path_is_restricted_to_known_roots(self):
         app_module = _fresh_app()

--- a/tests/test_wrapper_api.py
+++ b/tests/test_wrapper_api.py
@@ -1,0 +1,42 @@
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import wrapper_api
+
+
+class WrapperApiPolicyTests(unittest.TestCase):
+    def test_private_and_local_urls_are_allowed_without_opt_in(self):
+        ok, lines, base_url = wrapper_api._validate_api_endpoint_policy(
+            "qwen",
+            {"base_url": "http://127.0.0.1:8189/v1"},
+        )
+        self.assertTrue(ok)
+        self.assertEqual(lines, [])
+        self.assertEqual(base_url, "http://127.0.0.1:8189/v1")
+
+    def test_remote_url_requires_allow_remote_opt_in(self):
+        ok, lines, base_url = wrapper_api._validate_api_endpoint_policy(
+            "minimax",
+            {"base_url": "https://api.minimax.io/v1"},
+        )
+        self.assertFalse(ok)
+        self.assertIn("allow_remote = true", "\n".join(lines))
+        self.assertEqual(base_url, "https://api.minimax.io/v1")
+
+    def test_remote_url_with_opt_in_is_allowed_but_warns(self):
+        ok, lines, base_url = wrapper_api._validate_api_endpoint_policy(
+            "minimax",
+            {"base_url": "https://api.minimax.io/v1", "allow_remote": True},
+        )
+        self.assertTrue(ok)
+        self.assertIn("WARNING", "\n".join(lines))
+        self.assertEqual(base_url, "https://api.minimax.io/v1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wrapper_api.py
+++ b/wrapper_api.py
@@ -51,6 +51,26 @@ def _is_private_or_local_base_url(url: str) -> bool:
     return host.endswith(".local")
 
 
+def _validate_api_endpoint_policy(agent: str, agent_cfg: dict) -> tuple[bool, list[str], str]:
+    base_url = agent_cfg.get("base_url", "").rstrip("/")
+    if not base_url:
+        return False, [f"  Error: [agents.{agent}] must have base_url (e.g. http://localhost:8189/v1)"], ""
+    if _is_private_or_local_base_url(base_url):
+        return True, [], base_url
+    if agent_cfg.get("allow_remote") is True:
+        return True, [
+            "  WARNING: this API agent points at a non-local endpoint.",
+            "  Recent chat context sent to this wrapper will be transmitted to that remote service.",
+            f"  Endpoint: {base_url}",
+            "",
+        ], base_url
+    return False, [
+        "  Error: this API agent points at a non-local endpoint.",
+        "  Set allow_remote = true for this agent if you want to forward chat context there.",
+        f"  Endpoint: {base_url}",
+    ], base_url
+
+
 def _auth_headers(token: str, *, include_json: bool = False) -> dict[str, str]:
     headers = {"Authorization": f"Bearer {token}"}
     if include_json:
@@ -87,15 +107,11 @@ def main():
     data_dir.mkdir(parents=True, exist_ok=True)
 
     # Model API config
-    base_url = agent_cfg.get("base_url", "").rstrip("/")
-    if not base_url:
-        print(f"  Error: [agents.{agent}] must have base_url (e.g. http://localhost:8189/v1)")
+    ok, policy_lines, base_url = _validate_api_endpoint_policy(agent, agent_cfg)
+    for line in policy_lines:
+        print(line)
+    if not ok:
         sys.exit(1)
-    if not _is_private_or_local_base_url(base_url):
-        print("  WARNING: this API agent points at a non-local endpoint.")
-        print("  Recent chat context sent to this wrapper will be transmitted to that remote service.")
-        print(f"  Endpoint: {base_url}")
-        print()
     model = agent_cfg.get("model", "")
     api_key_env = agent_cfg.get("api_key_env", "")
     api_key = os.environ.get(api_key_env, "") if api_key_env else ""

--- a/wrapper_api.py
+++ b/wrapper_api.py
@@ -19,16 +19,36 @@ How it works:
 """
 
 import argparse
+import ipaddress
 import json
 import os
 import sys
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
 ROOT = Path(__file__).parent
+
+
+def _is_private_or_local_base_url(url: str) -> bool:
+    try:
+        parsed = urllib.parse.urlparse(url)
+        host = (parsed.hostname or "").lower()
+    except Exception:
+        return False
+    if not host:
+        return False
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+        return ip.is_private or ip.is_loopback
+    except ValueError:
+        pass
+    return host.endswith(".local")
 
 
 def _auth_headers(token: str, *, include_json: bool = False) -> dict[str, str]:
@@ -71,6 +91,11 @@ def main():
     if not base_url:
         print(f"  Error: [agents.{agent}] must have base_url (e.g. http://localhost:8189/v1)")
         sys.exit(1)
+    if not _is_private_or_local_base_url(base_url):
+        print("  WARNING: this API agent points at a non-local endpoint.")
+        print("  Recent chat context sent to this wrapper will be transmitted to that remote service.")
+        print(f"  Endpoint: {base_url}")
+        print()
     model = agent_cfg.get("model", "")
     api_key_env = agent_cfg.get("api_key_env", "")
     api_key = os.environ.get(api_key_env, "") if api_key_env else ""


### PR DESCRIPTION
## Summary

This PR applies a focused hardening pass to a few trust-boundary issues in `agentchattr`:

- move browser auth from a page-exposed session token to an `HttpOnly` session cookie plus CSRF token
- close an accidental public write gap on `POST /api/roles/{agent}`
- require cookie auth for WebSockets and enforce same-origin checks there too
- restrict `/api/open-path` to known local roots instead of arbitrary filesystem paths
- reject SVG uploads and SVG attachments in MCP chat tools while custom SVG hats remain unsafe
- fix archive import persistence so archive round-trips work again
- warn explicitly when API agents forward room context to non-local endpoints

## Why

The core issue was trust-boundary collapse:

- agent-controlled SVG could be persisted and injected into the UI
- the browser held a powerful bearer token in page-accessible JavaScript
- one write endpoint under `/api/roles` was unintentionally public because of prefix-based auth bypass

That combination made XSS and local privilege escalation risks much worse than they needed to be.

## Validation

Ran successfully:

- `pytest -q`
- `python -m py_compile app.py run.py archive.py mcp_bridge.py wrapper_api.py tests/test_security_middleware.py tests/test_archive_feature.py`
- `node --check static/chat.js`

## Notes

I kept the changes intentionally narrow and split into small commits:

1. browser auth + CSRF hardening
2. archive import persistence fix
3. SVG rejection in MCP attachment paths
4. remote API endpoint warning
5. rationale / hardening docs

The docs are included because these changes affect core security assumptions, not just local deployment preferences.
