### PR TITLE
feat(electron): Add browser pane and desktop QA follow-up

### DIFF
--- a/.claude/mockups/launcher-panel.html
+++ b/.claude/mockups/launcher-panel.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Agent Launcher Panel — Mockup</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: #0f0a1a;
+    color: #e0d8f0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 24px;
+  }
+  h1 { font-size: 14px; color: #a090c0; margin-bottom: 20px; text-transform: uppercase; letter-spacing: 2px; }
+  .note { font-size: 12px; color: #786898; margin-bottom: 24px; max-width: 900px; text-align: centre; }
+
+  /* === Layout: two views side by side === */
+  .views { display: flex; gap: 32px; flex-wrap: wrap; justify-content: centre; width: 100%; max-width: 1100px; }
+  .view { flex: 1; min-width: 420px; max-width: 520px; }
+  .view-label {
+    font-size: 11px; color: #8070a0; text-transform: uppercase; letter-spacing: 1.5px;
+    margin-bottom: 10px; padding-left: 4px;
+  }
+
+  /* === Panel frame === */
+  .panel {
+    background: #1a1228;
+    border: 1px solid #2a2040;
+    border-radius: 12px;
+    overflow: hidden;
+  }
+  .panel-header {
+    display: flex; align-items: centre; justify-content: space-between;
+    padding: 14px 18px;
+    background: #201838;
+    border-bottom: 1px solid #2a2040;
+  }
+  .panel-header h2 { font-size: 15px; font-weight: 600; }
+  .panel-header .add-btn {
+    background: #6c3fc7; color: white; border: none; border-radius: 6px;
+    padding: 5px 14px; font-size: 12px; cursor: pointer; font-weight: 500;
+  }
+
+  /* === Agent card === */
+  .agent-card {
+    padding: 16px 18px;
+    border-bottom: 1px solid #1e1630;
+    display: flex; align-items: flex-start; gap: 14px;
+  }
+  .agent-card:last-child { border-bottom: none; }
+  .agent-dot {
+    width: 10px; height: 10px; border-radius: 50%; margin-top: 5px; flex-shrink: 0;
+  }
+  .agent-dot.online { box-shadow: 0 0 6px currentColor; }
+  .agent-dot.offline { opacity: 0.35; }
+  .agent-info { flex: 1; }
+  .agent-name { font-size: 14px; font-weight: 600; }
+  .agent-meta { font-size: 11px; color: #786898; margin-top: 3px; }
+  .agent-flags { font-size: 11px; color: #a78bfa; margin-top: 4px; font-family: monospace; }
+  .agent-status {
+    font-size: 10px; padding: 2px 8px; border-radius: 10px;
+    text-transform: uppercase; letter-spacing: 0.5px; font-weight: 600;
+    white-space: nowrap; margin-top: 3px;
+  }
+  .status-running { background: #1a3a2a; color: #4ade80; }
+  .status-stopped { background: #2a1a1a; color: #888; }
+  .agent-actions { display: flex; gap: 6px; margin-top: 3px; }
+  .agent-actions button {
+    background: #2a2040; color: #c0b0e0; border: 1px solid #3a2860;
+    border-radius: 5px; padding: 3px 10px; font-size: 11px; cursor: pointer;
+  }
+  .agent-actions button.launch { background: #3a2870; color: #c8b8ff; border-color: #5040a0; }
+  .agent-actions button.stop { background: #3a1a1a; color: #f87171; border-color: #5a2020; }
+  .agent-actions button.logs { background: #1a2a3a; color: #60a5fa; border-color: #203050; }
+
+  /* === Launch config expanded === */
+  .launch-config {
+    background: #150f22;
+    border: 1px solid #2a2040;
+    border-radius: 8px;
+    margin: 10px 18px 16px 42px;
+    padding: 14px;
+  }
+  .launch-config h3 { font-size: 12px; color: #a090c0; margin-bottom: 10px; }
+  .config-row { display: flex; align-items: centre; gap: 10px; margin-bottom: 8px; }
+  .config-row label { font-size: 12px; color: #9080b0; min-width: 80px; }
+  .config-row input[type="text"] {
+    flex: 1; background: #0f0a1a; border: 1px solid #2a2040; border-radius: 4px;
+    color: #e0d8f0; padding: 4px 8px; font-size: 12px; font-family: monospace;
+  }
+  .toggle-row { display: flex; flex-wrap: wrap; gap: 8px; margin: 8px 0; }
+  .flag-toggle {
+    display: flex; align-items: centre; gap: 5px;
+    background: #1a1228; border: 1px solid #2a2040; border-radius: 5px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+  }
+  .flag-toggle.active { border-color: #6c3fc7; background: #2a1848; color: #c8b8ff; }
+  .flag-toggle input { display: none; }
+  .flag-toggle .check { width: 14px; height: 14px; border: 1px solid #4a3870; border-radius: 3px; display: flex; align-items: centre; justify-content: centre; font-size: 10px; }
+  .flag-toggle.active .check { background: #6c3fc7; border-color: #6c3fc7; }
+  .launch-btn {
+    background: #6c3fc7; color: white; border: none; border-radius: 6px;
+    padding: 7px 20px; font-size: 12px; cursor: pointer; font-weight: 600;
+    margin-top: 6px;
+  }
+  .config-section-label { font-size: 10px; color: #685888; text-transform: uppercase; letter-spacing: 1px; margin: 10px 0 4px; }
+
+  /* === Logs panel === */
+  .logs-panel {
+    background: #0a0612;
+    border: 1px solid #2a2040;
+    border-radius: 8px;
+    margin: 0 18px 16px 42px;
+    padding: 10px 14px;
+    max-height: 180px;
+    overflow-y: auto;
+    font-family: 'Cascadia Code', 'Fira Code', monospace;
+    font-size: 11px;
+    line-height: 1.6;
+    color: #8a80a0;
+  }
+  .logs-panel .log-line { white-space: pre-wrap; }
+  .logs-panel .log-info { color: #60a5fa; }
+  .logs-panel .log-tool { color: #a78bfa; }
+  .logs-panel .log-ok { color: #4ade80; }
+  .logs-panel .log-dim { color: #504070; }
+
+  /* === Session restore banner === */
+  .restore-banner {
+    background: #1a1830;
+    border: 1px solid #3a2860;
+    border-radius: 10px;
+    padding: 16px 20px;
+    margin-bottom: 24px;
+    max-width: 520px;
+    width: 100%;
+  }
+  .restore-banner h3 { font-size: 13px; color: #c8b8ff; margin-bottom: 10px; }
+  .restore-item {
+    display: flex; align-items: centre; gap: 10px; padding: 6px 0;
+    font-size: 12px;
+  }
+  .restore-item input[type="checkbox"] { accent-color: #6c3fc7; }
+  .restore-actions { display: flex; gap: 8px; margin-top: 12px; }
+  .restore-actions button {
+    padding: 6px 16px; border-radius: 6px; font-size: 12px; cursor: pointer; border: none;
+  }
+  .restore-actions .relaunch { background: #6c3fc7; color: white; font-weight: 600; }
+  .restore-actions .dismiss { background: #2a2040; color: #a090c0; }
+
+  /* Add agent form */
+  .add-form {
+    padding: 16px 18px;
+    border-top: 1px solid #2a2040;
+    background: #150f22;
+  }
+  .add-form h3 { font-size: 12px; color: #a090c0; margin-bottom: 10px; }
+  .colour-picker {
+    display: flex; gap: 6px; margin: 6px 0 10px;
+  }
+  .colour-swatch {
+    width: 22px; height: 22px; border-radius: 50%; cursor: pointer;
+    border: 2px solid transparent;
+  }
+  .colour-swatch.selected { border-color: white; }
+</style>
+</head>
+<body>
+
+<h1>Agent Launcher Panel — Design Mockup</h1>
+<p class="note">Two states shown: the main launcher panel (left) and the session-restore banner that appears on server restart (right, top).</p>
+
+<div class="views">
+
+  <!-- LEFT: Main launcher panel -->
+  <div class="view">
+    <div class="view-label">Launcher Panel (from header button)</div>
+    <div class="panel">
+      <div class="panel-header">
+        <h2>Agents</h2>
+        <button class="add-btn">+ Add Agent</button>
+      </div>
+
+      <!-- Running agent: Claude -->
+      <div class="agent-card">
+        <div class="agent-dot online" style="color: #da7756; background: #da7756;"></div>
+        <div class="agent-info">
+          <div class="agent-name">Claude</div>
+          <div class="agent-meta">claude &middot; C:\AI\MyProject &middot; 14m uptime</div>
+          <div class="agent-flags">--dangerously-skip-permissions</div>
+          <div class="agent-actions">
+            <button class="stop">Stop</button>
+            <button class="logs">Logs</button>
+          </div>
+        </div>
+        <div class="agent-status status-running">Running</div>
+      </div>
+
+      <!-- Logs expanded for Claude -->
+      <div class="logs-panel">
+        <div class="log-line log-dim">16:22:01</div>
+        <div class="log-line log-info">Registered as "claude" (slot 1)</div>
+        <div class="log-line log-info">MCP proxy on port 54321</div>
+        <div class="log-line log-dim">16:22:05</div>
+        <div class="log-line log-tool">mcp read #general</div>
+        <div class="log-line">Reading 3 new messages...</div>
+        <div class="log-line log-ok">Responded in #general (247 tokens)</div>
+        <div class="log-line log-dim">16:24:18</div>
+        <div class="log-line log-tool">mcp read #general</div>
+        <div class="log-line">Reading 1 new message...</div>
+        <div class="log-line log-ok">Responded in #general (182 tokens)</div>
+      </div>
+
+      <!-- Running agent: Codex -->
+      <div class="agent-card">
+        <div class="agent-dot online" style="color: #10a37f; background: #10a37f;"></div>
+        <div class="agent-info">
+          <div class="agent-name">Codex</div>
+          <div class="agent-meta">codex &middot; C:\AI\MyProject &middot; 8m uptime</div>
+          <div class="agent-flags">--dangerously-bypass-approvals-and-sandbox</div>
+          <div class="agent-actions">
+            <button class="stop">Stop</button>
+            <button class="logs">Logs</button>
+          </div>
+        </div>
+        <div class="agent-status status-running">Running</div>
+      </div>
+
+      <!-- Stopped agent: Gemini (with launch config expanded) -->
+      <div class="agent-card">
+        <div class="agent-dot offline" style="color: #4285f4; background: #4285f4;"></div>
+        <div class="agent-info">
+          <div class="agent-name">Gemini</div>
+          <div class="agent-meta">gemini &middot; not running</div>
+          <div class="agent-actions">
+            <button class="launch">Launch</button>
+          </div>
+        </div>
+        <div class="agent-status status-stopped">Stopped</div>
+      </div>
+
+      <!-- Launch config for Gemini -->
+      <div class="launch-config">
+        <h3>Launch Configuration</h3>
+
+        <div class="config-section-label">Working Directory</div>
+        <div class="config-row">
+          <input type="text" value="C:\AI\MyProject" style="width:100%;" />
+        </div>
+
+        <div class="config-section-label">Flags</div>
+        <div class="toggle-row">
+          <label class="flag-toggle active">
+            <input type="checkbox" checked /><span class="check">&#10003;</span> --yolo
+          </label>
+          <label class="flag-toggle">
+            <input type="checkbox" /><span class="check"></span> --sandbox
+          </label>
+        </div>
+
+        <div class="config-section-label">Extra Arguments</div>
+        <div class="config-row">
+          <input type="text" placeholder="e.g. --model gemini-2.5-pro" style="width:100%;" />
+        </div>
+
+        <button class="launch-btn">Launch Gemini</button>
+      </div>
+
+      <!-- Stopped agent: Kimi -->
+      <div class="agent-card">
+        <div class="agent-dot offline" style="color: #1783ff; background: #1783ff;"></div>
+        <div class="agent-info">
+          <div class="agent-name">Kimi</div>
+          <div class="agent-meta">kimi &middot; not running</div>
+          <div class="agent-actions">
+            <button class="launch">Launch</button>
+          </div>
+        </div>
+        <div class="agent-status status-stopped">Stopped</div>
+      </div>
+
+      <!-- Add agent form -->
+      <div class="add-form">
+        <h3>Add New Agent</h3>
+        <div class="config-row">
+          <label>Name</label>
+          <input type="text" placeholder="e.g. qwen" />
+        </div>
+        <div class="config-row">
+          <label>Command</label>
+          <input type="text" placeholder="e.g. qwen" />
+        </div>
+        <div class="config-row">
+          <label>Label</label>
+          <input type="text" placeholder="e.g. Qwen" />
+        </div>
+        <div class="config-section-label">Colour</div>
+        <div class="colour-picker">
+          <div class="colour-swatch" style="background:#da7756;"></div>
+          <div class="colour-swatch" style="background:#10a37f;"></div>
+          <div class="colour-swatch" style="background:#4285f4;"></div>
+          <div class="colour-swatch" style="background:#8b5cf6;" ></div>
+          <div class="colour-swatch selected" style="background:#facc15;"></div>
+          <div class="colour-swatch" style="background:#f43f5e;"></div>
+          <div class="colour-swatch" style="background:#2fe898;"></div>
+          <div class="colour-swatch" style="background:#1783ff;"></div>
+        </div>
+        <div class="config-row">
+          <label>MCP Mode</label>
+          <input type="text" placeholder="auto (flag/env/proxy)" value="auto" />
+        </div>
+        <button class="launch-btn" style="background:#3a2870;">Save Agent</button>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- RIGHT: Session restore + second view -->
+  <div class="view">
+    <div class="view-label">Session Restore (on server restart)</div>
+
+    <!-- Restore banner -->
+    <div class="restore-banner">
+      <h3>Previous session agents detected</h3>
+      <div class="restore-item">
+        <input type="checkbox" checked />
+        <div class="agent-dot online" style="color: #da7756; background: #da7756; width:8px; height:8px;"></div>
+        <span><strong>Claude</strong> &mdash; --dangerously-skip-permissions &middot; C:\AI\MyProject</span>
+      </div>
+      <div class="restore-item">
+        <input type="checkbox" checked />
+        <div class="agent-dot online" style="color: #10a37f; background: #10a37f; width:8px; height:8px;"></div>
+        <span><strong>Codex</strong> &mdash; --dangerously-bypass-approvals-and-sandbox &middot; C:\AI\MyProject</span>
+      </div>
+      <div class="restore-item">
+        <input type="checkbox" />
+        <div class="agent-dot offline" style="color: #4285f4; background: #4285f4; width:8px; height:8px;"></div>
+        <span><strong>Gemini</strong> &mdash; --yolo &middot; C:\AI\MyProject</span>
+      </div>
+      <div class="restore-actions">
+        <button class="relaunch">Relaunch Selected</button>
+        <button class="dismiss">Dismiss</button>
+      </div>
+    </div>
+
+    <div class="view-label" style="margin-top: 20px;">Agent card states</div>
+    <div class="panel">
+      <div class="panel-header">
+        <h2>State Reference</h2>
+      </div>
+
+      <!-- Working agent with activity indicator -->
+      <div class="agent-card">
+        <div class="agent-dot online" style="color: #da7756; background: #da7756; animation: pulse 1.5s infinite;"></div>
+        <div class="agent-info">
+          <div class="agent-name">Claude <span style="font-size:11px; color:#786898; font-weight:400;">(working)</span></div>
+          <div class="agent-meta">Responding to @mention in #general</div>
+          <div class="agent-actions">
+            <button class="stop">Stop</button>
+            <button class="logs">Logs</button>
+          </div>
+        </div>
+        <div class="agent-status" style="background:#2a2a10; color:#facc15;">Working</div>
+      </div>
+
+      <!-- Crashed / restarting -->
+      <div class="agent-card">
+        <div class="agent-dot" style="color: #f87171; background: #f87171; opacity:0.6;"></div>
+        <div class="agent-info">
+          <div class="agent-name">Codex <span style="font-size:11px; color:#f87171; font-weight:400;">(crashed)</span></div>
+          <div class="agent-meta">Exited 12s ago &middot; restart in 3s</div>
+          <div class="agent-actions">
+            <button class="launch">Relaunch</button>
+            <button class="logs">Logs</button>
+          </div>
+        </div>
+        <div class="agent-status" style="background:#3a1a1a; color:#f87171;">Crashed</div>
+      </div>
+
+      <!-- Editing agent config -->
+      <div class="agent-card">
+        <div class="agent-dot offline" style="color: #8b5cf6; background: #8b5cf6;"></div>
+        <div class="agent-info">
+          <div class="agent-name">Qwen</div>
+          <div class="agent-meta">qwen &middot; not configured</div>
+          <div class="agent-actions">
+            <button style="background:#2a1848; color:#a78bfa; border-color:#4a3870;">Edit</button>
+            <button style="background:#3a1a1a; color:#f87171; border-color:#5a2020;">Remove</button>
+          </div>
+        </div>
+        <div class="agent-status status-stopped">New</div>
+      </div>
+
+    </div>
+  </div>
+
+</div>
+
+<style>
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+</style>
+
+</body>
+</html>

--- a/.gitignore
+++ b/.gitignore
@@ -17,12 +17,16 @@ build/
 .gemini/
 .claude/
 tests/
+!tests/
+tests/*
+!tests/test_room_sidebar_ui.py
 agents_lineup.svg
 docs/*
 !docs/superpowers/
 docs/superpowers/*
 !docs/superpowers/qa/
 !docs/superpowers/qa/**
+!docs/project-status.md
 goals.py
 pr-reviews/
 agentchattr-*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,11 @@ build/
 .claude/
 tests/
 agents_lineup.svg
-docs/
+docs/*
+!docs/superpowers/
+docs/superpowers/*
+!docs/superpowers/qa/
+!docs/superpowers/qa/**
 goals.py
 pr-reviews/
 agentchattr-*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ docs/
 goals.py
 pr-reviews/
 agentchattr-*.zip
+electron/node_modules/
+electron/dist/
+electron/config.json

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Agents and humans talk in a shared chat room with multiple channels — when any
 
 ![screenshot](screenshot.png)
 
+## Fork Workflow Policy
+
+This fork is maintained as a fork-only codebase.
+
+- `origin` is the only writable remote for normal work.
+- `main` on `ArchonVII/agentchattr` is the authoritative branch for this fork.
+- `upstream` may be fetched for reference only.
+- Do not open upstream PRs from this fork.
+- Do not merge this fork's work into `bcurts/agentchattr`.
+- Do not treat upstream mergeability as part of the workflow for this repo.
+
 ## Quickstart (Windows)
 
 **1. Open the `windows` folder and double-click a launcher:**

--- a/README.md
+++ b/README.md
@@ -38,6 +38,37 @@ On first launch, the script auto-creates a virtual environment, installs Python 
 
 > **Tip:** To manually prompt an agent to check chat, type `mcp read #general` in their terminal.
 
+## Desktop Shell (Windows)
+
+The Electron shell wraps the same local server in a native Windows window with tray support, notifications, deep links, and a live Ports tab.
+
+```powershell
+npm --prefix electron install
+npm --prefix electron start
+```
+
+Notes:
+
+- The desktop shell starts `run.py` for you and expects to own port `8300`.
+- Do not leave `windows\start.bat`, `python run.py`, or another Electron instance running when you launch it.
+- Closing the main window hides the app to the system tray. Use the tray menu's `Quit` action when you want to fully stop the shell and its embedded server.
+- The browser launchers still open the web UI directly. Electron is a Windows desktop wrapper around that same agentchattr server, not a separate backend.
+
+### Desktop QA (Windows)
+
+```powershell
+.venv\Scripts\python -m pytest tests -q
+node --test tests/launcher_helpers.test.cjs
+npm --prefix electron test
+node --check static/launcher.js
+node --check electron/main.js
+node --check electron/renderer/renderer.js
+npm --prefix electron run smoke:launcher
+npm --prefix electron run smoke:desktop
+```
+
+For the manual tray, notification, deep-link, restore, and shutdown checklist, see `docs/superpowers/qa/desktop-shell-checklist.md`.
+
 ## Quickstart (Mac / Linux)
 
 **1. Make sure tmux is installed:**

--- a/app.py
+++ b/app.py
@@ -2722,8 +2722,15 @@ async def list_agent_definitions():
     from config_loader import load_agent_definitions
     from process_manager import AGENT_FLAG_PRESETS
     data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
-    defs = load_agent_definitions(data_dir, config.get("_base_agents", config.get("agents", {})))
-    return JSONResponse({"definitions": defs, "flag_presets": AGENT_FLAG_PRESETS})
+    base_agents = config.get("_base_agents", config.get("agents", {}))
+    defs = load_agent_definitions(data_dir, base_agents)
+    return JSONResponse(
+        {
+            "definitions": defs,
+            "flag_presets": AGENT_FLAG_PRESETS,
+            "builtin_names": sorted(base_agents.keys()),
+        }
+    )
 
 
 @app.post("/api/agent-definitions")
@@ -2867,6 +2874,30 @@ async def stop_agent(name: str):
     if not process_manager:
         return JSONResponse({"error": "process manager not initialised"}, status_code=500)
     result = process_manager.stop(name)
+    if result.get("ok") and registry:
+        target_name = name
+        deregistered = registry.deregister(target_name)
+        if not deregistered:
+            resolved_name = registry.resolve_name(name)
+            if resolved_name != name:
+                target_name = resolved_name
+                deregistered = registry.deregister(target_name)
+        if deregistered:
+            import mcp_bridge
+
+            mcp_bridge.purge_identity(target_name)
+            registry.clean_renames_for(target_name)
+            renamed = deregistered.pop("_renamed_back", None)
+            if renamed:
+                mcp_bridge.migrate_identity(renamed["old"], renamed["new"])
+                store.rename_sender(renamed["old"], renamed["new"])
+                if _event_loop:
+                    rename_event = json.dumps({
+                        "type": "agent_renamed",
+                        "old_name": renamed["old"],
+                        "new_name": renamed["new"],
+                    })
+                    asyncio.run_coroutine_threadsafe(_broadcast(rename_event), _event_loop)
     if result.get("ok") and _event_loop:
         managed = process_manager.list_managed()
         event_data = json.dumps({"type": "agent_processes", "data": managed})

--- a/app.py
+++ b/app.py
@@ -214,8 +214,13 @@ def _install_security_middleware(token: str, cfg: dict):
                 if _self.registry and _self.registry.resolve_token(bearer):
                     return await call_next(request)
 
+            # Check session token from (in priority order):
+            #   1. HttpOnly cookie (browser — preferred, not readable by JS)
+            #   2. X-Session-Token header (programmatic clients)
+            #   3. ?token= query param (legacy fallback)
             req_token = (
-                request.headers.get("x-session-token")
+                request.cookies.get("session")
+                or request.headers.get("x-session-token")
                 or request.query_params.get("token")
             )
             if req_token != _self.session_token:
@@ -1013,7 +1018,11 @@ def _on_registry_change():
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     # --- Security: validate session token on WebSocket connect ---
-    token = websocket.query_params.get("token", "")
+    # Check cookie first (browser), then query param (legacy fallback).
+    token = (
+        websocket.cookies.get("session")
+        or websocket.query_params.get("token", "")
+    )
     if token != session_token:
         # Must accept before closing so the browser receives the close frame.
         # Code 4003 triggers an auto-reload in the client to pick up the new token.

--- a/app.py
+++ b/app.py
@@ -2832,7 +2832,13 @@ async def launch_agent(base: str, request: Request):
 
     # Build wrapper.py command
     import sys as _sys
-    wrapper_cmd = [_sys.executable, str(Path(__file__).parent / "wrapper.py"), base, "--no-restart"]
+    wrapper_cmd = [
+        _sys.executable,
+        "-u",
+        str(Path(__file__).parent / "wrapper.py"),
+        base,
+        "--no-restart",
+    ]
     if instance_label:
         wrapper_cmd.extend(["--label", instance_label])
     if flags or extra_args:

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import json
 import re as _re
 import sys
 import threading
+import time as _time
 import uuid
 import logging
 from pathlib import Path
@@ -45,6 +46,28 @@ ws_clients: set[WebSocket] = set()
 
 # --- Security: session token (set by configure()) ---
 session_token: str = ""
+
+# --- Security: per-IP rate limiter for agent registration ---
+_REGISTER_RATE_LIMIT = 10       # max registrations per window
+_REGISTER_RATE_WINDOW = 60.0    # seconds
+_register_timestamps: dict[str, list[float]] = {}
+_register_lock = threading.Lock()
+
+
+def _check_register_rate(ip: str) -> bool:
+    """Return True if the request is within rate limits, False if exceeded."""
+    now = _time.monotonic()
+    with _register_lock:
+        timestamps = _register_timestamps.get(ip, [])
+        # Prune entries outside the window
+        timestamps = [t for t in timestamps if now - t < _REGISTER_RATE_WINDOW]
+        if len(timestamps) >= _REGISTER_RATE_LIMIT:
+            _register_timestamps[ip] = timestamps
+            return False
+        timestamps.append(now)
+        _register_timestamps[ip] = timestamps
+        return True
+
 
 # Room settings (persisted to data/settings.json)
 room_settings: dict = {
@@ -87,11 +110,64 @@ def _save_hats():
 
 
 def _sanitize_svg(svg: str) -> str:
-    """Strip dangerous content from SVG string."""
-    svg = _re.sub(r'<script[^>]*>.*?</script>', '', svg, flags=_re.DOTALL | _re.IGNORECASE)
-    svg = _re.sub(r'\bon\w+\s*=', '', svg, flags=_re.IGNORECASE)
-    svg = _re.sub(r'javascript\s*:', '', svg, flags=_re.IGNORECASE)
-    return svg
+    """Sanitise SVG using an element/attribute whitelist via ElementTree.
+
+    Blocks dangerous elements (script, foreignObject, iframe, etc.) and
+    dangerous attributes (on* event handlers, javascript:/data: URLs).
+    Falls back to empty string on parse failure.
+    """
+    import xml.etree.ElementTree as _ET
+
+    # XXE protection: strip DOCTYPE, ENTITY, and XML processing instructions
+    svg = _re.sub(r'<!DOCTYPE[^>]*>', '', svg, flags=_re.IGNORECASE)
+    svg = _re.sub(r'<!ENTITY[^>]*>', '', svg, flags=_re.IGNORECASE)
+    svg = _re.sub(r'<\?xml[^>]*\?>', '', svg, flags=_re.IGNORECASE)
+
+    # Register SVG namespaces so output doesn't get ns0: prefixes
+    _ET.register_namespace('', 'http://www.w3.org/2000/svg')
+    _ET.register_namespace('xlink', 'http://www.w3.org/1999/xlink')
+
+    try:
+        root = _ET.fromstring(svg.strip())
+    except _ET.ParseError:
+        return ''
+
+    # Root must be <svg>
+    tag = root.tag.split('}', 1)[-1].lower() if '}' in root.tag else root.tag.lower()
+    if tag != 'svg':
+        return ''
+
+    _FORBIDDEN_ELEMENTS = frozenset({
+        'script', 'foreignobject', 'iframe', 'embed', 'object', 'applet',
+        'image',       # can load external resources / trigger onerror
+        'animate', 'animatetransform', 'animatemotion', 'set',
+    })
+
+    def _local(tag_name: str) -> str:
+        return tag_name.split('}', 1)[-1].lower() if '}' in tag_name else tag_name.lower()
+
+    def _clean(elem):
+        # Remove forbidden child elements (iterate copy so removal is safe)
+        for child in list(elem):
+            if _local(child.tag) in _FORBIDDEN_ELEMENTS:
+                elem.remove(child)
+            else:
+                _clean(child)
+
+        # Remove dangerous attributes
+        for attr in list(elem.attrib):
+            attr_local = _local(attr)
+            value = (elem.attrib[attr] or '').lower().replace(' ', '').replace('\t', '')
+            # Block all event handlers (onclick, onload, onerror, …)
+            if attr_local.startswith('on'):
+                del elem.attrib[attr]
+            # Block javascript: and data: URLs in href/src attributes
+            elif attr_local in ('href', 'src') or attr_local.endswith(':href'):
+                if 'javascript:' in value or 'data:' in value:
+                    del elem.attrib[attr]
+
+    _clean(root)
+    return _ET.tostring(root, encoding='unicode')
 
 
 def set_agent_hat(agent: str, svg: str) -> str | None:
@@ -2089,6 +2165,13 @@ async def get_rules_freshness():
 @app.post("/api/register")
 async def register_agent(request: Request):
     """Wrapper calls this to register a new agent instance."""
+    # Rate limit: prevent registration spam (10 per 60s per IP).
+    client_ip = request.client.host if request.client else "unknown"
+    if not _check_register_rate(client_ip):
+        return JSONResponse(
+            {"error": "rate limit exceeded — too many registrations, try again later"},
+            status_code=429,
+        )
     try:
         body = await request.json()
     except Exception:

--- a/app.py
+++ b/app.py
@@ -2722,7 +2722,7 @@ async def list_agent_definitions():
     from config_loader import load_agent_definitions
     from process_manager import AGENT_FLAG_PRESETS
     data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
-    defs = load_agent_definitions(data_dir, config.get("agents", {}))
+    defs = load_agent_definitions(data_dir, config.get("_base_agents", config.get("agents", {})))
     return JSONResponse({"definitions": defs, "flag_presets": AGENT_FLAG_PRESETS})
 
 
@@ -2745,6 +2745,9 @@ async def add_agent_definition(request: Request):
     from config_loader import save_agent_definition
     data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
     save_agent_definition(data_dir, name, definition)
+    config.setdefault("agents", {})[name] = dict(definition)
+    if registry:
+        registry.upsert_base(name, definition)
     return JSONResponse({"ok": True})
 
 
@@ -2753,7 +2756,18 @@ async def remove_agent_definition(name: str):
     """Remove a user-defined agent."""
     from config_loader import delete_agent_definition
     data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
+    base_agents = config.get("_base_agents", {})
+    is_builtin = name in base_agents
+    if registry and registry.get_instances_for(name):
+        return JSONResponse(
+            {"error": f"cannot delete running agent definition: {name}"},
+            status_code=409,
+        )
     delete_agent_definition(data_dir, name)
+    if not is_builtin:
+        config.get("agents", {}).pop(name, None)
+        if registry:
+            registry.remove_base(name)
     return JSONResponse({"ok": True})
 
 
@@ -2808,7 +2822,10 @@ async def launch_agent(base: str, request: Request):
 
     from config_loader import load_agent_definitions
     data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
-    all_agents = load_agent_definitions(data_dir, config.get("agents", {}))
+    all_agents = load_agent_definitions(
+        data_dir,
+        config.get("_base_agents", config.get("agents", {})),
+    )
     agent_def = all_agents.get(base)
     if not agent_def:
         return JSONResponse({"error": f"unknown agent: {base}"}, status_code=400)

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import re as _re
+import shlex
 import sys
 import threading
 import time as _time
@@ -1199,7 +1200,7 @@ async def websocket_endpoint(websocket: WebSocket):
                         await broadcast_clear(channel=channel)
                         continue
                     if cmd == "/continue":
-                        router.continue_routing()
+                        router.continue_routing(channel)
                         store.add("system", "Resuming agent conversation...", msg_type="system", channel=channel)
                         await broadcast_status()
                         continue
@@ -2789,8 +2790,19 @@ async def launch_agent(base: str, request: Request):
         body = await request.json()
     except Exception:
         body = {}
-    flags = body.get("flags", [])
-    extra_args = body.get("extra_args", [])
+    raw_flags = body.get("flags", [])
+    if isinstance(raw_flags, list):
+        flags = [str(flag) for flag in raw_flags if str(flag).strip()]
+    else:
+        flags = []
+
+    raw_extra_args = body.get("extra_args", [])
+    if isinstance(raw_extra_args, str):
+        extra_args = shlex.split(raw_extra_args)
+    elif isinstance(raw_extra_args, list):
+        extra_args = [str(arg) for arg in raw_extra_args if str(arg).strip()]
+    else:
+        extra_args = []
     cwd = body.get("cwd") or room_settings.get("default_cwd") or "."
     instance_label = body.get("instance_label")
 
@@ -2800,8 +2812,6 @@ async def launch_agent(base: str, request: Request):
     agent_def = all_agents.get(base)
     if not agent_def:
         return JSONResponse({"error": f"unknown agent: {base}"}, status_code=400)
-
-    command = agent_def.get("command", base)
 
     # Build wrapper.py command
     import sys as _sys
@@ -2816,7 +2826,7 @@ async def launch_agent(base: str, request: Request):
     result = process_manager.launch(
         base=base,
         command=wrapper_cmd[0],
-        flags=flags,
+        flags=[],
         extra_args=wrapper_cmd[1:],
         cwd=cwd,
         instance_label=instance_label,

--- a/app.py
+++ b/app.py
@@ -41,6 +41,7 @@ agents: AgentTrigger | None = None
 registry: RuntimeRegistry | None = None
 session_store: SessionStore | None = None
 session_engine: SessionEngine | None = None
+process_manager = None  # ProcessManager, set by run.py
 config: dict = {}
 ws_clients: set[WebSocket] = set()
 
@@ -78,6 +79,7 @@ room_settings: dict = {
     "history_limit": "all",
     "contrast": "normal",
     "custom_roles": [],
+    "default_cwd": "",
 }
 
 # Channel validation
@@ -1136,6 +1138,14 @@ async def websocket_endpoint(websocket: WebSocket):
 
     # Send schedules
     await websocket.send_text(json.dumps({"type": "schedules", "data": schedules.list_all()}))
+
+    # Send managed agent processes
+    if process_manager:
+        await websocket.send_text(json.dumps({"type": "agent_processes", "data": process_manager.list_managed()}))
+        # Send restore state if any
+        restore = process_manager.get_restore_state()
+        if restore:
+            await websocket.send_text(json.dumps({"type": "session_restore", "data": restore}))
 
     # Send pending instances (so late-connecting browsers still see the naming lightbox)
     if registry:
@@ -2701,3 +2711,139 @@ async def serve_upload(filename: str):
     if filepath.exists():
         return FileResponse(filepath)
     return JSONResponse({"error": "not found"}, status_code=404)
+
+
+# --- Agent Launcher API ---
+
+@app.get("/api/agent-definitions")
+async def list_agent_definitions():
+    """List all agent definitions (config.toml + user-defined)."""
+    from config_loader import load_agent_definitions
+    from process_manager import AGENT_FLAG_PRESETS
+    data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
+    defs = load_agent_definitions(data_dir, config.get("agents", {}))
+    return JSONResponse({"definitions": defs, "flag_presets": AGENT_FLAG_PRESETS})
+
+
+@app.post("/api/agent-definitions")
+async def add_agent_definition(request: Request):
+    """Add a new user-defined agent."""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid JSON"}, status_code=400)
+    name = body.get("name", "").strip().lower()
+    if not name or not _re.match(r'^[a-z0-9]+$', name):
+        return JSONResponse({"error": "name must be alphanumeric lowercase"}, status_code=400)
+    definition = {
+        "command": body.get("command", name),
+        "color": body.get("color", "#888888"),
+        "label": body.get("label", name.capitalize()),
+        "cwd": body.get("cwd", ".."),
+    }
+    from config_loader import save_agent_definition
+    data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
+    save_agent_definition(data_dir, name, definition)
+    return JSONResponse({"ok": True})
+
+
+@app.delete("/api/agent-definitions/{name}")
+async def remove_agent_definition(name: str):
+    """Remove a user-defined agent."""
+    from config_loader import delete_agent_definition
+    data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
+    delete_agent_definition(data_dir, name)
+    return JSONResponse({"ok": True})
+
+
+@app.get("/api/agents/managed")
+async def list_managed_agents():
+    """List all server-managed agent processes."""
+    if not process_manager:
+        return JSONResponse({"data": []})
+    return JSONResponse({"data": process_manager.list_managed()})
+
+
+@app.get("/api/agents/restore")
+async def get_restore_state():
+    """Get previous session's agents for restore prompt."""
+    if not process_manager:
+        return JSONResponse({"data": []})
+    return JSONResponse({"data": process_manager.get_restore_state()})
+
+
+@app.post("/api/agents/restore/dismiss")
+async def dismiss_restore():
+    """Dismiss the session restore prompt."""
+    if process_manager:
+        process_manager.clear_restore_state()
+    return JSONResponse({"ok": True})
+
+
+@app.post("/api/agents/{base}/launch")
+async def launch_agent(base: str, request: Request):
+    """Launch a wrapper.py subprocess for the given agent."""
+    if not process_manager:
+        return JSONResponse({"error": "process manager not initialised"}, status_code=500)
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    flags = body.get("flags", [])
+    extra_args = body.get("extra_args", [])
+    cwd = body.get("cwd") or room_settings.get("default_cwd") or "."
+    instance_label = body.get("instance_label")
+
+    from config_loader import load_agent_definitions
+    data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
+    all_agents = load_agent_definitions(data_dir, config.get("agents", {}))
+    agent_def = all_agents.get(base)
+    if not agent_def:
+        return JSONResponse({"error": f"unknown agent: {base}"}, status_code=400)
+
+    command = agent_def.get("command", base)
+
+    # Build wrapper.py command
+    import sys as _sys
+    wrapper_cmd = [_sys.executable, str(Path(__file__).parent / "wrapper.py"), base, "--no-restart"]
+    if instance_label:
+        wrapper_cmd.extend(["--label", instance_label])
+    if flags or extra_args:
+        wrapper_cmd.append("--")
+        wrapper_cmd.extend(flags)
+        wrapper_cmd.extend(extra_args)
+
+    result = process_manager.launch(
+        base=base,
+        command=wrapper_cmd[0],
+        flags=flags,
+        extra_args=wrapper_cmd[1:],
+        cwd=cwd,
+        instance_label=instance_label,
+    )
+    if result.get("ok") and _event_loop:
+        managed = process_manager.list_managed()
+        event_data = json.dumps({"type": "agent_processes", "data": managed})
+        asyncio.run_coroutine_threadsafe(_broadcast(event_data), _event_loop)
+    return JSONResponse(result)
+
+
+@app.post("/api/agents/{name}/stop")
+async def stop_agent(name: str):
+    """Stop a managed wrapper subprocess."""
+    if not process_manager:
+        return JSONResponse({"error": "process manager not initialised"}, status_code=500)
+    result = process_manager.stop(name)
+    if result.get("ok") and _event_loop:
+        managed = process_manager.list_managed()
+        event_data = json.dumps({"type": "agent_processes", "data": managed})
+        asyncio.run_coroutine_threadsafe(_broadcast(event_data), _event_loop)
+    return JSONResponse(result)
+
+
+@app.get("/api/agents/{name}/logs")
+async def get_agent_logs(name: str):
+    """Return the last 100 log lines for a managed agent."""
+    if not process_manager:
+        return JSONResponse({"error": "process manager not initialised"}, status_code=500)
+    return JSONResponse({"lines": process_manager.get_logs(name)})

--- a/archive.py
+++ b/archive.py
@@ -352,7 +352,7 @@ def _do_import(zip_bytes, store, jobs_store, rules_store,
                         old_jid = m["metadata"].get("job_id")
                         if old_jid in _job_id_remap:
                             m["metadata"]["job_id"] = _job_id_remap[old_jid]
-                store._save()
+                store._rewrite()
     report["sections"]["jobs"] = job_report
 
     # --- Import rules ---

--- a/config_loader.py
+++ b/config_loader.py
@@ -40,6 +40,12 @@ def load_config(root: Path | None = None) -> dict:
             else:
                 print(f"  Warning: Ignoring local agent '{name}' (already defined in config.toml)")
 
+    config_agents = config.setdefault("agents", {})
+    data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
+    if not data_dir.is_absolute():
+        data_dir = root / data_dir
+    config["agents"] = load_agent_definitions(data_dir, config_agents)
+
     return config
 
 

--- a/config_loader.py
+++ b/config_loader.py
@@ -41,10 +41,11 @@ def load_config(root: Path | None = None) -> dict:
                 print(f"  Warning: Ignoring local agent '{name}' (already defined in config.toml)")
 
     config_agents = config.setdefault("agents", {})
+    config["_base_agents"] = dict(config_agents)
     data_dir = Path(config.get("server", {}).get("data_dir", "./data"))
     if not data_dir.is_absolute():
         data_dir = root / data_dir
-    config["agents"] = load_agent_definitions(data_dir, config_agents)
+    config["agents"] = load_agent_definitions(data_dir, config["_base_agents"])
 
     return config
 

--- a/config_loader.py
+++ b/config_loader.py
@@ -4,6 +4,7 @@ Used by run.py, wrapper.py, and wrapper_api.py so the server and all
 wrappers see the same agent definitions.
 """
 
+import json
 import tomllib
 from pathlib import Path
 
@@ -40,3 +41,48 @@ def load_config(root: Path | None = None) -> dict:
                 print(f"  Warning: Ignoring local agent '{name}' (already defined in config.toml)")
 
     return config
+
+
+def load_agent_definitions(data_dir: Path, config_agents: dict) -> dict:
+    """Merge config.toml agents with user-defined agents from agent_definitions.json.
+
+    config.toml agents win on name conflicts (same protection as config.local.toml).
+    """
+    merged = dict(config_agents)
+    defs_path = data_dir / "agent_definitions.json"
+    if defs_path.exists():
+        try:
+            user_defs = json.loads(defs_path.read_text("utf-8"))
+            for name, agent_cfg in user_defs.items():
+                if name not in merged:
+                    merged[name] = agent_cfg
+        except Exception:
+            pass
+    return merged
+
+
+def save_agent_definition(data_dir: Path, name: str, definition: dict):
+    """Save or update a user-defined agent definition."""
+    defs_path = data_dir / "agent_definitions.json"
+    defs_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = {}
+    if defs_path.exists():
+        try:
+            existing = json.loads(defs_path.read_text("utf-8"))
+        except Exception:
+            pass
+    existing[name] = definition
+    defs_path.write_text(json.dumps(existing, indent=2), "utf-8")
+
+
+def delete_agent_definition(data_dir: Path, name: str):
+    """Remove a user-defined agent definition."""
+    defs_path = data_dir / "agent_definitions.json"
+    if not defs_path.exists():
+        return
+    try:
+        existing = json.loads(defs_path.read_text("utf-8"))
+        existing.pop(name, None)
+        defs_path.write_text(json.dumps(existing, indent=2), "utf-8")
+    except Exception:
+        pass

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -1,0 +1,56 @@
+# Project Status — agentchattr
+Last updated: 2026-04-12 by Manager
+
+## Active Workstreams
+
+### Desktop Shell QA & Signoff
+- **Status:** Active
+- **Owner:** Unassigned
+- **Plan:** `docs/superpowers/qa/desktop-shell-checklist.md`
+- **Progress:** Full automated gate passed, including tray/notification/deep-link logic and explicit custom-agent stop/delete coverage
+- **Blocked by:** Nothing
+- **Next:** Keep the automated gate green; optional native-desktop spot checks can happen before a release. See `docs/superpowers/qa/release-readiness.md`.
+- **Notes:** Port `8300` must be free before launching Electron, the Electron shell should own the embedded `run.py` lifecycle, and a startup retry race in `electron/renderer/renderer.js` was fixed during the 2026-04-12 QA run.
+
+### Launcher Lifecycle Stabilization
+- **Status:** Active
+- **Owner:** Unassigned
+- **Plan:** `docs/superpowers/plans/2026-04-05-agent-launcher-panel.md`
+- **Progress:** Implementation landed; duplicate launches, restore-banner behavior, and explicit custom-agent stop/delete flow are smoke-covered
+- **Blocked by:** Nothing
+- **Next:** Archive or shrink the implementation plan now that validation is recorded. Track remaining follow-up in `docs/superpowers/qa/known-issues-next-milestones.md`.
+- **Notes:** The original launcher implementation is in the repo; this workstream is effectively in maintenance mode now.
+
+### Repo Workflow & Documentation Hygiene
+- **Status:** Active
+- **Owner:** Unassigned
+- **Plan:** None
+- **Progress:** Fork workflow policy is documented and stale notes were reconciled on 2026-04-12
+- **Blocked by:** Nothing
+- **Next:** Keep this status file current after QA runs or release-adjacent changes.
+- **Notes:** `origin/main` is the authoritative branch for this fork; `upstream` is fetch-only reference material.
+
+## Backlog (prioritized)
+1. Run optional native Windows tray/toast spot checks before a broader release and record the outcome in `docs/superpowers/qa/release-readiness.md`.
+2. Archive or shrink the launcher implementation plan now that the gate is green.
+3. Decide whether Windows smoke coverage should remain local-only or move into CI.
+
+## Recently Completed
+- [2026-04-12] Documented the fork-only workflow in `README.md` — `54fa3b9`
+- [2026-04-12] Added desktop smoke coverage and the Windows QA checklist — `3895be7`
+- [2026-04-12] Registered runtime custom agents cleanly in launcher flows — `0a6dec0`
+- [2026-04-12] Repaired launcher launch and restore contracts — `3f6c8b3`
+- [2026-04-12] Recorded the automated Windows desktop QA run, added tray/notification/deep-link unit coverage, added launcher custom-agent cleanup smoke coverage, and fixed Electron channel-focus + stop/delete cleanup races — local workspace change
+- [2026-04-05] Landed the launcher implementation and API/test scaffolding — `93d32b6`, `141c9ed`, `686088d`, `0d776af`, `6589d2b`
+
+## Parking Lot
+Items discussed but not yet planned:
+- Decide whether a separate native-desktop release checklist is still needed beyond `docs/superpowers/qa/release-readiness.md` and the existing QA gate.
+- Reduce or archive superseded implementation plans once their follow-up QA is fully recorded.
+
+## Decision Log
+| Date | Decision | Context |
+|------|----------|---------|
+| 2026-04-12 | Treat `origin/main` as the authoritative branch for this fork and keep `upstream` read-only. | Documented in `README.md` fork workflow policy. |
+| 2026-04-12 | Keep the Electron shell as a wrapper around the same local `run.py` server on port `8300`. | Documented in the Windows desktop shell section of `README.md`. |
+| 2026-04-12 | Use an HttpOnly `session` cookie for browser auth; do not rely on a JS-readable token global. | Reflected in `app.py`, `static/chat.js`, and the reconciled memory note. |

--- a/docs/superpowers/plans/2026-04-05-agent-launcher-panel.md
+++ b/docs/superpowers/plans/2026-04-05-agent-launcher-panel.md
@@ -1,0 +1,391 @@
+# Agent Launcher Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a web UI panel that lets users launch, stop, monitor, and configure AI coding agents directly from the browser — no separate terminal windows or batch files needed.
+
+**Architecture:** The server (`app.py`) gains a `ProcessManager` that spawns `wrapper.py` as managed subprocesses, captures their stdout into ring buffers, and exposes launch/stop/logs via REST + WebSocket. A new `launcher.js` frontend module renders the panel following the same pattern as `jobs.js` and `sessions.js`. Agent definitions are stored in `data/agent_definitions.json` and merged with `config.toml` on startup.
+
+**Tech Stack:** Python (FastAPI, subprocess, threading), vanilla JS (Hub pub/sub from core.js), existing WebSocket protocol.
+
+**Spec:** `docs/superpowers/specs/2026-04-05-agent-launcher-panel-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `process_manager.py` | Create | Spawn/stop wrappers, capture logs, persist launch state |
+| `static/launcher.js` | Create | Launcher panel UI, agent cards, log viewer, forms |
+| `app.py` | Modify | REST endpoints, WS events, wire ProcessManager |
+| `run.py` | Modify | Create ProcessManager, load restore state |
+| `static/index.html` | Modify | Add launcher button, panel container, script tag, CSS |
+| `static/chat.js` | Modify | Wire launcher panel toggle, handle new WS events |
+| `config_loader.py` | Modify | Merge agent_definitions.json into config |
+| `tests/test_process_manager.py` | Create | Unit tests for ProcessManager |
+| `tests/test_agent_definitions.py` | Create | Unit tests for agent definitions CRUD |
+| `tests/test_launcher_api.py` | Create | Integration tests for launcher REST endpoints |
+
+---
+
+### Task 1: ProcessManager Core — Spawn and Track Wrapper Subprocesses
+
+**Files:**
+- Create: `process_manager.py`
+- Create: `tests/test_process_manager.py`
+
+- [ ] **Step 1: Write the failing test for launch and state tracking**
+
+```python
+# tests/test_process_manager.py
+import time
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from process_manager import ProcessManager
+
+
+def test_launch_tracks_state():
+    """Launching an agent creates a tracked entry with correct state."""
+    pm = ProcessManager(data_dir=Path("./test_data"), server_port=8300)
+    result = pm.launch(
+        base="testbot",
+        command=sys.executable,
+        flags=[],
+        extra_args=["-c", "import time; time.sleep(0.5); print('hello')"],
+        cwd=".",
+    )
+    assert result["ok"] is True
+    assert result["name"] == "testbot"
+    assert result["pid"] > 0
+
+    managed = pm.list_managed()
+    assert len(managed) == 1
+    assert managed[0]["name"] == "testbot"
+    assert managed[0]["state"] in ("starting", "running")
+
+    time.sleep(1.5)
+    managed = pm.list_managed()
+    assert managed[0]["state"] in ("crashed", "stopped")
+
+    pm.shutdown()
+    import shutil
+    shutil.rmtree("./test_data", ignore_errors=True)
+
+
+def test_launch_duplicate_base_gets_suffix():
+    """Launching the same base twice assigns different names."""
+    pm = ProcessManager(data_dir=Path("./test_data"), server_port=8300)
+    r1 = pm.launch(base="bot", command=sys.executable,
+                   flags=[], extra_args=["-c", "import time; time.sleep(2)"], cwd=".")
+    r2 = pm.launch(base="bot", command=sys.executable,
+                   flags=[], extra_args=["-c", "import time; time.sleep(2)"], cwd=".")
+    assert r1["name"] == "bot"
+    assert r2["name"] == "bot-2"
+    assert len(pm.list_managed()) == 2
+    pm.stop("bot")
+    pm.stop("bot-2")
+    pm.shutdown()
+    import shutil
+    shutil.rmtree("./test_data", ignore_errors=True)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_process_manager.py -v`
+Expected: FAIL with "No module named 'process_manager'"
+
+- [ ] **Step 3: Write ProcessManager implementation**
+
+Create `process_manager.py` with:
+- `ManagedAgent` class: holds subprocess, ring buffer (deque maxlen=100), state machine (starting/running/crashed/stopped), reader thread for stdout, waiter thread for exit detection
+- `AGENT_FLAG_PRESETS` dict: known flag toggles per agent type (claude, codex, gemini, qwen)
+- `ProcessManager` class: launch (spawn subprocess, assign unique name), stop (SIGTERM then SIGKILL after 5s), get_logs, list_managed, get_restore_state, clear_restore_state, shutdown
+- Launch state persisted to `data/launch_state.json` on every launch/stop
+
+Key implementation details:
+- `launch()` uses `subprocess.Popen` with `stdout=PIPE, stderr=STDOUT` — no `shell=True`
+- For test mode (when command is sys.executable directly), run the command as-is
+- For production mode (when called from app.py), build `wrapper.py` command with `--no-restart` flag
+- Name assignment: first instance gets base name, subsequent get base-2, base-3, etc.
+- `on_log` callback (optional) called from reader thread for each line — used for WebSocket broadcast
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_process_manager.py -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add process_manager.py tests/test_process_manager.py
+git commit -m "feat(launcher): add ProcessManager for server-managed agent subprocesses"
+```
+
+---
+
+### Task 2: Agent Definitions Store
+
+**Files:**
+- Modify: `config_loader.py`
+- Create: `tests/test_agent_definitions.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_definitions.py
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from config_loader import load_agent_definitions, save_agent_definition, delete_agent_definition
+
+
+def test_load_definitions_merges_with_config(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "agent_definitions.json").write_text(json.dumps({
+        "mybot": {"command": "mybot", "color": "#ff0000", "label": "MyBot"}
+    }))
+    config_agents = {"claude": {"command": "claude", "color": "#da7756", "label": "Claude"}}
+    defs = load_agent_definitions(data_dir, config_agents)
+    assert "claude" in defs
+    assert "mybot" in defs
+    assert defs["mybot"]["color"] == "#ff0000"
+
+
+def test_save_and_delete_definition(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    save_agent_definition(data_dir, "newbot", {"command": "newbot", "color": "#00ff00", "label": "NewBot"})
+    defs = load_agent_definitions(data_dir, {})
+    assert "newbot" in defs
+
+    delete_agent_definition(data_dir, "newbot")
+    defs = load_agent_definitions(data_dir, {})
+    assert "newbot" not in defs
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_agent_definitions.py -v`
+Expected: FAIL with "cannot import name 'load_agent_definitions'"
+
+- [ ] **Step 3: Add functions to config_loader.py**
+
+Add `import json` at the top, then add three functions at the end:
+- `load_agent_definitions(data_dir, config_agents)` — merges config.toml agents with `data/agent_definitions.json` (config.toml wins on conflicts)
+- `save_agent_definition(data_dir, name, definition)` — upsert to JSON file
+- `delete_agent_definition(data_dir, name)` — remove from JSON file
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_agent_definitions.py -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config_loader.py tests/test_agent_definitions.py
+git commit -m "feat(launcher): add agent definitions CRUD to config_loader"
+```
+
+---
+
+### Task 3: REST API Endpoints and Server Wiring
+
+**Files:**
+- Modify: `app.py` (add global at line ~42, add `default_cwd` to room_settings at line ~50, add WS init data at line ~1138, add endpoints after line ~2695)
+- Modify: `run.py` (create ProcessManager after configure() call at line ~36)
+
+- [ ] **Step 1: Add ProcessManager global to app.py**
+
+After `session_engine` global (line 42), add:
+```python
+process_manager = None  # set by run.py
+```
+
+Add `"default_cwd": ""` to `room_settings` dict (line ~50).
+
+- [ ] **Step 2: Wire ProcessManager creation in run.py**
+
+After `configure()` call and data_dir setup, create ProcessManager with `on_log` callback that broadcasts via WebSocket.
+
+- [ ] **Step 3: Add REST endpoints to app.py**
+
+Add after the last endpoint (~line 2695):
+- `POST /api/agents/{base}/launch` — spawn wrapper subprocess via ProcessManager
+- `POST /api/agents/{name}/stop` — stop a managed agent
+- `GET /api/agents/{name}/logs` — return log ring buffer
+- `GET /api/agents/managed` — list all managed processes
+- `GET /api/agent-definitions` — list definitions + flag presets
+- `POST /api/agent-definitions` — add user-defined agent
+- `DELETE /api/agent-definitions/{name}` — remove user-defined agent
+- `GET /api/agents/restore` — get previous session state
+- `POST /api/agents/restore/dismiss` — clear restore state
+
+All endpoints use session token auth (existing middleware handles this).
+
+- [ ] **Step 4: Send managed agent state and restore data on WS connect**
+
+In the WebSocket handler, after sending schedules (~line 1138), add sends for `agent_processes` and `session_restore` events.
+
+- [ ] **Step 5: Verify syntax**
+
+Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -c "import ast; ast.parse(open('app.py').read()); ast.parse(open('run.py').read()); print('OK')"`
+Expected: OK
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app.py run.py
+git commit -m "feat(launcher): add REST endpoints and ProcessManager wiring"
+```
+
+---
+
+### Task 4: Frontend — Launcher Panel HTML, JS, and CSS
+
+**Files:**
+- Modify: `static/index.html` (header button at line ~25, panel container before line ~126, script tag after line ~327, CSS in style block)
+- Create: `static/launcher.js`
+
+- [ ] **Step 1: Add launcher button to header in index.html**
+
+After the `agent-status` div (line 25), before `jobs-toggle` button (line 26), add a new button with a lattice/terminal icon and id `launcher-toggle`.
+
+- [ ] **Step 2: Add panel container in index.html**
+
+Before `pins-panel` (line 126), add `<aside id="launcher-panel" class="hidden">` with header, list div, and add-agent form div.
+
+- [ ] **Step 3: Add script tag**
+
+After `rules-panel.js` (line 327): `<script src="/static/launcher.js?v=100"></script>`
+
+- [ ] **Step 4: Create launcher.js**
+
+Module pattern matching jobs.js:
+- State: `launcherDefinitions`, `launcherFlagPresets`, `launcherProcesses`, `launcherLogs`, `launcherLogsOpen`, `launcherConfigOpen`
+- Init: fetch definitions and managed agents on DOMContentLoaded
+- Hub subscriptions: `agent_processes` (re-render panel), `agent_log` (append to buffer, re-render logs), `session_restore` (show banner)
+- Functions: `toggleLauncherPanel`, `renderLauncherPanel`, `buildAgentCard`, `buildLaunchConfig`, `launchAgent`, `stopAgent`, `toggleLaunchConfig`, `toggleAgentLogs`, `fetchAgentLogs`, `renderAgentLogs`
+- Add Agent: `toggleAddAgentForm`, `saveNewAgent` with colour picker
+- Session Restore: `showRestoreBanner`, `relaunchSelected`, `dismissRestore`
+- All user content rendered via `escapeHtml()` (from core.js) — no raw innerHTML with untrusted data
+
+Note on XSS: All dynamic content inserted via innerHTML uses `escapeHtml()` for user-provided strings (agent names, flags, paths). This follows the existing pattern used by jobs.js and sessions.js in this codebase.
+
+- [ ] **Step 5: Add CSS styles to index.html**
+
+Add launcher panel styles matching the mockup: panel positioning, card layout, dot indicators, status badges, launch config form, flag toggles, log viewer, add-agent form, colour picker, restore banner.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add static/index.html static/launcher.js
+git commit -m "feat(launcher): add launcher panel UI with agent cards, logs, and forms"
+```
+
+---
+
+### Task 5: WebSocket Event Routing in chat.js
+
+**Files:**
+- Modify: `static/chat.js` (ws.onmessage handler, around lines 487-630)
+
+- [ ] **Step 1: Add event routing**
+
+After the `schedule` case (line ~628), add:
+```javascript
+    } else if (event.type === "agent_processes") {
+      Hub.emit("agent_processes", event);
+    } else if (event.type === "agent_log") {
+      Hub.emit("agent_log", event);
+    } else if (event.type === "session_restore") {
+      Hub.emit("session_restore", event);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add static/chat.js
+git commit -m "feat(launcher): route launcher WS events through Hub"
+```
+
+---
+
+### Task 6: Integration Tests
+
+**Files:**
+- Create: `tests/test_launcher_api.py`
+
+- [ ] **Step 1: Write integration tests**
+
+Tests using Starlette TestClient:
+- `test_list_definitions` — GET /api/agent-definitions returns definitions and flag_presets
+- `test_add_and_delete_definition` — POST then DELETE agent definition
+- `test_list_managed_empty` — GET /api/agents/managed returns empty list initially
+
+All requests use cookie auth: `cookies={"session": "test-token"}`
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_launcher_api.py -v`
+Expected: 3 passed
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_launcher_api.py
+git commit -m "test(launcher): add integration tests for launcher API endpoints"
+```
+
+---
+
+### Task 7: Manual Testing and Polish
+
+- [ ] **Step 1: Start the server and open browser**
+
+Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python run.py`
+Navigate to http://localhost:8300
+
+- [ ] **Step 2: Verify panel functionality**
+
+Check: launcher button in header, panel opens/closes, definitions listed, add agent form works, launch config expands with flag toggles, no JS errors in console.
+
+- [ ] **Step 3: Test agent launch and stop**
+
+Launch an agent from the panel. Verify: registration, status pills, logs, stop button. Launch a second instance of the same agent — verify it gets a suffix name.
+
+- [ ] **Step 4: Test session restore**
+
+Stop server, restart it, verify restore banner appears with previous agents listed.
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add <specific files>
+git commit -m "fix(launcher): polish from manual testing"
+```
+
+---
+
+## Summary
+
+| Task | Description | Est. Steps |
+|------|-------------|------------|
+| 1 | ProcessManager core | 5 |
+| 2 | Agent definitions store | 5 |
+| 3 | REST API + server wiring | 6 |
+| 4 | Frontend panel (HTML + JS + CSS) | 6 |
+| 5 | WS event routing | 2 |
+| 6 | Integration tests | 3 |
+| 7 | Manual testing + polish | 5 |
+| **Total** | | **32 steps** |

--- a/docs/superpowers/plans/2026-04-05-agent-launcher-panel.md
+++ b/docs/superpowers/plans/2026-04-05-agent-launcher-panel.md
@@ -10,6 +10,13 @@
 
 **Spec:** `docs/superpowers/specs/2026-04-05-agent-launcher-panel-design.md`
 
+## Status Snapshot (2026-04-12)
+
+- Implementation landed across `93d32b6`, `141c9ed`, `686088d`, `0d776af`, `6589d2b`, `3f6c8b3`, and `0a6dec0`.
+- Automated Windows QA is now recorded in `docs/superpowers/qa/desktop-shell-checklist.md`.
+- No blocking automation gaps remain. Optional native-desktop spot-checks can still be done before a release.
+- Implementation drift from the original plan: launcher styles ship in `static/launcher.css`, linked from `static/index.html`, instead of staying inline in `static/index.html`.
+
 ---
 
 ## File Structure
@@ -18,9 +25,10 @@
 |------|--------|---------------|
 | `process_manager.py` | Create | Spawn/stop wrappers, capture logs, persist launch state |
 | `static/launcher.js` | Create | Launcher panel UI, agent cards, log viewer, forms |
+| `static/launcher.css` | Create | Launcher panel styling, status badges, logs, and restore banner |
 | `app.py` | Modify | REST endpoints, WS events, wire ProcessManager |
 | `run.py` | Modify | Create ProcessManager, load restore state |
-| `static/index.html` | Modify | Add launcher button, panel container, script tag, CSS |
+| `static/index.html` | Modify | Add launcher button, panel container, and launcher asset links |
 | `static/chat.js` | Modify | Wire launcher panel toggle, handle new WS events |
 | `config_loader.py` | Modify | Merge agent_definitions.json into config |
 | `tests/test_process_manager.py` | Create | Unit tests for ProcessManager |
@@ -35,7 +43,7 @@
 - Create: `process_manager.py`
 - Create: `tests/test_process_manager.py`
 
-- [ ] **Step 1: Write the failing test for launch and state tracking**
+- [x] **Step 1: Write the failing test for launch and state tracking**
 
 ```python
 # tests/test_process_manager.py
@@ -94,12 +102,12 @@ def test_launch_duplicate_base_gets_suffix():
     shutil.rmtree("./test_data", ignore_errors=True)
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_process_manager.py -v`
 Expected: FAIL with "No module named 'process_manager'"
 
-- [ ] **Step 3: Write ProcessManager implementation**
+- [x] **Step 3: Write ProcessManager implementation**
 
 Create `process_manager.py` with:
 - `ManagedAgent` class: holds subprocess, ring buffer (deque maxlen=100), state machine (starting/running/crashed/stopped), reader thread for stdout, waiter thread for exit detection
@@ -114,12 +122,12 @@ Key implementation details:
 - Name assignment: first instance gets base name, subsequent get base-2, base-3, etc.
 - `on_log` callback (optional) called from reader thread for each line — used for WebSocket broadcast
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_process_manager.py -v`
 Expected: 2 passed
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add process_manager.py tests/test_process_manager.py
@@ -134,7 +142,7 @@ git commit -m "feat(launcher): add ProcessManager for server-managed agent subpr
 - Modify: `config_loader.py`
 - Create: `tests/test_agent_definitions.py`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```python
 # tests/test_agent_definitions.py
@@ -173,24 +181,24 @@ def test_save_and_delete_definition(tmp_path):
     assert "newbot" not in defs
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_agent_definitions.py -v`
 Expected: FAIL with "cannot import name 'load_agent_definitions'"
 
-- [ ] **Step 3: Add functions to config_loader.py**
+- [x] **Step 3: Add functions to config_loader.py**
 
 Add `import json` at the top, then add three functions at the end:
 - `load_agent_definitions(data_dir, config_agents)` — merges config.toml agents with `data/agent_definitions.json` (config.toml wins on conflicts)
 - `save_agent_definition(data_dir, name, definition)` — upsert to JSON file
 - `delete_agent_definition(data_dir, name)` — remove from JSON file
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_agent_definitions.py -v`
 Expected: 2 passed
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add config_loader.py tests/test_agent_definitions.py
@@ -205,7 +213,7 @@ git commit -m "feat(launcher): add agent definitions CRUD to config_loader"
 - Modify: `app.py` (add global at line ~42, add `default_cwd` to room_settings at line ~50, add WS init data at line ~1138, add endpoints after line ~2695)
 - Modify: `run.py` (create ProcessManager after configure() call at line ~36)
 
-- [ ] **Step 1: Add ProcessManager global to app.py**
+- [x] **Step 1: Add ProcessManager global to app.py**
 
 After `session_engine` global (line 42), add:
 ```python
@@ -214,11 +222,11 @@ process_manager = None  # set by run.py
 
 Add `"default_cwd": ""` to `room_settings` dict (line ~50).
 
-- [ ] **Step 2: Wire ProcessManager creation in run.py**
+- [x] **Step 2: Wire ProcessManager creation in run.py**
 
 After `configure()` call and data_dir setup, create ProcessManager with `on_log` callback that broadcasts via WebSocket.
 
-- [ ] **Step 3: Add REST endpoints to app.py**
+- [x] **Step 3: Add REST endpoints to app.py**
 
 Add after the last endpoint (~line 2695):
 - `POST /api/agents/{base}/launch` — spawn wrapper subprocess via ProcessManager
@@ -233,16 +241,16 @@ Add after the last endpoint (~line 2695):
 
 All endpoints use session token auth (existing middleware handles this).
 
-- [ ] **Step 4: Send managed agent state and restore data on WS connect**
+- [x] **Step 4: Send managed agent state and restore data on WS connect**
 
 In the WebSocket handler, after sending schedules (~line 1138), add sends for `agent_processes` and `session_restore` events.
 
-- [ ] **Step 5: Verify syntax**
+- [x] **Step 5: Verify syntax**
 
 Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -c "import ast; ast.parse(open('app.py').read()); ast.parse(open('run.py').read()); print('OK')"`
 Expected: OK
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add app.py run.py
@@ -254,22 +262,23 @@ git commit -m "feat(launcher): add REST endpoints and ProcessManager wiring"
 ### Task 4: Frontend — Launcher Panel HTML, JS, and CSS
 
 **Files:**
-- Modify: `static/index.html` (header button at line ~25, panel container before line ~126, script tag after line ~327, CSS in style block)
+- Modify: `static/index.html` (header button, panel container, launcher asset links)
 - Create: `static/launcher.js`
+- Create: `static/launcher.css`
 
-- [ ] **Step 1: Add launcher button to header in index.html**
+- [x] **Step 1: Add launcher button to header in index.html**
 
 After the `agent-status` div (line 25), before `jobs-toggle` button (line 26), add a new button with a lattice/terminal icon and id `launcher-toggle`.
 
-- [ ] **Step 2: Add panel container in index.html**
+- [x] **Step 2: Add panel container in index.html**
 
 Before `pins-panel` (line 126), add `<aside id="launcher-panel" class="hidden">` with header, list div, and add-agent form div.
 
-- [ ] **Step 3: Add script tag**
+- [x] **Step 3: Add script tag**
 
 After `rules-panel.js` (line 327): `<script src="/static/launcher.js?v=100"></script>`
 
-- [ ] **Step 4: Create launcher.js**
+- [x] **Step 4: Create launcher.js**
 
 Module pattern matching jobs.js:
 - State: `launcherDefinitions`, `launcherFlagPresets`, `launcherProcesses`, `launcherLogs`, `launcherLogsOpen`, `launcherConfigOpen`
@@ -282,11 +291,11 @@ Module pattern matching jobs.js:
 
 Note on XSS: All dynamic content inserted via innerHTML uses `escapeHtml()` for user-provided strings (agent names, flags, paths). This follows the existing pattern used by jobs.js and sessions.js in this codebase.
 
-- [ ] **Step 5: Add CSS styles to index.html**
+- [x] **Step 5: Add CSS styles in `static/launcher.css` and link them from `static/index.html`**
 
 Add launcher panel styles matching the mockup: panel positioning, card layout, dot indicators, status badges, launch config form, flag toggles, log viewer, add-agent form, colour picker, restore banner.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add static/index.html static/launcher.js
@@ -300,7 +309,7 @@ git commit -m "feat(launcher): add launcher panel UI with agent cards, logs, and
 **Files:**
 - Modify: `static/chat.js` (ws.onmessage handler, around lines 487-630)
 
-- [ ] **Step 1: Add event routing**
+- [x] **Step 1: Add event routing**
 
 After the `schedule` case (line ~628), add:
 ```javascript
@@ -312,7 +321,7 @@ After the `schedule` case (line ~628), add:
       Hub.emit("session_restore", event);
 ```
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 git add static/chat.js
@@ -326,7 +335,7 @@ git commit -m "feat(launcher): route launcher WS events through Hub"
 **Files:**
 - Create: `tests/test_launcher_api.py`
 
-- [ ] **Step 1: Write integration tests**
+- [x] **Step 1: Write integration tests**
 
 Tests using Starlette TestClient:
 - `test_list_definitions` — GET /api/agent-definitions returns definitions and flag_presets
@@ -335,12 +344,12 @@ Tests using Starlette TestClient:
 
 All requests use cookie auth: `cookies={"session": "test-token"}`
 
-- [ ] **Step 2: Run tests**
+- [x] **Step 2: Run tests**
 
 Run: `cd C:\AI\JAgentchattr && .venv\Scripts\python -m pytest tests/test_launcher_api.py -v`
 Expected: 3 passed
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add tests/test_launcher_api.py
@@ -350,6 +359,8 @@ git commit -m "test(launcher): add integration tests for launcher API endpoints"
 ---
 
 ### Task 7: Manual Testing and Polish
+
+**Status note (2026-04-12):** The automated Windows QA gate has been recorded, the launcher smoke now covers explicit custom-agent stop/delete cleanup, and a startup race in `electron/renderer/renderer.js` was fixed during that run. These checklist items are now optional native-desktop spot checks rather than release blockers.
 
 - [ ] **Step 1: Start the server and open browser**
 

--- a/docs/superpowers/qa/desktop-shell-checklist.md
+++ b/docs/superpowers/qa/desktop-shell-checklist.md
@@ -1,0 +1,47 @@
+# Desktop Shell QA Checklist
+
+Use this when validating the launcher and Electron desktop workflow on Windows after changes to `static/launcher.js`, `app.py`, or anything under `electron/`.
+
+## Preconditions
+
+- [ ] `.venv` exists at the repo root.
+- [ ] `npm --prefix electron install` has been run at least once.
+- [ ] `electron/node_modules/electron/dist/electron.exe` exists.
+- [ ] No standalone `run.py` server is already holding port `8300`.
+- [ ] No resident Electron instance is still running in the tray.
+
+## Automated Gate
+
+- [ ] `.venv\Scripts\python -m pytest tests -q`
+- [ ] `node --test tests/launcher_helpers.test.cjs`
+- [ ] `npm --prefix electron test`
+- [ ] `node --check static/launcher.js`
+- [ ] `node --check electron/main.js`
+- [ ] `node --check electron/renderer/renderer.js`
+- [ ] `npm --prefix electron run smoke:launcher`
+- [ ] `npm --prefix electron run smoke:desktop`
+
+If either smoke command fails, inspect the screenshots and logs written to `data/qa-artifacts/`.
+
+## Manual Checks
+
+- [ ] Tray lifecycle
+  Start the desktop shell, close the main window, confirm it hides to the tray, restore it with the tray icon, then quit from the tray menu and confirm the app exits fully.
+- [ ] Notifications and unread badge
+  With the shell unfocused, trigger a notification from the chat UI or a webview-originated event and confirm the native toast appears, clicking it focuses the window, and the unread badge clears when the app regains focus.
+- [ ] Deep links
+  Launch `agentchattr://channel/general` and `agentchattr://port/8300` while the shell is already running and confirm the existing instance focuses the correct tab/channel instead of spawning a duplicate app.
+- [ ] Ports tab
+  Open the Ports tab, confirm active listeners appear, and verify the kill action behaves sensibly for a disposable local process before using it on anything important.
+- [ ] Launcher custom-agent lifecycle
+  Add a disposable custom agent, launch it, confirm logs are available, stop it, and delete the definition cleanly.
+- [ ] Duplicate instances
+  Launch the same agent twice and confirm each instance gets a unique name, its own status pill, and independent stop/log controls.
+- [ ] Restore banner
+  With launcher-started agents still in the saved restore state, refresh the browser UI and confirm the restore banner appears and relaunches the selected agents.
+- [ ] Shutdown cleanup
+  After quitting Electron, confirm neither Electron nor `run.py` still owns port `8300`, then relaunch the shell to verify the next start is clean.
+
+## CI Note
+
+The smoke commands stay local-only for now. They depend on Windows, an installed Edge channel for Playwright browser automation, Electron's single-instance lock, and exclusive ownership of port `8300`.

--- a/docs/superpowers/qa/desktop-shell-checklist.md
+++ b/docs/superpowers/qa/desktop-shell-checklist.md
@@ -2,6 +2,14 @@
 
 Use this when validating the launcher and Electron desktop workflow on Windows after changes to `static/launcher.js`, `app.py`, or anything under `electron/`.
 
+## Latest Recorded Run
+
+- **Date:** 2026-04-12
+- **Automated gate:** Passed end-to-end. Verified `.venv`, Electron install, and an open port `8300`; then ran `.venv\Scripts\python -m pytest tests -q`, `node --test tests/launcher_helpers.test.cjs`, `npm --prefix electron test`, `node --check static/launcher.js`, `node --check electron/main.js`, `node --check electron/renderer/renderer.js`, `npm --prefix electron run smoke:launcher`, and `npm --prefix electron run smoke:desktop`.
+- **Regression fixed during the run:** `electron/renderer/renderer.js` could drop early `focus-channel` events when `webview.executeJavaScript()` threw during startup. The retry path now treats those startup errors as transient instead of abandoning the pending channel sync.
+- **Automated coverage now includes:** Ports tab render, channel-focus propagation into the embedded chat webview, duplicate launcher instances, restore banner after reload, explicit custom-agent stop/delete via the launcher UI, release of port `8300` on Electron shutdown, notification badge/click handling, tray show-hide/quit logic, and second-instance deep-link dispatch.
+- **Manual follow-up:** No blocking QA gaps remain for repository validation. Native tray icon behavior and Windows toast presentation can still be spot-checked on a real desktop session before a release if desired.
+
 ## Preconditions
 
 - [ ] `.venv` exists at the repo root.

--- a/docs/superpowers/qa/known-issues-next-milestones.md
+++ b/docs/superpowers/qa/known-issues-next-milestones.md
@@ -1,0 +1,49 @@
+# Known Issues & Next Milestones — agentchattr
+Last updated: 2026-04-12
+
+## Known Issues And Operational Caveats
+
+| Area | Current state | Impact | Workaround / next action |
+|------|---------------|--------|--------------------------|
+| Multi-instance rename + `/resume` | Known rough edge | If agents are relaunched in a different order, an instance can reclaim the wrong prior name | Launch instances in the same order when possible, or correct names via the status pills |
+| Native tray + toast validation | No known failing bug, but not fully human-signed-off | Automation is strong, but native Windows behavior still benefits from a real desktop check | Run the manual checks in `desktop-shell-checklist.md` before a broader release |
+| Windows desktop smoke in CI | Not implemented | Regressions rely on local QA discipline instead of CI catching them | Decide whether to keep smoke local-only or add Windows CI coverage |
+| Launcher implementation plan | Functionally superseded, still present as a full build plan | Creates doc drift and can make the current workstream look larger than it is | Archive or shrink `docs/superpowers/plans/2026-04-05-agent-launcher-panel.md` |
+| Electron ownership of port `8300` | Intentional constraint, easy to violate during local testing | Parallel local launches can create confusing startup or shutdown conflicts | Keep Electron as the sole owner of the embedded server during desktop-shell validation |
+
+## What Is Stable
+
+- Core browser/server workflow for multi-agent chat is present and usable
+- Launcher lifecycle behavior is implemented and smoke-covered
+- Desktop shell deep links, tray logic, notifications, and shutdown cleanup have automated coverage
+- Custom-agent stop/delete cleanup now has explicit launcher-facing coverage
+
+## Next Milestones
+
+### 1. Desktop Shell Release Signoff
+
+- Run the optional native Windows spot checks for tray and toast behavior
+- Record the outcome in `release-readiness.md`
+- If the checks stay clean, treat the desktop wrapper as signed off for release-adjacent work
+
+### 2. Launcher Maintenance Cleanup
+
+- Archive or shrink the launcher implementation plan
+- Keep the launcher smoke coverage focused on lifecycle behavior rather than reopening implementation scope
+
+### 3. QA Process Decision
+
+- Decide whether Windows smoke coverage stays local-only or moves into CI
+- If it stays local-only, preserve a clear human-owned release checklist
+
+### 4. Status And Docs Hygiene
+
+- Keep `docs/project-status.md` current after QA runs and release-adjacent fixes
+- Prefer short operational notes over long implementation plans once a feature is in maintenance mode
+
+## References
+
+- `README.md`
+- `docs/project-status.md`
+- `docs/superpowers/qa/desktop-shell-checklist.md`
+- `docs/superpowers/plans/2026-04-05-agent-launcher-panel.md`

--- a/docs/superpowers/qa/release-readiness.md
+++ b/docs/superpowers/qa/release-readiness.md
@@ -1,0 +1,60 @@
+# Release Readiness — Desktop Shell & Launcher
+Last updated: 2026-04-12
+
+## Recommendation
+
+- **Status:** Release candidate
+- **Blocking issues:** None known from the current automated gate
+- **Recommended before a broader Windows release:** Perform a real-desktop spot check for tray icon behavior and native toast presentation
+
+This repo is in a good shipping posture for local and internal use. The launcher implementation is landed, the desktop wrapper is functioning, and the current workspace passes the full local QA gate. The remaining gap is confidence-signoff on native Windows behavior that automation only approximates.
+
+## Verified On 2026-04-12
+
+- `.venv\\Scripts\\python -m pytest tests -q`
+- `node --test tests/launcher_helpers.test.cjs`
+- `npm --prefix electron test`
+- `node --check static/launcher.js`
+- `node --check electron/main.js`
+- `node --check electron/renderer/renderer.js`
+- `npm --prefix electron run smoke:launcher`
+- `npm --prefix electron run smoke:desktop`
+
+## Coverage Confirmed By The Current Gate
+
+- Launcher panel rendering and control flow
+- Duplicate launcher instances with distinct runtime names
+- Restore banner behavior after reload
+- Explicit custom-agent stop and delete flows
+- Deep-link dispatch into an already-running desktop shell
+- Notification badge updates and click handling
+- Tray show/hide/quit behavior
+- Release of port `8300` on Electron shutdown
+- Ports tab render and desktop wrapper startup
+
+## Remaining Manual Signoff
+
+- Verify tray icon behavior on a real Windows desktop session
+- Verify native Windows toast display and click-to-focus behavior
+- Verify a clean shutdown/relaunch cycle after quitting from the tray menu
+
+## Operational Constraints
+
+- Port `8300` must be free before Electron starts
+- The Electron shell should own the embedded `run.py` lifecycle
+- Do not run `windows\\start.bat`, `python run.py`, or another Electron instance alongside the shell you are validating
+
+## Hold Criteria
+
+Do not treat the build as release-ready if any of the following happens:
+
+- `smoke:launcher` or `smoke:desktop` fails
+- Electron leaves `run.py` or port `8300` behind after quit
+- Deep links stop focusing the existing instance
+- Custom agents cannot be stopped and deleted cleanly from the launcher
+
+## Reference Docs
+
+- `docs/superpowers/qa/desktop-shell-checklist.md`
+- `docs/project-status.md`
+- `docs/superpowers/qa/known-issues-next-milestones.md`

--- a/docs/superpowers/specs/2026-04-05-agent-launcher-panel-design.md
+++ b/docs/superpowers/specs/2026-04-05-agent-launcher-panel-design.md
@@ -1,0 +1,265 @@
+# Agent Launcher Panel — Design Spec
+
+## Overview
+
+Add an in-browser agent launcher panel to agentchattr so users can launch, stop, monitor, and configure AI coding agents (Claude, Codex, Gemini, etc.) directly from the web UI — without needing separate terminal windows or batch files.
+
+## Goals
+
+1. Launch any configured agent from the UI with one click
+2. Configure CLI flags (e.g. `--dangerously-skip-permissions`, `--yolo`, `--worktree`) per launch via preset toggles and free-text
+3. Set working directory globally or per-agent
+4. Launch multiple instances of the same agent (e.g. two Claudes with different flags)
+5. View last ~100 lines of agent output (read-only log tail)
+6. Stop running agents from the UI
+7. Add/edit/remove agent definitions from the UI (no config.toml editing required)
+8. On server restart, offer to relaunch agents from the previous session
+
+## Architecture
+
+### Current flow (external launchers)
+
+```
+User double-clicks start_claude.bat
+  -> bat creates venv, starts server if needed
+  -> bat runs: python wrapper.py claude
+  -> wrapper.py registers with server, spawns agent subprocess, runs heartbeat
+  -> agent is online
+```
+
+### New flow (server-managed)
+
+```
+User clicks "Launch" in browser UI
+  -> browser POSTs to /api/agents/<name>/launch with flags, cwd, extra_args
+  -> server spawns wrapper.py as a managed subprocess
+  -> wrapper.py registers, spawns agent, runs heartbeat (same as before)
+  -> server captures wrapper stdout/stderr into a ring buffer (last 100 lines)
+  -> server streams log lines to browser via WebSocket
+  -> user can stop via POST /api/agents/<name>/stop (server kills the wrapper process)
+```
+
+The key insight: the server becomes the process manager for wrappers. The wrappers themselves are unchanged — they still register, heartbeat, and inject keystrokes exactly as they do today. The server just owns their lifecycle instead of a batch file.
+
+### Component breakdown
+
+#### 1. Process Manager (`process_manager.py` — new file)
+
+Responsibilities:
+- Spawn `wrapper.py` subprocesses with configured flags, cwd, and env
+- Capture stdout/stderr into a per-agent ring buffer (100 lines)
+- Track process state: starting, running, crashed, stopped
+- Kill processes on stop request
+- Persist launch configs to `data/launch_state.json` for session restore
+- Provide log lines to the WebSocket broadcast system
+
+State per managed agent:
+```python
+{
+    "name": "claude",           # agent base name
+    "pid": 12345,               # wrapper process PID
+    "state": "running",         # starting | running | crashed | stopped
+    "flags": ["--dangerously-skip-permissions"],
+    "extra_args": [],
+    "cwd": "C:\\AI\\MyProject",
+    "started_at": 1743868800.0,
+    "log_buffer": ["line1", "line2", ...],  # ring buffer, max 100
+}
+```
+
+Key design decisions:
+- One ProcessManager instance, owned by the server (created in `configure()`)
+- Wrapper subprocesses use `subprocess.Popen` with `stdout=PIPE, stderr=STDOUT`
+- A reader thread per process drains stdout and appends to the ring buffer
+- On process exit, state transitions to "crashed" (with exit code) or "stopped" (if user-initiated)
+- No automatic restart from the server side — the user relaunches from the UI
+
+#### 2. REST API endpoints (in `app.py`)
+
+All endpoints require session token (cookie or header).
+
+**Launch:**
+```
+POST /api/agents/<base>/launch
+Body: {
+    "flags": ["--dangerously-skip-permissions"],
+    "extra_args": ["--model", "opus"],
+    "cwd": "C:\\AI\\MyProject",       // optional, falls back to default
+    "instance_label": null             // optional, for multi-instance naming
+}
+Response: { "ok": true, "name": "claude", "pid": 12345 }
+```
+
+**Stop:**
+```
+POST /api/agents/<name>/stop
+Response: { "ok": true }
+```
+Note: `<base>` in launch refers to the agent type (e.g. "claude"); `<name>` in stop refers to the specific instance (e.g. "claude-2"). Stop is a hard kill (SIGTERM then SIGKILL after 5s) — wrapper deregisters on exit, so presence updates immediately.
+
+**Logs:**
+```
+GET /api/agents/<name>/logs
+Response: { "lines": ["line1", "line2", ...] }
+```
+
+**List managed agents:**
+```
+GET /api/agents/managed
+Response: [{ "name": "claude", "state": "running", "pid": 12345, "flags": [...], "cwd": "...", "started_at": ... }, ...]
+```
+
+**Agent definitions (CRUD):**
+```
+GET    /api/agent-definitions          -> list all agent definitions
+POST   /api/agent-definitions          -> add new agent definition
+PUT    /api/agent-definitions/<name>   -> update agent definition
+DELETE /api/agent-definitions/<name>   -> remove agent definition
+```
+
+Agent definitions are stored in `data/agent_definitions.json`. On startup, definitions from `config.toml` are loaded as defaults; user-added definitions are merged in. User-added definitions take precedence over config.toml for the same name.
+
+#### 3. WebSocket events (additions to existing WS protocol)
+
+**Server -> Client:**
+```json
+{"type": "agent_process", "data": {"name": "claude", "state": "running", "pid": 12345, "flags": [...], "cwd": "..."}}
+{"type": "agent_log", "data": {"name": "claude", "line": "Registered as claude (slot 1)"}}
+{"type": "agent_definitions", "data": [{"name": "claude", "command": "claude", "color": "#da7756", ...}]}
+{"type": "session_restore", "data": [{"name": "claude", "flags": [...], "cwd": "...", "base": "claude"}]}
+```
+
+#### 4. Launch State Persistence (`data/launch_state.json`)
+
+On every launch/stop, the process manager writes the current set of running agents and their launch configs:
+
+```json
+[
+    {
+        "base": "claude",
+        "flags": ["--dangerously-skip-permissions"],
+        "extra_args": [],
+        "cwd": "C:\\AI\\MyProject",
+        "instance_label": null
+    },
+    {
+        "base": "codex",
+        "flags": ["--dangerously-bypass-approvals-and-sandbox"],
+        "extra_args": [],
+        "cwd": "C:\\AI\\MyProject",
+        "instance_label": null
+    }
+]
+```
+
+On server restart:
+1. Server reads `data/launch_state.json`
+2. Sends `session_restore` event to the first WebSocket client that connects
+3. Browser shows the restore banner with checkboxes
+4. User selects which agents to relaunch
+5. Browser POSTs `/api/agents/<base>/launch` for each selected agent
+6. Server clears the restore state after the user acts (relaunch or dismiss)
+
+#### 5. Preset Flags (per agent type)
+
+Known flag presets are defined in the server and sent to the UI. Each preset has a label and the actual CLI flag:
+
+```python
+AGENT_FLAG_PRESETS = {
+    "claude": [
+        {"label": "Skip permissions", "flag": "--dangerously-skip-permissions"},
+        {"label": "Worktree", "flag": "--worktree"},
+    ],
+    "codex": [
+        {"label": "Bypass approvals", "flag": "--dangerously-bypass-approvals-and-sandbox"},
+    ],
+    "gemini": [
+        {"label": "Yolo", "flag": "--yolo"},
+        {"label": "Sandbox", "flag": "--sandbox"},
+    ],
+    "qwen": [
+        {"label": "Yolo", "flag": "--yolo"},
+    ],
+}
+```
+
+The UI renders these as toggle buttons. The free-text "Extra Arguments" field handles anything not in the presets.
+
+#### 6. Frontend (`static/launcher.js` — new file)
+
+A new JS module following the same pattern as `jobs.js` and `sessions.js`:
+- Reads from `window`: `ws`, `activeChannel`, `agentConfig`
+- Subscribes to Hub for `agent_process`, `agent_log`, `agent_definitions`, `session_restore` events
+- Renders the launcher panel (slide-out from a new header button, like Jobs/Rules)
+
+Panel structure:
+- **Header**: "Agents" title + "+ Add Agent" button
+- **Agent cards**: one per defined agent, sorted running-first then alphabetical
+  - Running: coloured dot (glowing), name, meta (command, cwd, uptime), flags, Stop/Logs/Launch Another buttons
+  - Stopped: dimmed dot, name, meta, Launch button
+  - Crashed: red dot, name, exit info, Relaunch/Logs buttons
+- **Logs drawer**: collapsible per-agent, shows last 100 lines, auto-scrolls, monospace
+- **Launch config**: expands below a stopped agent's card when "Launch" is clicked
+  - Working directory input (pre-filled with default)
+  - Flag preset toggles (agent-specific)
+  - Extra arguments free-text
+  - "Launch [Agent]" button
+- **"Launch Another" button** on running agents: opens the same launch config form but for a new instance of that agent type
+- **Add Agent form**: name, command, label, colour picker (swatches), MCP mode dropdown. "Save Agent" persists to `data/agent_definitions.json`
+- **Edit/Remove**: available on stopped, user-defined agents
+
+**Session restore banner**: rendered at the top of the chat area (not inside the panel) when `session_restore` event arrives. Checkbox list of previous agents with their flags and cwd. "Relaunch Selected" and "Dismiss" buttons. Disappears after action.
+
+#### 7. Default Working Directory
+
+A new setting in `data/settings.json`:
+```json
+{
+    "default_cwd": "C:\\AI\\MyProject"
+}
+```
+
+Editable from Settings panel. Used as the pre-filled value in all launch config forms. Per-agent cwd overrides this.
+
+#### 8. Multi-Instance Support
+
+When clicking "Launch Another" on a running agent (e.g. Claude):
+1. UI opens the launch config form with the same defaults
+2. User can change flags, cwd, or add an instance label
+3. POST to `/api/agents/claude/launch` — the server spawns another wrapper
+4. Wrapper registers with the server, gets assigned "claude-2" (existing multi-instance logic)
+5. The launcher panel shows both instances as separate cards, grouped under the same agent type header
+
+Instance naming follows existing registry logic: first instance is "claude", second is "claude-2", etc. If instance_label is provided, the wrapper passes it as the `--label` argument.
+
+Card grouping: when multiple instances of the same type are running, they appear as a group with a subtle type header (e.g. "Claude (2 instances)"). Each instance card shows its assigned name ("claude", "claude-2"), its own flags, cwd, and independent Stop/Logs buttons. The "Launch Another" button appears once at the group level.
+
+## Security Considerations
+
+- All launcher API endpoints require session token (enforced by existing middleware)
+- `cwd` is validated to be an existing directory before launch
+- Agent command must match a defined agent (no arbitrary command execution)
+- Subprocess spawning uses argument lists (no `shell=True`)
+- Flag presets are server-defined; free-text args are passed through to the wrapper (which passes them to the CLI)
+- Log buffer is in-memory only (not persisted to disk)
+
+## Files to Create/Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `process_manager.py` | Create | Process lifecycle, log capture, state persistence |
+| `static/launcher.js` | Create | Frontend panel, cards, forms, log viewer |
+| `app.py` | Modify | Add REST endpoints, WS events, wire up ProcessManager |
+| `run.py` | Modify | Create ProcessManager, load launch state, handle restore |
+| `static/chat.js` | Modify | Add header button, wire up launcher panel toggle |
+| `static/index.html` | Modify | Add `<script src="launcher.js">`, panel container div |
+| `static/styles.css` | Modify | Launcher panel styles (or inline in launcher.js) |
+| `data/agent_definitions.json` | Auto-created | User-defined agent configs |
+| `data/launch_state.json` | Auto-created | Previous session state for restore |
+
+## Out of Scope
+
+- Full embedded terminal (xterm.js) — read-only log tail only
+- Agent-to-agent process dependencies (e.g. "start Codex after Claude")
+- Remote agent launching (always localhost)
+- Modifying wrapper.py or wrapper_windows.py — they work as-is

--- a/electron/.gitignore
+++ b/electron/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+config.json
+.superpowers/

--- a/electron/browser-window.js
+++ b/electron/browser-window.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const { BrowserWindow } = require("electron");
+
+let browserWindow = null;
+
+function normaliseBrowserUrl(urlString) {
+  if (typeof urlString !== "string" || !urlString.trim()) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(urlString);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      return null;
+    }
+    return parsed.toString();
+  } catch (_error) {
+    return null;
+  }
+}
+
+function ensureBrowserWindow(parentWindow) {
+  if (browserWindow && !browserWindow.isDestroyed()) {
+    return browserWindow;
+  }
+
+  browserWindow = new BrowserWindow({
+    width: 1280,
+    height: 900,
+    title: "Browser",
+    autoHideMenuBar: true,
+    parent: parentWindow && !parentWindow.isDestroyed?.() ? parentWindow : undefined,
+    webPreferences: {
+      contextIsolation: true,
+      sandbox: true,
+    },
+  });
+
+  browserWindow.on("closed", () => {
+    browserWindow = null;
+  });
+
+  return browserWindow;
+}
+
+function openBrowserWindow(urlString, parentWindow) {
+  const safeUrl = normaliseBrowserUrl(urlString);
+  if (!safeUrl) {
+    return { success: false, error: "URL must start with http:// or https://" };
+  }
+
+  const targetWindow = ensureBrowserWindow(parentWindow);
+  void targetWindow.loadURL(safeUrl);
+  targetWindow.show();
+  targetWindow.focus();
+
+  return { success: true, url: safeUrl };
+}
+
+function _resetBrowserWindowForTests() {
+  browserWindow = null;
+}
+
+module.exports = {
+  normaliseBrowserUrl,
+  openBrowserWindow,
+  _resetBrowserWindowForTests,
+};

--- a/electron/deep-links.js
+++ b/electron/deep-links.js
@@ -141,5 +141,7 @@ function setupDeepLinks(app, mainWindow) {
 }
 
 module.exports = {
+  extractDeepLinkUrl,
+  parseDeepLink,
   setupDeepLinks,
 };

--- a/electron/deep-links.js
+++ b/electron/deep-links.js
@@ -1,0 +1,145 @@
+const { URL } = require('url');
+
+const PROTOCOL = 'agentchattr';
+
+let hasSingleInstanceLock = null;
+let secondInstanceListener = null;
+
+function resolveMainWindow(mainWindow) {
+  return typeof mainWindow === 'function' ? mainWindow() : mainWindow;
+}
+
+function extractDeepLinkUrl(argv) {
+  if (!Array.isArray(argv)) {
+    return null;
+  }
+
+  return (
+    argv.find(
+      (value) => typeof value === 'string' && value.startsWith(`${PROTOCOL}://`)
+    ) ?? null
+  );
+}
+
+function parseDeepLink(urlString) {
+  if (typeof urlString !== 'string' || !urlString.startsWith(`${PROTOCOL}://`)) {
+    return null;
+  }
+
+  let parsedUrl;
+
+  try {
+    parsedUrl = new URL(urlString);
+  } catch (error) {
+    console.warn(`Failed to parse deep link URL: ${urlString}`, error);
+    return null;
+  }
+
+  const type = parsedUrl.hostname;
+  const value = decodeURIComponent(parsedUrl.pathname.replace(/^\/+/, ''));
+
+  if (!value) {
+    return null;
+  }
+
+  if (type === 'channel' || type === 'agent') {
+    return { type, value };
+  }
+
+  if (type === 'port') {
+    const port = Number(value);
+
+    if (Number.isInteger(port) && port > 0) {
+      return { type, value: port };
+    }
+  }
+
+  return null;
+}
+
+function showAndFocusWindow(mainWindow) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  if (typeof mainWindow.isMinimized === 'function' && mainWindow.isMinimized()) {
+    mainWindow.restore();
+  }
+
+  mainWindow.show();
+  mainWindow.focus();
+}
+
+function dispatchDeepLink(mainWindow, payload) {
+  if (!payload) {
+    return;
+  }
+
+  const window = resolveMainWindow(mainWindow);
+
+  if (!window || window.isDestroyed()) {
+    return;
+  }
+
+  const { webContents } = window;
+
+  if (
+    !webContents ||
+    (typeof webContents.isDestroyed === 'function' && webContents.isDestroyed())
+  ) {
+    return;
+  }
+
+  webContents.send('deep-link', payload);
+  showAndFocusWindow(window);
+}
+
+function ensureSingleInstanceLock(app) {
+  if (hasSingleInstanceLock !== null) {
+    return hasSingleInstanceLock;
+  }
+
+  hasSingleInstanceLock = app.requestSingleInstanceLock();
+
+  if (!hasSingleInstanceLock) {
+    app.quit();
+  }
+
+  return hasSingleInstanceLock;
+}
+
+function setupDeepLinks(app, mainWindow) {
+  if (!ensureSingleInstanceLock(app)) {
+    return false;
+  }
+
+  app.setAsDefaultProtocolClient(PROTOCOL);
+
+  if (secondInstanceListener) {
+    app.removeListener('second-instance', secondInstanceListener);
+  }
+
+  secondInstanceListener = (_event, argv) => {
+    const urlString = extractDeepLinkUrl(argv);
+
+    if (!urlString) {
+      return;
+    }
+
+    const payload = parseDeepLink(urlString);
+
+    if (!payload) {
+      return;
+    }
+
+    dispatchDeepLink(mainWindow, payload);
+  };
+
+  app.on('second-instance', secondInstanceListener);
+
+  return true;
+}
+
+module.exports = {
+  setupDeepLinks,
+};

--- a/electron/desktop-command-bridge.js
+++ b/electron/desktop-command-bridge.js
@@ -1,0 +1,23 @@
+"use strict";
+
+function handleDesktopCommand(data, sendToHost) {
+  if (!data || typeof data !== "object" || data.type !== "desktop_command") {
+    return false;
+  }
+
+  const payload = data.data;
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  if (payload.command !== "browser_open" || typeof payload.url !== "string") {
+    return false;
+  }
+
+  sendToHost("desktop-command", payload);
+  return true;
+}
+
+module.exports = {
+  handleDesktopCommand,
+};

--- a/electron/dialogs.js
+++ b/electron/dialogs.js
@@ -1,0 +1,17 @@
+const { dialog, ipcMain } = require('electron');
+
+function resolveMainWindow(mainWindow) {
+  return typeof mainWindow === 'function' ? mainWindow() : mainWindow;
+}
+
+function setupDialogs(mainWindow) {
+  ipcMain.removeHandler('show-open-dialog');
+
+  ipcMain.handle('show-open-dialog', (_event, options = {}) => {
+    return dialog.showOpenDialog(resolveMainWindow(mainWindow), options);
+  });
+}
+
+module.exports = {
+  setupDialogs,
+};

--- a/electron/main.js
+++ b/electron/main.js
@@ -257,10 +257,6 @@ function startServer(pythonPath) {
 function wireModules() {
   if (!mainWindow) return;
 
-  // Preferences (H-1 fix: this replaces the duplicate handlers from registerIpcHandlers)
-  const { createPreferences } = require("./preferences");
-  preferences = createPreferences();
-
   // Dialogs
   const { setupDialogs } = require("./dialogs");
   setupDialogs(mainWindow);
@@ -291,6 +287,11 @@ function wireModules() {
 
 app.whenReady().then(() => {
   registerIpcHandlers();
+
+  if (!preferences) {
+    const { createPreferences } = require("./preferences");
+    preferences = createPreferences();
+  }
 
   const pythonPath = findPythonPath();
   if (!pythonPath) {

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,318 @@
+const { app, BrowserWindow, dialog, ipcMain } = require("electron");
+const { spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const net = require("net");
+const { pathToFileURL } = require("url");
+
+// --- Constants (CASK: Constants first) ---
+const REPO_ROOT = path.resolve(__dirname, "..");
+const SERVER_PORT = 8300;
+const PYTHON_PATH = path.join(REPO_ROOT, ".venv", "Scripts", "python.exe");
+const RENDERER_ENTRY = path.join(__dirname, "renderer", "index.html");
+const READY_SIGNAL = "Uvicorn running on";
+const FORCE_KILL_DELAY_MS = 5000;
+
+// --- State ---
+let mainWindow = null;
+let serverProcess = null;
+let serverReady = false;
+let serverExited = false;
+let isQuitting = false;
+let forceKillTimer = null;
+let stdoutBuffer = "";
+let stderrBuffer = "";
+let trayInstance = null;
+let preferences = null;
+
+// --- Single-instance lock (must happen before app.whenReady) ---
+// H-4 fix: acquire lock synchronously at module load
+const { setupDeepLinks } = require("./deep-links");
+const gotLock = app.requestSingleInstanceLock();
+if (!gotLock) {
+  app.quit();
+}
+
+function findPythonPath() {
+  return fs.existsSync(PYTHON_PATH) ? PYTHON_PATH : null;
+}
+
+function registerIpcHandlers() {
+  // Pop-out handler — echoes request back to renderer
+  ipcMain.on("pop-out", (_event, view) => {
+    if (!mainWindow || !view) return;
+    mainWindow.webContents.send("notification", {
+      type: "pop-out-requested",
+      view,
+    });
+  });
+
+  // H-6 fix: validate PID before calling process.kill()
+  ipcMain.handle("kill-process", async (_event, pid) => {
+    const safePid = Number.isInteger(pid) && pid > 0 ? pid : null;
+    if (!safePid) return { success: false, error: "Invalid PID" };
+    try {
+      process.kill(safePid);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+
+  // H-1 fix: Do NOT register get-preference, set-preference, or show-open-dialog here.
+  // Those are handled by preferences.js and dialogs.js respectively.
+
+  // Forwarded notification from renderer (webview ipc-message bridge)
+  // H-2 fix: renderer forwards webview 'send-notification' here
+  ipcMain.on("send-notification", (_event, payload) => {
+    // Handled by notifications.js — this is a fallback in case notifications
+    // module hasn't registered yet. The notifications module uses removeListener
+    // before re-registering, so this won't conflict.
+  });
+}
+
+function createWindow() {
+  if (mainWindow) {
+    mainWindow.show();
+    return;
+  }
+
+  const bounds = preferences
+    ? preferences.get("windowBounds")
+    : { width: 1200, height: 800 };
+
+  mainWindow = new BrowserWindow({
+    width: bounds.width || 1200,
+    height: bounds.height || 800,
+    x: bounds.x,
+    y: bounds.y,
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      webviewTag: true,
+    },
+  });
+
+  mainWindow.loadURL(pathToFileURL(RENDERER_ENTRY).toString());
+
+  mainWindow.on("close", (event) => {
+    if (isQuitting) return;
+    event.preventDefault();
+    mainWindow.hide();
+  });
+
+  // Save window bounds on move/resize
+  const saveBounds = () => {
+    if (preferences && mainWindow && !mainWindow.isDestroyed()) {
+      preferences.set("windowBounds", mainWindow.getBounds());
+    }
+  };
+  mainWindow.on("moved", saveBounds);
+  mainWindow.on("resized", saveBounds);
+
+  mainWindow.on("closed", () => {
+    mainWindow = null;
+  });
+}
+
+function waitForServerPort(
+  port,
+  host = "127.0.0.1",
+  retries = 40,
+  delayMs = 250,
+) {
+  return new Promise((resolve, reject) => {
+    let attemptsRemaining = retries;
+    const tryConnect = () => {
+      const socket = net.createConnection({ host, port });
+      socket.once("connect", () => {
+        socket.end();
+        resolve();
+      });
+      socket.once("error", () => {
+        socket.destroy();
+        attemptsRemaining -= 1;
+        if (attemptsRemaining <= 0) {
+          reject(new Error(`Timed out waiting for ${host}:${port}`));
+          return;
+        }
+        setTimeout(tryConnect, delayMs);
+      });
+    };
+    tryConnect();
+  });
+}
+
+function showStartupError(message) {
+  dialog.showErrorBox("agentchattr desktop", message);
+}
+
+async function handleReadySignal() {
+  if (serverReady) return;
+  serverReady = true;
+  try {
+    await waitForServerPort(SERVER_PORT);
+    createWindow();
+    wireModules();
+  } catch (error) {
+    showStartupError(
+      `The Python server reported ready, but port ${SERVER_PORT} never opened.\n\n${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    app.quit();
+  }
+}
+
+function handleServerOutput(chunk, streamName) {
+  const text = chunk.toString();
+  const currentBuffer = streamName === "stdout" ? stdoutBuffer : stderrBuffer;
+  const nextBuffer = currentBuffer + text;
+  const lines = nextBuffer.split(/\r?\n/);
+  const remainder = lines.pop() ?? "";
+  if (streamName === "stdout") {
+    stdoutBuffer = remainder;
+  } else {
+    stderrBuffer = remainder;
+  }
+  for (const line of lines) {
+    if (line.includes(READY_SIGNAL)) {
+      void handleReadySignal();
+    }
+  }
+}
+
+function shutdownServer() {
+  if (!serverProcess || serverExited) return;
+  // H-5 fix: on Windows, use taskkill for graceful shutdown instead of SIGTERM
+  // (SIGTERM is silently coerced to SIGKILL on Windows by Node.js)
+  if (process.platform === "win32") {
+    const { execFile } = require("child_process");
+    // taskkill /T kills the process tree (Python + uvicorn workers)
+    execFile(
+      "taskkill",
+      ["/PID", String(serverProcess.pid), "/T", "/F"],
+      (err) => {
+        if (err) console.warn("taskkill failed:", err);
+      },
+    );
+  } else {
+    try {
+      serverProcess.kill("SIGTERM");
+    } catch (e) {
+      console.warn("SIGTERM failed:", e);
+    }
+    forceKillTimer = setTimeout(() => {
+      if (!serverProcess || serverExited) return;
+      try {
+        serverProcess.kill("SIGKILL");
+      } catch (e) {
+        console.warn("SIGKILL failed:", e);
+      }
+    }, FORCE_KILL_DELAY_MS);
+  }
+}
+
+function startServer(pythonPath) {
+  serverExited = false;
+  serverProcess = spawn(pythonPath, ["run.py"], {
+    cwd: REPO_ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  serverProcess.stdout.on("data", (chunk) =>
+    handleServerOutput(chunk, "stdout"),
+  );
+  serverProcess.stderr.on("data", (chunk) =>
+    handleServerOutput(chunk, "stderr"),
+  );
+
+  serverProcess.once("error", (error) => {
+    showStartupError(
+      `Failed to launch the Python server with ${pythonPath}.\n\n${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    app.quit();
+  });
+
+  serverProcess.once("exit", (code, signal) => {
+    serverExited = true;
+    if (forceKillTimer) {
+      clearTimeout(forceKillTimer);
+      forceKillTimer = null;
+    }
+    if (!serverReady && !isQuitting) {
+      showStartupError(
+        `The Python server exited before becoming ready.\n\nExit code: ${code ?? "null"}\nSignal: ${signal ?? "null"}`,
+      );
+      app.quit();
+    }
+  });
+}
+
+// C-3 fix: wire all satellite modules after window creation
+function wireModules() {
+  if (!mainWindow) return;
+
+  // Preferences (H-1 fix: this replaces the duplicate handlers from registerIpcHandlers)
+  const { createPreferences } = require("./preferences");
+  preferences = createPreferences();
+
+  // Dialogs
+  const { setupDialogs } = require("./dialogs");
+  setupDialogs(mainWindow);
+
+  // System tray
+  const { createTray } = require("./tray");
+  trayInstance = createTray(mainWindow);
+
+  // Notifications (needs tray for badge)
+  const { setupNotifications } = require("./notifications");
+  setupNotifications(mainWindow, trayInstance);
+
+  // Port scanner
+  const { startScanning } = require("./port-scanner");
+  const scanInterval = preferences.get("portScanInterval") || 5000;
+  startScanning(mainWindow, scanInterval);
+
+  // Global shortcuts
+  const { registerShortcuts } = require("./shortcuts");
+  registerShortcuts(mainWindow, preferences);
+
+  // Deep links — already acquired single-instance lock above,
+  // now wire the second-instance event handler
+  // C-4 fix: deep-links.js sends raw URL string, renderer parses it
+  // (deep-links.js already sends { type, value } object — renderer needs to handle that)
+  setupDeepLinks(app, () => mainWindow);
+}
+
+app.whenReady().then(() => {
+  registerIpcHandlers();
+
+  const pythonPath = findPythonPath();
+  if (!pythonPath) {
+    showStartupError(
+      `Python was not found at:\n${PYTHON_PATH}\n\nCreate the project virtualenv before starting the desktop wrapper.`,
+    );
+    app.quit();
+    return;
+  }
+
+  startServer(pythonPath);
+});
+
+app.on("before-quit", () => {
+  isQuitting = true;
+  const { stopScanning } = require("./port-scanner");
+  stopScanning();
+  const { unregisterAll } = require("./shortcuts");
+  unregisterAll();
+  shutdownServer();
+});
+
+app.on("window-all-closed", () => {
+  // Don't quit — tray keeps the app alive
+});

--- a/electron/main.js
+++ b/electron/main.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const net = require("net");
 const { pathToFileURL } = require("url");
+const { openBrowserWindow } = require("./browser-window");
 
 // --- Constants (CASK: Constants first) ---
 const REPO_ROOT = path.resolve(__dirname, "..");
@@ -60,6 +61,10 @@ function registerIpcHandlers() {
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  });
+
+  ipcMain.handle("open-browser-url", async (_event, url) => {
+    return openBrowserWindow(url, mainWindow);
   });
 
   // H-1 fix: Do NOT register get-preference, set-preference, or show-open-dialog here.

--- a/electron/notifications.js
+++ b/electron/notifications.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+const path = require('path');
+const { Notification, ipcMain, nativeImage } = require('electron');
+
+const ICON_PATH = path.join(__dirname, 'assets', 'icon.png');
+const FALLBACK_COLOUR = '#da7756';
+
+let unreadCount = 0;
+let registeredWindow = null;
+let notificationListener = null;
+let focusListener = null;
+
+function createSvgDataUrl(svgMarkup) {
+  return `data:image/svg+xml;base64,${Buffer.from(svgMarkup).toString('base64')}`;
+}
+
+function createFallbackIcon() {
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+      <rect width="32" height="32" rx="6" ry="6" fill="${FALLBACK_COLOUR}" />
+    </svg>
+  `;
+
+  return nativeImage.createFromDataURL(createSvgDataUrl(svg));
+}
+
+function buildNotificationOptions(title, body) {
+  const options = {
+    title,
+    body,
+  };
+
+  if (fs.existsSync(ICON_PATH)) {
+    options.icon = ICON_PATH;
+  } else {
+    options.icon = createFallbackIcon();
+  }
+
+  return options;
+}
+
+function updateBadge(trayModule, count) {
+  if (trayModule && typeof trayModule.setBadge === 'function') {
+    trayModule.setBadge(count);
+  }
+}
+
+function resetUnreadCount(trayModule) {
+  unreadCount = 0;
+  updateBadge(trayModule, 0);
+}
+
+function setupNotifications(mainWindow, trayModule) {
+  if (registeredWindow && focusListener) {
+    registeredWindow.removeListener('focus', focusListener);
+  }
+
+  registeredWindow = mainWindow ?? null;
+  focusListener = () => {
+    resetUnreadCount(trayModule);
+  };
+
+  if (registeredWindow && !registeredWindow.isDestroyed()) {
+    registeredWindow.on('focus', focusListener);
+  }
+
+  if (notificationListener) {
+    ipcMain.removeListener('send-notification', notificationListener);
+  }
+
+  notificationListener = (_event, payload = {}) => {
+    const {
+      title = 'agentchattr',
+      body = '',
+      channel = null,
+    } = payload && typeof payload === 'object' ? payload : {};
+
+    unreadCount += 1;
+    updateBadge(trayModule, unreadCount);
+
+    const notification = new Notification(buildNotificationOptions(title, body));
+
+    notification.on('click', () => {
+      if (!registeredWindow || registeredWindow.isDestroyed()) {
+        return;
+      }
+
+      registeredWindow.show();
+      registeredWindow.focus();
+
+      if (
+        registeredWindow.webContents &&
+        typeof registeredWindow.webContents.isDestroyed === 'function' &&
+        !registeredWindow.webContents.isDestroyed()
+      ) {
+        registeredWindow.webContents.send('focus-channel', channel);
+      }
+    });
+
+    notification.show();
+  };
+
+  ipcMain.on('send-notification', notificationListener);
+}
+
+module.exports = {
+  setupNotifications,
+};

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,0 +1,1100 @@
+{
+  "name": "agentchattr-desktop",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agentchattr-desktop",
+      "dependencies": {
+        "electron": "^35.0.0",
+        "electron-store": "^8.2.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/atomically": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
+      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
+        "atomically": "^1.7.0",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^6.0.1",
+        "env-paths": "^2.2.1",
+        "json-schema-typed": "^7.0.3",
+        "onetime": "^5.1.2",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/debounce-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron": {
+      "version": "35.7.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
+      "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-store": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.2.0.tgz",
+      "integrity": "sha512-ukLL5Bevdil6oieAOXz3CMy+OgaItMiVBg701MNlG6W5RaC0AHN7rvlqTCmeb6O7jP0Qa1KKYTE0xV0xbhF4Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "conf": "^10.2.0",
+        "type-fest": "^2.17.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -8,6 +8,9 @@
       "dependencies": {
         "electron": "^35.0.0",
         "electron-store": "^8.2.0"
+      },
+      "devDependencies": {
+        "playwright-core": "^1.59.1"
       }
     },
     "node_modules/@electron/get": {
@@ -911,6 +914,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/progress": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "agentchattr-desktop",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^35.0.0",
+    "electron-store": "^8.2.0"
+  }
+}

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,10 +2,16 @@
   "name": "agentchattr-desktop",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "test": "node --test qa/*.test.cjs",
+    "smoke:launcher": "node qa/launcher-smoke.cjs",
+    "smoke:desktop": "node qa/desktop-smoke.cjs"
   },
   "dependencies": {
     "electron": "^35.0.0",
     "electron-store": "^8.2.0"
+  },
+  "devDependencies": {
+    "playwright-core": "^1.59.1"
   }
 }

--- a/electron/port-scanner.js
+++ b/electron/port-scanner.js
@@ -1,0 +1,400 @@
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_INTERVAL_MS = 5000;
+const NETSTAT_ARGS = ['-ano'];
+const AGENTS_API_URL = 'http://127.0.0.1:8300/api/agents';
+const KNOWN_AGENTCHATTR_PORTS = new Set([8200, 8201, 8300]);
+const MAX_HISTORY_ENTRIES = 100;
+const NETSTAT_BUFFER_BYTES = 10 * 1024 * 1024;
+const TASKLIST_BUFFER_BYTES = 1024 * 1024;
+
+let scanTimer = null;
+let scanInFlight = false;
+let targetWindow = null;
+let previousPortsByKey = new Map();
+let processNameCache = new Map();
+const history = [];
+
+function parseEndpoint(endpoint) {
+  if (!endpoint) {
+    return null;
+  }
+
+  if (endpoint.startsWith('[')) {
+    const separatorIndex = endpoint.lastIndexOf(']:');
+
+    if (separatorIndex === -1) {
+      return null;
+    }
+
+    const address = endpoint.slice(1, separatorIndex);
+    const port = parseInt(endpoint.slice(separatorIndex + 2), 10);
+
+    if (Number.isNaN(port)) {
+      return null;
+    }
+
+    return { address, port };
+  }
+
+  const separatorIndex = endpoint.lastIndexOf(':');
+
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  const address = endpoint.slice(0, separatorIndex);
+  const port = parseInt(endpoint.slice(separatorIndex + 1), 10);
+
+  if (Number.isNaN(port)) {
+    return null;
+  }
+
+  return { address, port };
+}
+
+function parseNetstatLine(line) {
+  const parts = line.trim().split(/\s+/);
+
+  if (parts.length < 5) {
+    return null;
+  }
+
+  const [protocol, localEndpoint, , state, rawPid] = parts;
+
+  if (state !== 'LISTENING') {
+    return null;
+  }
+
+  const endpoint = parseEndpoint(localEndpoint);
+
+  if (!endpoint) {
+    return null;
+  }
+
+  const pid = parseInt(rawPid, 10);
+
+  if (Number.isNaN(pid)) {
+    return null;
+  }
+
+  return {
+    protocol,
+    address: endpoint.address,
+    port: endpoint.port,
+    pid,
+  };
+}
+
+function parseTasklistProcessName(stdout) {
+  const firstLine = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  if (!firstLine || firstLine.startsWith('INFO:')) {
+    return null;
+  }
+
+  const match = firstLine.match(/^"((?:[^"]|"")*)"/);
+
+  if (!match) {
+    return null;
+  }
+
+  return match[1].replace(/""/g, '"');
+}
+
+function normaliseToken(value) {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/\.exe$/i, '')
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+function portKey(entry) {
+  return `${entry.protocol}|${entry.address}|${entry.port}|${entry.pid}`;
+}
+
+function pushHistoryEntry(entry) {
+  history.push(entry);
+
+  while (history.length > MAX_HISTORY_ENTRIES) {
+    history.shift();
+  }
+}
+
+function isWindowAvailable(mainWindow) {
+  if (!mainWindow) {
+    return false;
+  }
+
+  if (typeof mainWindow.isDestroyed === 'function' && mainWindow.isDestroyed()) {
+    return false;
+  }
+
+  if (!mainWindow.webContents) {
+    return false;
+  }
+
+  if (
+    typeof mainWindow.webContents.isDestroyed === 'function' &&
+    mainWindow.webContents.isDestroyed()
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+async function scanPorts() {
+  const { stdout } = await execFileAsync('netstat', NETSTAT_ARGS, {
+    maxBuffer: NETSTAT_BUFFER_BYTES,
+    windowsHide: true,
+  });
+
+  return stdout
+    .split(/\r?\n/)
+    .filter((line) => line.includes('LISTENING'))
+    .map(parseNetstatLine)
+    .filter(Boolean);
+}
+
+async function lookupProcessName(pid) {
+  const safePid = parseInt(pid, 10);
+
+  if (Number.isNaN(safePid)) {
+    return 'Unknown';
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      'tasklist',
+      ['/FI', `PID eq ${safePid}`, '/FO', 'CSV', '/NH'],
+      {
+        maxBuffer: TASKLIST_BUFFER_BYTES,
+        windowsHide: true,
+      }
+    );
+
+    return parseTasklistProcessName(stdout) ?? 'Unknown';
+  } catch (error) {
+    console.warn(`Failed to resolve process name for PID ${safePid}:`, error);
+    return 'Unknown';
+  }
+}
+
+async function resolveProcessNames(ports) {
+  const activePids = new Set();
+
+  for (const entry of ports) {
+    if (Number.isInteger(entry.pid)) {
+      activePids.add(entry.pid);
+    }
+  }
+
+  // Drop vanished PIDs so reused Windows PIDs do not keep stale names.
+  for (const cachedPid of Array.from(processNameCache.keys())) {
+    if (!activePids.has(cachedPid)) {
+      processNameCache.delete(cachedPid);
+    }
+  }
+
+  const uncachedPids = Array.from(activePids).filter((pid) => !processNameCache.has(pid));
+
+  await Promise.all(
+    uncachedPids.map(async (pid) => {
+      processNameCache.set(pid, await lookupProcessName(pid));
+    })
+  );
+
+  return ports.map((entry) => ({
+    ...entry,
+    processName: processNameCache.get(entry.pid) ?? 'Unknown',
+  }));
+}
+
+function findAgentMatch(processName, agents) {
+  const processToken = normaliseToken(processName);
+
+  if (!processToken) {
+    return null;
+  }
+
+  for (const [agentName, details] of Object.entries(agents)) {
+    const nameToken = normaliseToken(agentName);
+    const labelToken = normaliseToken(details?.label);
+
+    if (
+      (nameToken && (processToken.includes(nameToken) || nameToken.includes(processToken))) ||
+      (labelToken && (processToken.includes(labelToken) || labelToken.includes(processToken)))
+    ) {
+      return {
+        agent: agentName,
+        agentColour: details?.color ?? details?.colour ?? null,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function fetchRegisteredAgents() {
+  try {
+    const response = await fetch(AGENTS_API_URL);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const payload = await response.json();
+
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return null;
+    }
+
+    return payload;
+  } catch (error) {
+    console.warn('Failed to fetch registered agents:', error);
+    return null;
+  }
+}
+
+async function tagAgentPorts(ports) {
+  const registeredAgents = await fetchRegisteredAgents();
+  const agentchattrColour =
+    registeredAgents?.agentchattr?.color ?? registeredAgents?.agentchattr?.colour ?? null;
+
+  return ports.map((entry) => {
+    if (KNOWN_AGENTCHATTR_PORTS.has(entry.port)) {
+      return {
+        ...entry,
+        agent: 'agentchattr',
+        agentColour: agentchattrColour,
+      };
+    }
+
+    const matchedAgent = registeredAgents
+      ? findAgentMatch(entry.processName, registeredAgents)
+      : null;
+
+    if (matchedAgent) {
+      return {
+        ...entry,
+        ...matchedAgent,
+      };
+    }
+
+    return {
+      ...entry,
+      agent: 'System',
+      agentColour: null,
+    };
+  });
+}
+
+function updateHistory(currentPorts) {
+  const currentPortsByKey = new Map(currentPorts.map((entry) => [portKey(entry), entry]));
+  const timestamp = Date.now();
+
+  for (const [key, entry] of currentPortsByKey.entries()) {
+    if (!previousPortsByKey.has(key)) {
+      pushHistoryEntry({
+        type: 'open',
+        port: entry.port,
+        pid: entry.pid,
+        processName: entry.processName ?? 'Unknown',
+        agent: entry.agent ?? null,
+        timestamp,
+      });
+    }
+  }
+
+  for (const [key, entry] of previousPortsByKey.entries()) {
+    if (!currentPortsByKey.has(key)) {
+      pushHistoryEntry({
+        type: 'close',
+        port: entry.port,
+        pid: entry.pid,
+        processName: entry.processName ?? 'Unknown',
+        agent: entry.agent ?? null,
+        timestamp,
+      });
+    }
+  }
+
+  previousPortsByKey = currentPortsByKey;
+}
+
+async function performScanCycle() {
+  if (scanInFlight) {
+    return;
+  }
+
+  scanInFlight = true;
+
+  try {
+    let scannedPorts;
+
+    try {
+      scannedPorts = await scanPorts();
+    } catch (error) {
+      console.error('Failed to scan listening ports:', error);
+      return;
+    }
+
+    const portsWithNames = await resolveProcessNames(scannedPorts);
+    const taggedPorts = await tagAgentPorts(portsWithNames);
+
+    updateHistory(taggedPorts);
+
+    if (isWindowAvailable(targetWindow)) {
+      targetWindow.webContents.send('port-data', {
+        ports: taggedPorts,
+        history: getHistory(),
+      });
+    }
+  } catch (error) {
+    console.error('Port scanning cycle failed:', error);
+  } finally {
+    scanInFlight = false;
+  }
+}
+
+function startScanning(mainWindow, intervalMs = DEFAULT_INTERVAL_MS) {
+  stopScanning();
+
+  targetWindow = mainWindow ?? null;
+
+  const safeIntervalMs =
+    Number.isFinite(intervalMs) && intervalMs > 0 ? intervalMs : DEFAULT_INTERVAL_MS;
+
+  void performScanCycle();
+
+  scanTimer = setInterval(() => {
+    void performScanCycle();
+  }, safeIntervalMs);
+}
+
+function stopScanning() {
+  if (scanTimer) {
+    clearInterval(scanTimer);
+    scanTimer = null;
+  }
+
+  targetWindow = null;
+}
+
+function getHistory() {
+  return history.slice();
+}
+
+module.exports = {
+  startScanning,
+  stopScanning,
+  getHistory,
+};

--- a/electron/preferences.js
+++ b/electron/preferences.js
@@ -1,0 +1,61 @@
+const { ipcMain } = require("electron");
+const ElectronStore = require("electron-store");
+
+const DEFAULT_SHORTCUT = "CommandOrControl+Shift+A";
+
+const schema = {
+  closeBehaviour: {
+    type: "string",
+    enum: ["ask", "tray", "quit"],
+    default: "ask",
+  },
+  windowBounds: {
+    type: "object",
+    properties: {
+      width: {
+        type: "number",
+      },
+      height: {
+        type: "number",
+      },
+    },
+    default: {
+      width: 1200,
+      height: 800,
+    },
+  },
+  globalShortcut: {
+    type: "string",
+    default: DEFAULT_SHORTCUT,
+  },
+  portScanInterval: {
+    type: "number",
+    default: 5000,
+  },
+  poppedOutWindows: {
+    type: "array",
+    default: [],
+  },
+};
+
+function createPreferences() {
+  const store = new ElectronStore({ schema });
+
+  ipcMain.removeHandler("get-preference");
+  ipcMain.removeHandler("set-preference");
+
+  ipcMain.handle("get-preference", (_event, key) => {
+    return store.get(key);
+  });
+
+  ipcMain.handle("set-preference", (_event, key, value) => {
+    store.set(key, value);
+    return value;
+  });
+
+  return store;
+}
+
+module.exports = {
+  createPreferences,
+};

--- a/electron/preload-webview.js
+++ b/electron/preload-webview.js
@@ -1,13 +1,22 @@
 'use strict';
 
 const { ipcRenderer } = require('electron');
+const { handleDesktopCommand } = require('./desktop-command-bridge');
 
 function sendNotification(payload) {
   ipcRenderer.sendToHost('send-notification', payload);
 }
 
+function sendDesktopCommand(_channel, payload) {
+  ipcRenderer.sendToHost('desktop-command', payload);
+}
+
 function checkForNotification(data) {
   if (!data || typeof data !== 'object') {
+    return;
+  }
+
+  if (handleDesktopCommand(data, sendDesktopCommand)) {
     return;
   }
 

--- a/electron/preload-webview.js
+++ b/electron/preload-webview.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const { ipcRenderer } = require('electron');
+
+function sendNotification(payload) {
+  ipcRenderer.sendToHost('send-notification', payload);
+}
+
+function checkForNotification(data) {
+  if (!data || typeof data !== 'object') {
+    return;
+  }
+
+  if (data.type === 'message') {
+    const body = typeof data.body === 'string' ? data.body : '';
+
+    if (body.includes('@user') || body.includes('@all')) {
+      sendNotification({
+        title: `${data.sender} mentioned you`,
+        body: body.substring(0, 100),
+        channel: data.channel,
+      });
+    }
+
+    return;
+  }
+
+  if (data.type === 'agent_log') {
+    const line = typeof data.line === 'string' ? data.line : '';
+
+    if (/error|crash|exception/i.test(line)) {
+      sendNotification({
+        title: `Agent ${data.name} error`,
+        body: line.substring(0, 100),
+      });
+    }
+
+    return;
+  }
+
+  if (data.type === 'job_update' && ['completed', 'failed'].includes(data.status)) {
+    sendNotification({
+      title: `Job ${data.status}`,
+      body: data.job_name || 'Unknown job',
+    });
+  }
+}
+
+function addSocketMessageListener(socket) {
+  socket.addEventListener('message', (event) => {
+    if (typeof event.data !== 'string') {
+      return;
+    }
+
+    try {
+      const data = JSON.parse(event.data);
+      checkForNotification(data);
+    } catch (error) {
+      // Ignore non-JSON frames to preserve native behaviour.
+    }
+  });
+}
+
+function installWebSocketInterceptor() {
+  const OrigWebSocket = window.WebSocket;
+
+  if (typeof OrigWebSocket !== 'function') {
+    return;
+  }
+
+  function WrappedWebSocket(...args) {
+    const socket = new OrigWebSocket(...args);
+    addSocketMessageListener(socket);
+    return socket;
+  }
+
+  WrappedWebSocket.CONNECTING = OrigWebSocket.CONNECTING;
+  WrappedWebSocket.OPEN = OrigWebSocket.OPEN;
+  WrappedWebSocket.CLOSING = OrigWebSocket.CLOSING;
+  WrappedWebSocket.CLOSED = OrigWebSocket.CLOSED;
+  WrappedWebSocket.prototype = OrigWebSocket.prototype;
+
+  Object.setPrototypeOf(WrappedWebSocket, OrigWebSocket);
+
+  window.WebSocket = WrappedWebSocket;
+}
+
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', installWebSocketInterceptor, { once: true });
+} else {
+  installWebSocketInterceptor();
+}

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,32 @@
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("electronAPI", {
+  onPortData(callback) {
+    ipcRenderer.on("port-data", (_event, data) => callback(data));
+  },
+  onNotification(callback) {
+    ipcRenderer.on("notification", (_event, data) => callback(data));
+  },
+  onDeepLink(callback) {
+    ipcRenderer.on("deep-link", (_event, url) => callback(url));
+  },
+  // H-2 fix: forward webview notifications to main process
+  sendNotification(payload) {
+    ipcRenderer.send("send-notification", payload);
+  },
+  requestPopOut(view) {
+    ipcRenderer.send("pop-out", view);
+  },
+  killProcess(pid) {
+    return ipcRenderer.invoke("kill-process", pid);
+  },
+  getPreference(key) {
+    return ipcRenderer.invoke("get-preference", key);
+  },
+  setPreference(key, value) {
+    return ipcRenderer.invoke("set-preference", key, value);
+  },
+  showOpenDialog(options) {
+    return ipcRenderer.invoke("show-open-dialog", options);
+  },
+});

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -10,6 +10,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onDeepLink(callback) {
     ipcRenderer.on("deep-link", (_event, url) => callback(url));
   },
+  onFocusChannel(callback) {
+    ipcRenderer.on("focus-channel", (_event, channel) => callback(channel));
+  },
   // H-2 fix: forward webview notifications to main process
   sendNotification(payload) {
     ipcRenderer.send("send-notification", payload);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -20,6 +20,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
   requestPopOut(view) {
     ipcRenderer.send("pop-out", view);
   },
+  openBrowserUrl(url) {
+    return ipcRenderer.invoke("open-browser-url", url);
+  },
   killProcess(pid) {
     return ipcRenderer.invoke("kill-process", pid);
   },

--- a/electron/qa/browser-pane-state.test.cjs
+++ b/electron/qa/browser-pane-state.test.cjs
@@ -1,0 +1,81 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  createBrowserPaneState,
+  normaliseBrowserTarget,
+  reduceBrowserCommand,
+  popoutBrowserPane,
+  closeBrowserPane,
+} = require("../renderer/browser-pane-state.js");
+
+test("normaliseBrowserTarget defaults to docked and allows window", () => {
+  assert.equal(normaliseBrowserTarget(undefined), "docked");
+  assert.equal(normaliseBrowserTarget("window"), "window");
+  assert.equal(normaliseBrowserTarget("weird"), null);
+});
+
+test("reduceBrowserCommand docks valid browser urls into the pane state", () => {
+  const initial = createBrowserPaneState();
+  const result = reduceBrowserCommand(initial, {
+    command: "browser_open",
+    target: "docked",
+    url: "https://example.com/docs",
+    requested_by: "codex",
+  });
+
+  assert.equal(result.effect, null);
+  assert.equal(result.error, null);
+  assert.deepEqual(result.state, {
+    visible: true,
+    url: "https://example.com/docs",
+    requestedBy: "codex",
+  });
+});
+
+test("reduceBrowserCommand returns a pop-out effect for window targets", () => {
+  const initial = createBrowserPaneState();
+  const result = reduceBrowserCommand(initial, {
+    command: "browser_open",
+    target: "window",
+    url: "https://example.com",
+    requested_by: "codex",
+  });
+
+  assert.deepEqual(result.state, initial);
+  assert.deepEqual(result.effect, {
+    type: "popout",
+    url: "https://example.com/",
+  });
+  assert.equal(result.error, null);
+});
+
+test("popoutBrowserPane reuses the current docked url without hiding the pane", () => {
+  const initial = {
+    visible: true,
+    url: "https://example.com/docs",
+    requestedBy: "codex",
+  };
+
+  const result = popoutBrowserPane(initial);
+
+  assert.deepEqual(result.state, initial);
+  assert.deepEqual(result.effect, {
+    type: "popout",
+    url: "https://example.com/docs",
+  });
+});
+
+test("closeBrowserPane hides the pane but keeps the last visited url", () => {
+  const result = closeBrowserPane({
+    visible: true,
+    url: "https://example.com/docs",
+    requestedBy: "codex",
+  });
+
+  assert.deepEqual(result, {
+    visible: false,
+    url: "https://example.com/docs",
+    requestedBy: "codex",
+  });
+});

--- a/electron/qa/browser-window.test.cjs
+++ b/electron/qa/browser-window.test.cjs
@@ -1,0 +1,90 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+function loadBrowserWindowModule(electronMock) {
+  const target = require.resolve("../browser-window.js");
+  delete require.cache[target];
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === "electron") {
+      return electronMock;
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    return require("../browser-window.js");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+test("normaliseBrowserUrl only accepts http and https urls", () => {
+  const { normaliseBrowserUrl } = loadBrowserWindowModule({ BrowserWindow: class {} });
+
+  assert.equal(normaliseBrowserUrl("https://example.com"), "https://example.com/");
+  assert.equal(normaliseBrowserUrl("http://localhost:8300/chat"), "http://localhost:8300/chat");
+  assert.equal(normaliseBrowserUrl("file:///C:/secret.txt"), null);
+  assert.equal(normaliseBrowserUrl("javascript:alert(1)"), null);
+});
+
+test("openBrowserWindow creates or reuses an Electron window for browser urls", () => {
+  const instances = [];
+
+  class FakeBrowserWindow {
+    constructor(options) {
+      this.options = options;
+      this.loaded = [];
+      this.showCalls = 0;
+      this.focusCalls = 0;
+      this.closedHandler = null;
+      instances.push(this);
+    }
+
+    loadURL(url) {
+      this.loaded.push(url);
+      return Promise.resolve();
+    }
+
+    show() {
+      this.showCalls += 1;
+    }
+
+    focus() {
+      this.focusCalls += 1;
+    }
+
+    isDestroyed() {
+      return false;
+    }
+
+    on(eventName, handler) {
+      if (eventName === "closed") {
+        this.closedHandler = handler;
+      }
+    }
+  }
+
+  const {
+    openBrowserWindow,
+    _resetBrowserWindowForTests,
+  } = loadBrowserWindowModule({ BrowserWindow: FakeBrowserWindow });
+
+  _resetBrowserWindowForTests();
+
+  const first = openBrowserWindow("https://example.com", { id: 1 });
+  const second = openBrowserWindow("https://openai.com/docs", { id: 1 });
+
+  assert.equal(first.success, true);
+  assert.equal(second.success, true);
+  assert.equal(instances.length, 1);
+  assert.deepEqual(instances[0].loaded, [
+    "https://example.com/",
+    "https://openai.com/docs",
+  ]);
+  assert.equal(instances[0].showCalls, 2);
+  assert.equal(instances[0].focusCalls, 2);
+  assert.equal(instances[0].options.title, "Browser");
+});

--- a/electron/qa/deep-links.test.cjs
+++ b/electron/qa/deep-links.test.cjs
@@ -1,0 +1,37 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { extractDeepLinkUrl, parseDeepLink } = require("../deep-links.js");
+
+test("extractDeepLinkUrl returns the first deep-link argument", () => {
+  assert.equal(
+    extractDeepLinkUrl([
+      "electron.exe",
+      ".",
+      "agentchattr://channel/reviews",
+      "agentchattr://port/8300",
+    ]),
+    "agentchattr://channel/reviews",
+  );
+});
+
+test("parseDeepLink recognises channel, agent, and port payloads", () => {
+  assert.deepEqual(parseDeepLink("agentchattr://channel/reviews"), {
+    type: "channel",
+    value: "reviews",
+  });
+  assert.deepEqual(parseDeepLink("agentchattr://agent/codex"), {
+    type: "agent",
+    value: "codex",
+  });
+  assert.deepEqual(parseDeepLink("agentchattr://port/8300"), {
+    type: "port",
+    value: 8300,
+  });
+});
+
+test("parseDeepLink rejects malformed or empty payloads", () => {
+  assert.equal(parseDeepLink("https://example.com"), null);
+  assert.equal(parseDeepLink("agentchattr://channel/"), null);
+  assert.equal(parseDeepLink("agentchattr://port/not-a-number"), null);
+});

--- a/electron/qa/desktop-command-bridge.test.cjs
+++ b/electron/qa/desktop-command-bridge.test.cjs
@@ -1,0 +1,49 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { handleDesktopCommand } = require("../desktop-command-bridge.js");
+
+test("handleDesktopCommand forwards browser-open requests to the host renderer", () => {
+  const sent = [];
+  const handled = handleDesktopCommand(
+    {
+      type: "desktop_command",
+      data: {
+        command: "browser_open",
+        url: "https://example.com",
+        requested_by: "codex",
+      },
+    },
+    (channel, payload) => {
+      sent.push([channel, payload]);
+    },
+  );
+
+  assert.equal(handled, true);
+  assert.deepEqual(sent, [
+    [
+      "desktop-command",
+      {
+        command: "browser_open",
+        url: "https://example.com",
+        requested_by: "codex",
+      },
+    ],
+  ]);
+});
+
+test("handleDesktopCommand ignores non-browser payloads", () => {
+  const sent = [];
+  const handled = handleDesktopCommand(
+    {
+      type: "message",
+      data: { sender: "codex", body: "hello" },
+    },
+    (channel, payload) => {
+      sent.push([channel, payload]);
+    },
+  );
+
+  assert.equal(handled, false);
+  assert.deepEqual(sent, []);
+});

--- a/electron/qa/desktop-smoke.cjs
+++ b/electron/qa/desktop-smoke.cjs
@@ -1,0 +1,208 @@
+const fs = require("node:fs");
+const net = require("node:net");
+const path = require("node:path");
+
+const { _electron } = require("playwright-core");
+
+const {
+  findElectronExecutable,
+  findPythonExecutable,
+} = require("./helpers.cjs");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const ELECTRON_DIR = path.resolve(__dirname, "..");
+const BASE_URL = process.env.AGENTCHATTR_SMOKE_URL || "http://127.0.0.1:8300";
+const SERVER_PORT = Number(new URL(BASE_URL).port || "8300");
+const ARTIFACT_DIR = path.join(REPO_ROOT, "data", "qa-artifacts");
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function isPortOpen(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const finish = (value) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(value);
+    };
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  });
+}
+
+async function waitFor(fn, label, timeoutMs = 30000, intervalMs = 250) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const value = await fn();
+      if (value) {
+        return value;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await sleep(intervalMs);
+  }
+
+  const detail = lastError ? `: ${lastError.message}` : "";
+  throw new Error(`Timed out waiting for ${label}${detail}`);
+}
+
+async function isServerReady(baseUrl) {
+  try {
+    const response = await fetch(`${baseUrl}/`, { redirect: "manual" });
+    return response.ok;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function ensureArtifactDir() {
+  fs.mkdirSync(ARTIFACT_DIR, { recursive: true });
+}
+
+async function writeFailureArtifacts(page, prefix) {
+  ensureArtifactDir();
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  if (page) {
+    await page.screenshot({
+      path: path.join(ARTIFACT_DIR, `${prefix}-${stamp}.png`),
+      fullPage: true,
+    });
+  }
+}
+
+async function runDesktopSmoke() {
+  const pythonPath = findPythonExecutable(REPO_ROOT);
+  if (!pythonPath) {
+    throw new Error(
+      "Python virtualenv not found. Create .venv before running desktop smoke.",
+    );
+  }
+
+  const electronExecutable = findElectronExecutable(ELECTRON_DIR);
+  if (!electronExecutable) {
+    throw new Error(
+      "Electron executable not found. Run `npm --prefix electron install` before desktop smoke.",
+    );
+  }
+
+  if (await isPortOpen(SERVER_PORT)) {
+    throw new Error(
+      `Port ${SERVER_PORT} is already in use. Close any existing run.py or Electron instance before running desktop smoke.`,
+    );
+  }
+
+  let electronApp = null;
+  let window = null;
+
+  try {
+    electronApp = await _electron.launch({
+      executablePath: electronExecutable,
+      args: [ELECTRON_DIR],
+    });
+
+    window = await electronApp.firstWindow();
+    await window.waitForLoadState("domcontentloaded");
+
+    await waitFor(() => isServerReady(BASE_URL), "Electron embedded server", 45000);
+
+    await window.locator('button[data-tab="ports"]').click();
+    await waitFor(
+      () =>
+        window.locator("#ports-container").evaluate((element) => {
+          return !element.hidden;
+        }),
+      "ports tab visibility",
+    );
+    await waitFor(
+      async () =>
+        (await window.locator(".ports-title").textContent())?.trim() === "Ports",
+      "ports shell render",
+    );
+
+    await window.locator('button[data-tab="chat"]').click();
+    await waitFor(
+      async () =>
+        (await window
+          .locator('button[data-tab="chat"]')
+          .getAttribute("aria-selected")) === "true",
+      "chat tab activation",
+    );
+
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      const mainWindow = BrowserWindow.getAllWindows()[0];
+      if (!mainWindow) {
+        throw new Error("No BrowserWindow available for smoke focus test.");
+      }
+      mainWindow.webContents.send("focus-channel", "planning");
+    });
+
+    await waitFor(
+      async () =>
+        (await window
+          .locator('button[data-tab="chat"]')
+          .getAttribute("aria-selected")) === "true",
+      "chat tab after focus-channel",
+    );
+
+    await waitFor(
+      () =>
+        window.evaluate(async () => {
+          const webview = document.getElementById("chat-webview");
+          if (!webview) {
+            return false;
+          }
+
+          try {
+            return (
+              (await webview.executeJavaScript(
+                "localStorage.getItem('agentchattr-channel')",
+                true,
+              )) === "planning"
+            );
+          } catch (_error) {
+            return false;
+          }
+        }),
+      "focus-channel propagation into the chat webview",
+      15000,
+    );
+
+    await electronApp.evaluate(({ app }) => {
+      app.quit();
+    });
+
+    await waitFor(
+      async () => !(await isPortOpen(SERVER_PORT)),
+      "Electron shutdown releasing port 8300",
+      20000,
+    );
+
+    console.log("Desktop smoke passed.");
+  } catch (error) {
+    await writeFailureArtifacts(window, "desktop-smoke");
+    throw error;
+  } finally {
+    if (electronApp) {
+      await electronApp.close().catch(() => {});
+    }
+  }
+}
+
+if (require.main === module) {
+  runDesktopSmoke().catch((error) => {
+    console.error(error?.stack || String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  runDesktopSmoke,
+};

--- a/electron/qa/helpers.cjs
+++ b/electron/qa/helpers.cjs
@@ -1,0 +1,76 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const DEFAULT_SMOKE_AGENT_COLOUR = "#06b6d4";
+
+function escapePythonString(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+function buildSmokeAgentDefinition({
+  name,
+  label = "Smoke Agent",
+  command,
+  color = DEFAULT_SMOKE_AGENT_COLOUR,
+}) {
+  return {
+    name,
+    label,
+    command,
+    color,
+  };
+}
+
+function buildSmokeAgentExtraArgs({
+  sentinel = "SMOKE_READY",
+  sleepSeconds = 30,
+} = {}) {
+  const safeSentinel = escapePythonString(sentinel);
+  const safeSleepSeconds = Number.isFinite(sleepSeconds)
+    ? Math.max(1, Math.floor(sleepSeconds))
+    : 30;
+
+  return `-u -c "import time; print('${safeSentinel}', flush=True); time.sleep(${safeSleepSeconds})"`;
+}
+
+function findPythonExecutable(rootDir, platform = process.platform) {
+  const candidates =
+    platform === "win32"
+      ? [path.join(rootDir, ".venv", "Scripts", "python.exe")]
+      : [path.join(rootDir, ".venv", "bin", "python")];
+
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+function findElectronExecutable(
+  electronDir,
+  platform = process.platform,
+) {
+  const candidates =
+    platform === "win32"
+      ? [path.join(electronDir, "node_modules", "electron", "dist", "electron.exe")]
+      : platform === "darwin"
+        ? [
+            path.join(
+              electronDir,
+              "node_modules",
+              "electron",
+              "dist",
+              "Electron.app",
+              "Contents",
+              "MacOS",
+              "Electron",
+            ),
+          ]
+        : [path.join(electronDir, "node_modules", "electron", "dist", "electron")];
+
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+module.exports = {
+  DEFAULT_SMOKE_AGENT_COLOUR,
+  buildSmokeAgentDefinition,
+  buildSmokeAgentExtraArgs,
+  findElectronExecutable,
+  findPythonExecutable,
+};

--- a/electron/qa/helpers.test.cjs
+++ b/electron/qa/helpers.test.cjs
@@ -1,0 +1,62 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  buildSmokeAgentDefinition,
+  buildSmokeAgentExtraArgs,
+  findElectronExecutable,
+  findPythonExecutable,
+} = require("./helpers.cjs");
+
+test("buildSmokeAgentDefinition returns a launcher-safe custom agent definition", () => {
+  const definition = buildSmokeAgentDefinition({
+    name: "smokebot42",
+    label: "Smoke Bot",
+    command: "C:\\repo\\.venv\\Scripts\\python.exe",
+  });
+
+  assert.deepEqual(definition, {
+    name: "smokebot42",
+    label: "Smoke Bot",
+    command: "C:\\repo\\.venv\\Scripts\\python.exe",
+    color: "#06b6d4",
+  });
+});
+
+test("buildSmokeAgentExtraArgs embeds the sentinel and keeps the process alive", () => {
+  const extraArgs = buildSmokeAgentExtraArgs({
+    sentinel: "QA_READY",
+    sleepSeconds: 42,
+  });
+
+  assert.match(extraArgs, /QA_READY/);
+  assert.match(extraArgs, /time\.sleep\(42\)/);
+  assert.match(extraArgs, /flush=True/);
+});
+
+test("findPythonExecutable prefers the local virtualenv", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentchattr-python-"));
+  const pythonPath = path.join(root, ".venv", "Scripts", "python.exe");
+  fs.mkdirSync(path.dirname(pythonPath), { recursive: true });
+  fs.writeFileSync(pythonPath, "");
+
+  assert.equal(findPythonExecutable(root, "win32"), pythonPath);
+});
+
+test("findElectronExecutable resolves the bundled Windows binary", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentchattr-electron-"));
+  const electronPath = path.join(
+    root,
+    "node_modules",
+    "electron",
+    "dist",
+    "electron.exe",
+  );
+  fs.mkdirSync(path.dirname(electronPath), { recursive: true });
+  fs.writeFileSync(electronPath, "");
+
+  assert.equal(findElectronExecutable(root, "win32"), electronPath);
+});

--- a/electron/qa/launcher-smoke.cjs
+++ b/electron/qa/launcher-smoke.cjs
@@ -1,0 +1,406 @@
+const fs = require("node:fs");
+const net = require("node:net");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const { chromium } = require("playwright-core");
+
+const {
+  buildSmokeAgentDefinition,
+  buildSmokeAgentExtraArgs,
+  findPythonExecutable,
+} = require("./helpers.cjs");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const BASE_URL = process.env.AGENTCHATTR_SMOKE_URL || "http://127.0.0.1:8300";
+const SERVER_PORT = Number(new URL(BASE_URL).port || "8300");
+const ARTIFACT_DIR = path.join(REPO_ROOT, "data", "qa-artifacts");
+const BROWSER_CHANNEL = process.platform === "win32" ? "msedge" : "chrome";
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function isPortOpen(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const finish = (value) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(value);
+    };
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  });
+}
+
+async function waitFor(fn, label, timeoutMs = 30000, intervalMs = 250) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const value = await fn();
+      if (value) {
+        return value;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await sleep(intervalMs);
+  }
+
+  const detail = lastError ? `: ${lastError.message}` : "";
+  throw new Error(`Timed out waiting for ${label}${detail}`);
+}
+
+async function isServerReady(baseUrl) {
+  try {
+    const response = await fetch(`${baseUrl}/`, { redirect: "manual" });
+    return response.ok;
+  } catch (_error) {
+    return false;
+  }
+}
+
+async function stopChildProcess(child) {
+  if (!child || child.exitCode !== null) {
+    return;
+  }
+
+  child.kill();
+
+  try {
+    await waitFor(
+      async () => child.exitCode !== null || !(await isPortOpen(SERVER_PORT)),
+      "smoke server shutdown",
+      10000,
+    );
+  } catch (_error) {
+    if (process.platform === "win32") {
+      spawn("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      await waitFor(
+        async () => child.exitCode !== null || !(await isPortOpen(SERVER_PORT)),
+        "taskkill server shutdown",
+        10000,
+      );
+      return;
+    }
+
+    child.kill("SIGKILL");
+    await waitFor(
+      async () => child.exitCode !== null || !(await isPortOpen(SERVER_PORT)),
+      "forced smoke server shutdown",
+      10000,
+    );
+  }
+}
+
+async function startServer(pythonPath) {
+  if (await isPortOpen(SERVER_PORT)) {
+    throw new Error(
+      `Port ${SERVER_PORT} is already in use. Stop any existing agentchattr server before running launcher smoke.`,
+    );
+  }
+
+  const logs = [];
+  const child = spawn(pythonPath, ["run.py"], {
+    cwd: REPO_ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  const capture = (chunk) => {
+    const lines = chunk
+      .toString()
+      .split(/\r?\n/)
+      .map((line) => line.trimEnd())
+      .filter(Boolean);
+
+    logs.push(...lines);
+    if (logs.length > 300) {
+      logs.splice(0, logs.length - 300);
+    }
+  };
+
+  child.stdout.on("data", capture);
+  child.stderr.on("data", capture);
+
+  await waitFor(async () => {
+    if (child.exitCode !== null) {
+      throw new Error(`run.py exited early with code ${child.exitCode}`);
+    }
+
+    return isServerReady(BASE_URL);
+  }, "agentchattr web server", 45000);
+
+  return {
+    child,
+    logs,
+    async stop() {
+      await stopChildProcess(child);
+    },
+  };
+}
+
+function ensureArtifactDir() {
+  fs.mkdirSync(ARTIFACT_DIR, { recursive: true });
+}
+
+async function writeFailureArtifacts(page, serverLogs, prefix) {
+  ensureArtifactDir();
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  if (page) {
+    await page.screenshot({
+      path: path.join(ARTIFACT_DIR, `${prefix}-${stamp}.png`),
+      fullPage: true,
+    });
+  }
+
+  if (serverLogs?.length) {
+    fs.writeFileSync(
+      path.join(ARTIFACT_DIR, `${prefix}-${stamp}.log`),
+      `${serverLogs.join("\n")}\n`,
+      "utf-8",
+    );
+  }
+}
+
+function toCookieHeader(cookies) {
+  return cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join("; ");
+}
+
+async function apiJson(pathname, { method = "GET", body, cookieHeader }) {
+  const headers = {};
+  if (cookieHeader) {
+    headers.Cookie = cookieHeader;
+  }
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(`${BASE_URL}${pathname}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(`${method} ${pathname} failed with HTTP ${response.status}`);
+  }
+
+  return response.status === 204 ? null : response.json();
+}
+
+async function cleanupSmokeArtifacts(baseName, cookieHeader) {
+  if (!cookieHeader) {
+    return;
+  }
+
+  try {
+    const managedPayload = await apiJson("/api/agents/managed", {
+      cookieHeader,
+    });
+    const ours = managedPayload.data.filter((item) => item.base === baseName);
+
+    for (const item of ours) {
+      try {
+        await apiJson(`/api/agents/${encodeURIComponent(item.name)}/stop`, {
+          method: "POST",
+          cookieHeader,
+        });
+      } catch (_error) {
+        // Best-effort cleanup.
+      }
+    }
+
+    await waitFor(async () => {
+      const payload = await apiJson("/api/agents/managed", { cookieHeader });
+      return payload.data.every((item) => item.base !== baseName);
+    }, `${baseName} instances to stop`, 15000);
+  } catch (_error) {
+    // Continue with definition cleanup even if process cleanup failed.
+  }
+
+  try {
+    await apiJson(`/api/agent-definitions/${encodeURIComponent(baseName)}`, {
+      method: "DELETE",
+      cookieHeader,
+    });
+  } catch (_error) {
+    // The definition may already be gone or still blocked by a live process.
+  }
+
+  try {
+    await apiJson("/api/agents/restore/dismiss", {
+      method: "POST",
+      cookieHeader,
+    });
+  } catch (_error) {
+    // Ignore cleanup errors here too.
+  }
+}
+
+async function assertLauncherPanelOpen(page) {
+  await waitFor(
+    () =>
+      page.locator("#launcher-panel").evaluate((element) => {
+        return !element.classList.contains("hidden");
+      }),
+    "launcher panel",
+  );
+}
+
+async function runLauncherSmoke() {
+  const pythonPath = findPythonExecutable(REPO_ROOT);
+  if (!pythonPath) {
+    throw new Error(
+      "Python virtualenv not found. Create .venv before running launcher smoke.",
+    );
+  }
+
+  const baseName = `smokeagent${Date.now().toString(36)}`;
+  const label = `Smoke Agent ${baseName.slice(-4)}`;
+  const sentinel = `SMOKE_READY_${baseName}`;
+  const definition = buildSmokeAgentDefinition({
+    name: baseName,
+    label,
+    command: pythonPath,
+  });
+  const extraArgs = buildSmokeAgentExtraArgs({
+    sentinel,
+    sleepSeconds: 45,
+  });
+
+  let server = null;
+  let browser = null;
+  let context = null;
+  let page = null;
+  let cookieHeader = "";
+
+  try {
+    server = await startServer(pythonPath);
+    browser = await chromium.launch({
+      channel: BROWSER_CHANNEL,
+      headless: true,
+    });
+    context = await browser.newContext({
+      viewport: { width: 1440, height: 960 },
+    });
+    await context.addInitScript(() => {
+      localStorage.setItem("help_seen", "1");
+    });
+    page = await context.newPage();
+
+    await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+    await page.locator("#launcher-toggle").waitFor();
+    await page.click("#launcher-toggle");
+    await assertLauncherPanelOpen(page);
+
+    await page.getByRole("button", { name: "+ Add Agent" }).click();
+    await page.fill("#new-agent-name", definition.name);
+    await page.fill("#new-agent-command", definition.command);
+    await page.fill("#new-agent-label", definition.label);
+    await page
+      .locator("#add-agent-form")
+      .getByRole("button", { name: "Save", exact: true })
+      .click();
+
+    const card = page.locator(".launcher-card").filter({
+      hasText: definition.label,
+    });
+    await card.waitFor();
+    await card.getByRole("button", { name: "Launch", exact: true }).click();
+    await page.fill(`#launch-cwd-${definition.name}`, REPO_ROOT);
+    await page.fill(`#launch-extra-${definition.name}`, extraArgs);
+    await page
+      .getByRole("button", { name: `Launch ${definition.label}` })
+      .click();
+
+    const firstInstanceName = await waitFor(async () => {
+      const payload = await page.evaluate(() =>
+        fetch("/api/agents/managed").then((response) => response.json()),
+      );
+      return (
+        payload.data.find((item) => item.base === definition.name)?.name ?? null
+      );
+    }, "first launcher instance");
+
+    await page.evaluate((name) => {
+      return window.toggleAgentLogs(name);
+    }, firstInstanceName);
+    await waitFor(async () => {
+      const text = await page.locator(`#logs-${firstInstanceName}`).textContent();
+      return text && text.includes(sentinel);
+    }, "launcher log sentinel");
+
+    await card.getByRole("button", { name: "Launch Another" }).click();
+    await page.fill(`#launch-cwd-${definition.name}`, REPO_ROOT);
+    await page.fill(`#launch-extra-${definition.name}`, extraArgs);
+    await page
+      .getByRole("button", { name: `Launch ${definition.label}` })
+      .click();
+
+    const secondInstanceName = await waitFor(async () => {
+      const payload = await page.evaluate(() =>
+        fetch("/api/agents/managed").then((response) => response.json()),
+      );
+      const ours = payload.data.filter((item) => item.base === definition.name);
+      if (ours.length < 2) {
+        return null;
+      }
+      return ours.find((item) => item.name !== definition.name)?.name ?? null;
+    }, "second launcher instance");
+
+    const restorePayload = await page.evaluate(() =>
+      fetch("/api/agents/restore").then((response) => response.json()),
+    );
+    if (!restorePayload.data.some((item) => item.base === definition.name)) {
+      throw new Error(`Restore state never included ${definition.name}`);
+    }
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await waitFor(
+      () => page.locator("#restore-banner").isVisible(),
+      "restore banner after reload",
+    );
+
+    cookieHeader = toCookieHeader(await context.cookies(BASE_URL));
+
+    console.log(
+      `Launcher smoke passed for ${definition.name} and ${secondInstanceName}.`,
+    );
+  } catch (error) {
+    await writeFailureArtifacts(page, server?.logs ?? [], "launcher-smoke");
+    throw error;
+  } finally {
+    if (!cookieHeader && context) {
+      cookieHeader = toCookieHeader(await context.cookies(BASE_URL));
+    }
+
+    await cleanupSmokeArtifacts(baseName, cookieHeader);
+
+    if (browser) {
+      await browser.close();
+    }
+    if (server) {
+      await server.stop();
+    }
+  }
+}
+
+if (require.main === module) {
+  runLauncherSmoke().catch((error) => {
+    console.error(error?.stack || String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  runLauncherSmoke,
+};

--- a/electron/qa/launcher-smoke.cjs
+++ b/electron/qa/launcher-smoke.cjs
@@ -372,6 +372,41 @@ async function runLauncherSmoke() {
 
     cookieHeader = toCookieHeader(await context.cookies(BASE_URL));
 
+    await page.click("#launcher-toggle");
+    await assertLauncherPanelOpen(page);
+
+    for (const instanceName of [firstInstanceName, secondInstanceName]) {
+      await waitFor(
+        () =>
+          page
+            .locator(`button.launcher-btn.danger[data-name="${instanceName}"]`)
+            .count(),
+        `stop control for ${instanceName}`,
+      );
+      await page
+        .locator(`button.launcher-btn.danger[data-name="${instanceName}"]`)
+        .click();
+      await waitFor(async () => {
+        const payload = await page.evaluate(() =>
+          fetch("/api/agents/managed").then((response) => response.json()),
+        );
+        const instance = payload.data.find((item) => item.name === instanceName);
+        return (
+          !instance ||
+          (instance.state !== "running" && instance.state !== "starting")
+        );
+      }, `${instanceName} to stop`);
+    }
+
+    page.once("dialog", (dialog) => dialog.accept());
+    await card.getByRole("button", { name: "Delete", exact: true }).click();
+    await waitFor(async () => {
+      const payload = await page.evaluate(() =>
+        fetch("/api/agent-definitions").then((response) => response.json()),
+      );
+      return !payload.definitions[definition.name];
+    }, `${definition.name} definition to delete`);
+
     console.log(
       `Launcher smoke passed for ${definition.name} and ${secondInstanceName}.`,
     );

--- a/electron/qa/notifications.test.cjs
+++ b/electron/qa/notifications.test.cjs
@@ -1,0 +1,101 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const Module = require("node:module");
+
+function loadNotificationsModule(electronMock) {
+  const target = require.resolve("../notifications.js");
+  delete require.cache[target];
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === "electron") {
+      return electronMock;
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    return require("../notifications.js");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+test("setupNotifications increments badges, focuses the window on click, and clears unread on focus", () => {
+  class FakeNotification extends EventEmitter {
+    static instances = [];
+
+    constructor(options) {
+      super();
+      this.options = options;
+      this.shown = false;
+      FakeNotification.instances.push(this);
+    }
+
+    show() {
+      this.shown = true;
+    }
+  }
+
+  const ipcMain = new EventEmitter();
+  const electronMock = {
+    Notification: FakeNotification,
+    ipcMain,
+    nativeImage: {
+      createFromDataURL(value) {
+        return { value };
+      },
+    },
+  };
+
+  const { setupNotifications } = loadNotificationsModule(electronMock);
+
+  const badgeUpdates = [];
+  const focusChannelEvents = [];
+  const mainWindow = new EventEmitter();
+  let showCalls = 0;
+  let focusCalls = 0;
+
+  mainWindow.isDestroyed = () => false;
+  mainWindow.show = () => {
+    showCalls += 1;
+  };
+  mainWindow.focus = () => {
+    focusCalls += 1;
+  };
+  mainWindow.webContents = {
+    isDestroyed() {
+      return false;
+    },
+    send(channel, payload) {
+      focusChannelEvents.push([channel, payload]);
+    },
+  };
+
+  setupNotifications(mainWindow, {
+    setBadge(count) {
+      badgeUpdates.push(count);
+    },
+  });
+
+  ipcMain.emit("send-notification", null, {
+    title: "codex mentioned you",
+    body: "@user please check #planning",
+    channel: "planning",
+  });
+
+  assert.equal(FakeNotification.instances.length, 1);
+  assert.equal(FakeNotification.instances[0].shown, true);
+  assert.equal(FakeNotification.instances[0].options.title, "codex mentioned you");
+  assert.deepEqual(badgeUpdates, [1]);
+
+  FakeNotification.instances[0].emit("click");
+
+  assert.equal(showCalls, 1);
+  assert.equal(focusCalls, 1);
+  assert.deepEqual(focusChannelEvents, [["focus-channel", "planning"]]);
+
+  mainWindow.emit("focus");
+  assert.deepEqual(badgeUpdates, [1, 0]);
+});

--- a/electron/qa/tray.test.cjs
+++ b/electron/qa/tray.test.cjs
@@ -1,0 +1,126 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const Module = require("node:module");
+
+function loadTrayModule(electronMock) {
+  const target = require.resolve("../tray.js");
+  delete require.cache[target];
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === "electron") {
+      return electronMock;
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    return require("../tray.js");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+test("createTray toggles window visibility, supports quit, and setBadge updates the overlay icon", () => {
+  class FakeTray extends EventEmitter {
+    constructor(icon) {
+      super();
+      this.icon = icon;
+      this.contextMenu = null;
+      this.toolTip = null;
+      this.destroyed = false;
+    }
+
+    setToolTip(value) {
+      this.toolTip = value;
+    }
+
+    setContextMenu(value) {
+      this.contextMenu = value;
+    }
+
+    destroy() {
+      this.destroyed = true;
+    }
+  }
+
+  let quitCalls = 0;
+  const electronMock = {
+    Tray: FakeTray,
+    Menu: {
+      buildFromTemplate(template) {
+        return template;
+      },
+    },
+    nativeImage: {
+      createFromPath() {
+        return {
+          isEmpty() {
+            return false;
+          },
+        };
+      },
+      createFromDataURL(value) {
+        return { value };
+      },
+    },
+    app: {
+      quit() {
+        quitCalls += 1;
+      },
+    },
+  };
+
+  const { createTray, setBadge } = loadTrayModule(electronMock);
+
+  const overlayCalls = [];
+  let visible = true;
+  let focusCalls = 0;
+  const mainWindow = {
+    isDestroyed() {
+      return false;
+    },
+    isVisible() {
+      return visible;
+    },
+    hide() {
+      visible = false;
+    },
+    show() {
+      visible = true;
+    },
+    focus() {
+      focusCalls += 1;
+    },
+    setOverlayIcon(icon, description) {
+      overlayCalls.push([icon, description]);
+    },
+  };
+
+  const tray = createTray(mainWindow);
+  assert.equal(tray.toolTip, "agentchattr");
+  assert.equal(tray.contextMenu[0].label, "Show/Hide");
+  assert.equal(tray.contextMenu[2].label, "Quit");
+
+  tray.contextMenu[0].click();
+  assert.equal(visible, false);
+
+  tray.contextMenu[0].click();
+  assert.equal(visible, true);
+  assert.equal(focusCalls, 1);
+
+  visible = false;
+  tray.emit("double-click");
+  assert.equal(visible, true);
+  assert.equal(focusCalls, 2);
+
+  setBadge(3);
+  setBadge(0);
+  assert.equal(overlayCalls.length, 2);
+  assert.match(overlayCalls[0][1], /3 unread notifications/);
+  assert.deepEqual(overlayCalls[1], [null, ""]);
+
+  tray.contextMenu[2].click();
+  assert.equal(quitCalls, 1);
+});

--- a/electron/renderer/browser-pane-state.js
+++ b/electron/renderer/browser-pane-state.js
@@ -1,0 +1,103 @@
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.BrowserPaneState = factory();
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  function createBrowserPaneState() {
+    return {
+      visible: false,
+      url: "",
+      requestedBy: "",
+    };
+  }
+
+  function normaliseBrowserUrl(urlString) {
+    if (typeof urlString !== "string" || !urlString.trim()) {
+      return null;
+    }
+
+    try {
+      const parsed = new URL(urlString);
+      if (!["http:", "https:"].includes(parsed.protocol)) {
+        return null;
+      }
+      return parsed.toString();
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function normaliseBrowserTarget(target) {
+    if (target === undefined || target === null || target === "") {
+      return "docked";
+    }
+    if (target === "docked" || target === "window") {
+      return target;
+    }
+    return null;
+  }
+
+  function reduceBrowserCommand(state, payload) {
+    const current = state || createBrowserPaneState();
+    const target = normaliseBrowserTarget(payload?.target);
+    const url = normaliseBrowserUrl(payload?.url || "");
+
+    if (!target || !url || payload?.command !== "browser_open") {
+      return {
+        state: current,
+        effect: null,
+        error: "invalid_command",
+      };
+    }
+
+    if (target === "window") {
+      return {
+        state: current,
+        effect: { type: "popout", url },
+        error: null,
+      };
+    }
+
+    return {
+      state: {
+        visible: true,
+        url,
+        requestedBy: typeof payload?.requested_by === "string" ? payload.requested_by : "",
+      },
+      effect: null,
+      error: null,
+    };
+  }
+
+  function popoutBrowserPane(state) {
+    const current = state || createBrowserPaneState();
+    if (!current.url) {
+      return { state: current, effect: null };
+    }
+    return {
+      state: current,
+      effect: { type: "popout", url: current.url },
+    };
+  }
+
+  function closeBrowserPane(state) {
+    const current = state || createBrowserPaneState();
+    return {
+      visible: false,
+      url: current.url || "",
+      requestedBy: current.requestedBy || "",
+    };
+  }
+
+  return {
+    createBrowserPaneState,
+    normaliseBrowserTarget,
+    reduceBrowserCommand,
+    popoutBrowserPane,
+    closeBrowserPane,
+  };
+});

--- a/electron/renderer/index.html
+++ b/electron/renderer/index.html
@@ -93,12 +93,111 @@
         background: #12121e;
       }
 
-      webview {
-        position: absolute;
-        inset: 0;
+      .chat-shell {
+        display: flex;
+        height: 100%;
+        min-height: 0;
+      }
+
+      .chat-primary {
+        flex: 1;
+        min-width: 0;
+        min-height: 0;
+      }
+
+      #chat-webview,
+      #browser-webview {
         width: 100%;
         height: 100%;
         border: none;
+      }
+
+      .browser-pane {
+        width: min(44vw, 540px);
+        min-width: 320px;
+        max-width: 50%;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        background: #171726;
+        border-left: 1px solid #2a2a3a;
+      }
+
+      .browser-pane[hidden] {
+        display: none;
+      }
+
+      .browser-pane-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 12px;
+        border-bottom: 1px solid #2a2a3a;
+        background: #161624;
+      }
+
+      .browser-pane-copy {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .browser-pane-title {
+        display: block;
+        font-size: 12px;
+        font-weight: 600;
+        color: #e0e0e0;
+      }
+
+      .browser-pane-meta,
+      .browser-pane-url {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .browser-pane-meta {
+        margin-top: 2px;
+        font-size: 11px;
+        color: #888;
+      }
+
+      .browser-pane-url {
+        margin-top: 4px;
+        font-size: 11px;
+        color: #b4b4c3;
+        font-family: Consolas, "Courier New", monospace;
+      }
+
+      .browser-pane-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .browser-pane-button {
+        padding: 6px 10px;
+        border: 1px solid #2a2a3a;
+        border-radius: 6px;
+        background: #1f1f31;
+        color: #d6d6e3;
+        cursor: pointer;
+        font-size: 12px;
+      }
+
+      .browser-pane-button:hover:not(:disabled) {
+        border-color: #da7756;
+        color: #fff2eb;
+      }
+
+      .browser-pane-button:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+
+      .browser-pane-surface {
+        flex: 1;
+        min-height: 0;
       }
 
       #ports-container {
@@ -286,17 +385,57 @@
       </div>
 
       <div class="content-area">
-        <webview
-          id="chat-webview"
-          src="http://127.0.0.1:8300"
-          allowpopups
-          partition="persist:agentchattr"
-          preload=""
-        ></webview>
+        <div id="chat-shell" class="chat-shell">
+          <div class="chat-primary">
+            <webview
+              id="chat-webview"
+              src="http://127.0.0.1:8300"
+              allowpopups
+              partition="persist:agentchattr"
+              preload=""
+            ></webview>
+          </div>
+          <aside id="browser-pane" class="browser-pane" hidden>
+            <div class="browser-pane-header">
+              <div class="browser-pane-copy">
+                <span class="browser-pane-title">Browser</span>
+                <span id="browser-pane-meta" class="browser-pane-meta">No page open</span>
+                <span id="browser-pane-url" class="browser-pane-url">about:blank</span>
+              </div>
+              <div class="browser-pane-actions">
+                <button
+                  id="browser-pane-popout"
+                  type="button"
+                  class="browser-pane-button"
+                  aria-label="Pop out browser pane"
+                >
+                  Pop out
+                </button>
+                <button
+                  id="browser-pane-close"
+                  type="button"
+                  class="browser-pane-button"
+                  aria-label="Close browser pane"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+            <div class="browser-pane-surface">
+              <webview
+                id="browser-webview"
+                src="about:blank"
+                allowpopups
+                partition="persist:agentchattr-browser"
+              ></webview>
+            </div>
+          </aside>
+        </div>
         <div id="ports-container" hidden></div>
       </div>
     </div>
 
+    <script src="./browser-pane-state.js"></script>
     <script src="./renderer.js"></script>
   </body>
 </html>

--- a/electron/renderer/index.html
+++ b/electron/renderer/index.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>agentchattr</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+
+      html,
+      body {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        background: #12121e;
+        color: #e0e0e0;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      }
+
+      body {
+        min-height: 100dvh;
+        overflow: hidden;
+      }
+
+      button {
+        font: inherit;
+      }
+
+      #app {
+        display: flex;
+        flex-direction: column;
+        height: 100dvh;
+        background: #12121e;
+      }
+
+      .tab-bar {
+        display: flex;
+        align-items: stretch;
+        height: 36px;
+        background: #1a1a2e;
+        border-bottom: 1px solid #2a2a3a;
+        padding: 0 8px;
+        gap: 8px;
+        flex-shrink: 0;
+      }
+
+      .tab-item {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+      }
+
+      .tab-button {
+        height: 36px;
+        padding: 0 16px;
+        background: transparent;
+        border: none;
+        color: #888;
+        cursor: pointer;
+        font-size: 13px;
+        border-bottom: 2px solid transparent;
+      }
+
+      .tab-button.active {
+        color: #da7756;
+        border-bottom-color: #da7756;
+      }
+
+      .pop-out-button {
+        width: 20px;
+        height: 20px;
+        margin-left: 4px;
+        padding: 0;
+        border: none;
+        border-radius: 4px;
+        background: transparent;
+        color: #888;
+        cursor: pointer;
+        opacity: 0.5;
+      }
+
+      .pop-out-button:hover {
+        opacity: 1;
+        color: #e0e0e0;
+      }
+
+      .content-area {
+        flex: 1;
+        overflow: hidden;
+        position: relative;
+        background: #12121e;
+      }
+
+      webview {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        border: none;
+      }
+
+      #ports-container {
+        position: absolute;
+        inset: 0;
+        overflow: auto;
+        background: #12121e;
+      }
+
+      webview[hidden],
+      #ports-container[hidden] {
+        display: none;
+      }
+
+      .ports-shell {
+        box-sizing: border-box;
+        min-height: 100%;
+        padding: 20px;
+      }
+
+      .ports-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+
+      .ports-title {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 600;
+        color: #e0e0e0;
+      }
+
+      .ports-meta {
+        font-size: 12px;
+        color: #888;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .ports-empty,
+      .ports-notice {
+        border: 1px solid #2a2a3a;
+        border-radius: 10px;
+        background: #1a1a2e;
+        padding: 16px;
+      }
+
+      .ports-empty {
+        color: #b4b4c3;
+      }
+
+      .ports-empty strong {
+        display: block;
+        margin-bottom: 6px;
+        color: #e0e0e0;
+      }
+
+      .ports-notice {
+        margin-bottom: 16px;
+        font-size: 13px;
+        color: #e0e0e0;
+      }
+
+      .ports-notice.error {
+        border-color: #7a3d3d;
+        color: #ffb5b5;
+      }
+
+      .ports-table-wrap {
+        border: 1px solid #2a2a3a;
+        border-radius: 10px;
+        overflow: hidden;
+        background: #1a1a2e;
+      }
+
+      .ports-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .ports-table thead {
+        background: #171726;
+      }
+
+      .ports-table th,
+      .ports-table td {
+        padding: 12px 14px;
+        border-bottom: 1px solid #2a2a3a;
+        text-align: left;
+        vertical-align: middle;
+      }
+
+      .ports-table th {
+        color: #a7a7b7;
+        font-weight: 600;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      }
+
+      .ports-table tbody tr:hover {
+        background: rgba(218, 119, 86, 0.08);
+      }
+
+      .ports-table tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      .mono {
+        font-family: Consolas, "Courier New", monospace;
+      }
+
+      .muted {
+        color: #888;
+      }
+
+      .kill-button {
+        min-width: 56px;
+        padding: 6px 10px;
+        border: 1px solid #5b2f2f;
+        border-radius: 6px;
+        background: #2a1717;
+        color: #ffb5b5;
+        cursor: pointer;
+      }
+
+      .kill-button:hover:not(:disabled) {
+        border-color: #da7756;
+        color: #ffd3c8;
+      }
+
+      .kill-button:disabled {
+        cursor: not-allowed;
+        opacity: 0.45;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <div class="tab-bar" role="tablist" aria-label="Desktop tabs">
+        <div class="tab-item">
+          <button
+            type="button"
+            class="tab-button active"
+            data-tab="chat"
+            role="tab"
+            aria-selected="true"
+          >
+            Chat
+          </button>
+          <button
+            type="button"
+            class="pop-out-button"
+            data-popout="chat"
+            aria-label="Pop out Chat"
+            title="Pop out Chat"
+          >
+            &#8599;
+          </button>
+        </div>
+        <div class="tab-item">
+          <button
+            type="button"
+            class="tab-button"
+            data-tab="ports"
+            role="tab"
+            aria-selected="false"
+          >
+            Ports
+          </button>
+          <button
+            type="button"
+            class="pop-out-button"
+            data-popout="ports"
+            aria-label="Pop out Ports"
+            title="Pop out Ports"
+          >
+            &#8599;
+          </button>
+        </div>
+      </div>
+
+      <div class="content-area">
+        <webview
+          id="chat-webview"
+          src="http://127.0.0.1:8300"
+          allowpopups
+          partition="persist:agentchattr"
+          preload=""
+        ></webview>
+        <div id="ports-container" hidden></div>
+      </div>
+    </div>
+
+    <script src="./renderer.js"></script>
+  </body>
+</html>

--- a/electron/renderer/renderer.js
+++ b/electron/renderer/renderer.js
@@ -1,0 +1,415 @@
+"use strict";
+
+const state = {
+  activeTab: "chat",
+  portRows: [],
+  notice: null,
+  pendingChannel: null,
+  webviewReady: false,
+};
+
+const elements = {
+  tabButtons: Array.from(document.querySelectorAll(".tab-button")),
+  popOutButtons: Array.from(document.querySelectorAll(".pop-out-button")),
+  chatWebview: document.getElementById("chat-webview"),
+  portsContainer: document.getElementById("ports-container"),
+};
+
+const RESERVED_DEEP_LINK_TARGETS = new Set(["chat", "ports", "channel"]);
+
+function fileUrlToPath(fileUrl) {
+  const pathname = decodeURIComponent(new URL(fileUrl).pathname);
+  if (/^\/[A-Za-z]:/.test(pathname)) {
+    return pathname.slice(1).replace(/\//g, "\\");
+  }
+
+  return pathname;
+}
+
+function configureWebview() {
+  const preloadPath = fileUrlToPath(
+    new URL("../preload-webview.js", window.location.href).toString(),
+  );
+  const currentPreload = elements.chatWebview.getAttribute("preload");
+
+  if (currentPreload === preloadPath) {
+    return;
+  }
+
+  elements.chatWebview.setAttribute("preload", preloadPath);
+  elements.chatWebview.setAttribute(
+    "src",
+    elements.chatWebview.getAttribute("src"),
+  );
+}
+
+function activateTab(tabName) {
+  state.activeTab = tabName;
+
+  for (const button of elements.tabButtons) {
+    const isActive = button.dataset.tab === tabName;
+    button.classList.toggle("active", isActive);
+    button.setAttribute("aria-selected", String(isActive));
+  }
+
+  elements.chatWebview.hidden = tabName !== "chat";
+  elements.portsContainer.hidden = tabName !== "ports";
+}
+
+function readField(row, keys, fallback = "\u2014") {
+  for (const key of keys) {
+    const value = row?.[key];
+
+    if (value !== undefined && value !== null && value !== "") {
+      return value;
+    }
+  }
+
+  return fallback;
+}
+
+function readPid(row) {
+  const value = readField(row, ["pid", "processId"], null);
+  return value === null ? null : String(value);
+}
+
+function normalisePortRows(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (Array.isArray(payload?.ports)) {
+    return payload.ports;
+  }
+
+  if (Array.isArray(payload?.rows)) {
+    return payload.rows;
+  }
+
+  if (Array.isArray(payload?.items)) {
+    return payload.items;
+  }
+
+  if (Array.isArray(payload?.data)) {
+    return payload.data;
+  }
+
+  return [];
+}
+
+function setNotice(message, tone = "info") {
+  state.notice = message ? { message, tone } : null;
+}
+
+function buildCell(text, className = "") {
+  const cell = document.createElement("td");
+  cell.textContent = text;
+
+  if (className) {
+    cell.className = className;
+  }
+
+  return cell;
+}
+
+async function handleKillProcess(pid) {
+  if (!pid || !window.electronAPI?.killProcess) {
+    return;
+  }
+
+  const result = await window.electronAPI.killProcess(pid);
+
+  if (result?.success) {
+    setNotice(`Termination signal sent to PID ${pid}.`);
+  } else {
+    setNotice(result?.error ?? `Unable to terminate PID ${pid}.`, "error");
+  }
+
+  renderPorts();
+}
+
+function renderPorts() {
+  const container = elements.portsContainer;
+  container.innerHTML = "";
+
+  const shell = document.createElement("div");
+  shell.className = "ports-shell";
+
+  const header = document.createElement("div");
+  header.className = "ports-header";
+
+  const title = document.createElement("h1");
+  title.className = "ports-title";
+  title.textContent = "Ports";
+
+  const meta = document.createElement("div");
+  meta.className = "ports-meta";
+  meta.textContent = `${state.portRows.length} entr${state.portRows.length === 1 ? "y" : "ies"}`;
+
+  header.append(title, meta);
+  shell.appendChild(header);
+
+  if (state.notice) {
+    const notice = document.createElement("div");
+    notice.className =
+      `ports-notice ${state.notice.tone === "error" ? "error" : ""}`.trim();
+    notice.textContent = state.notice.message;
+    shell.appendChild(notice);
+  }
+
+  if (state.portRows.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "ports-empty";
+    empty.innerHTML =
+      "<strong>Waiting for port data</strong><span>Port information will appear here when the Electron main process emits it.</span>";
+    shell.appendChild(empty);
+    container.appendChild(shell);
+    return;
+  }
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "ports-table-wrap";
+
+  const table = document.createElement("table");
+  table.className = "ports-table";
+
+  const thead = document.createElement("thead");
+  const headerRow = document.createElement("tr");
+
+  for (const label of [
+    "Port",
+    "Address",
+    "PID",
+    "Process",
+    "Agent",
+    "Actions",
+  ]) {
+    const th = document.createElement("th");
+    th.scope = "col";
+    th.textContent = label;
+    headerRow.appendChild(th);
+  }
+
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+
+  for (const row of state.portRows) {
+    const tr = document.createElement("tr");
+    const pid = readPid(row);
+
+    tr.appendChild(
+      buildCell(
+        String(readField(row, ["port", "localPort", "listenPort"])),
+        "mono",
+      ),
+    );
+    tr.appendChild(
+      buildCell(String(readField(row, ["address", "host", "bind", "ip"]))),
+    );
+    tr.appendChild(buildCell(pid ?? "\u2014", "mono"));
+    tr.appendChild(
+      buildCell(
+        String(
+          readField(row, ["process", "processName", "command", "name", "exe"]),
+        ),
+        "muted",
+      ),
+    );
+    tr.appendChild(
+      buildCell(
+        String(readField(row, ["agent", "agentName", "owner", "channel"])),
+      ),
+    );
+
+    const actionCell = document.createElement("td");
+    const killButton = document.createElement("button");
+    killButton.type = "button";
+    killButton.className = "kill-button";
+    killButton.textContent = "Kill";
+    killButton.disabled = !pid;
+    killButton.addEventListener("click", async () => {
+      killButton.disabled = true;
+      await handleKillProcess(pid);
+      killButton.disabled = !pid;
+    });
+    actionCell.appendChild(killButton);
+    tr.appendChild(actionCell);
+
+    tbody.appendChild(tr);
+  }
+
+  table.appendChild(tbody);
+  wrapper.appendChild(table);
+  shell.appendChild(wrapper);
+  container.appendChild(shell);
+}
+
+function parseDeepLink(rawUrl) {
+  try {
+    const url = new URL(rawUrl);
+
+    if (url.protocol !== "agentchattr:") {
+      return null;
+    }
+
+    const host = url.hostname.toLowerCase();
+    const segments = url.pathname
+      .split("/")
+      .filter(Boolean)
+      .map((segment) => decodeURIComponent(segment));
+
+    const tabParam = url.searchParams.get("tab")?.toLowerCase();
+    let targetTab = tabParam === "ports" ? "ports" : "chat";
+    let targetChannel = url.searchParams.get("channel");
+
+    if (host === "ports" || segments[0] === "ports") {
+      targetTab = "ports";
+    } else if (host === "chat") {
+      targetTab = "chat";
+      targetChannel ??= segments[0] ?? null;
+    } else if (host === "channel") {
+      targetTab = "chat";
+      targetChannel ??= segments[0] ?? null;
+    } else if (host && !RESERVED_DEEP_LINK_TARGETS.has(host)) {
+      targetTab = "chat";
+      targetChannel ??= host;
+    } else if (
+      segments[0] &&
+      !RESERVED_DEEP_LINK_TARGETS.has(segments[0].toLowerCase())
+    ) {
+      targetChannel ??= segments[0];
+    }
+
+    return {
+      tab: targetTab,
+      channel: targetChannel ? decodeURIComponent(targetChannel) : null,
+    };
+  } catch (error) {
+    console.error("Unable to parse deep link:", error);
+    return null;
+  }
+}
+
+async function synchronisePendingChannel(attempt = 0) {
+  if (!state.pendingChannel || !state.webviewReady) {
+    return;
+  }
+
+  const channel = state.pendingChannel;
+  const script = `
+    (() => {
+      try {
+        const channel = ${JSON.stringify(channel)};
+        localStorage.setItem('agentchattr-channel', channel);
+        if (typeof window.switchChannel === 'function') {
+          window.switchChannel(channel);
+          return 'switched';
+        }
+        return 'stored';
+      } catch (error) {
+        return 'error:' + error.message;
+      }
+    })();
+  `;
+
+  try {
+    const result = await elements.chatWebview.executeJavaScript(script, true);
+
+    if (result === "switched" || attempt >= 10) {
+      state.pendingChannel = null;
+      return;
+    }
+
+    setTimeout(() => {
+      void synchronisePendingChannel(attempt + 1);
+    }, 250);
+  } catch (error) {
+    console.error("Unable to switch channel in chat webview:", error);
+  }
+}
+
+function handleDeepLink(input) {
+  // C-4 fix: accept both raw URL strings and pre-parsed { type, value } objects
+  // from deep-links.js
+  let target;
+  if (typeof input === "object" && input !== null && input.type) {
+    // Pre-parsed object from deep-links.js: { type: 'channel'|'agent'|'port', value }
+    if (input.type === "port") {
+      target = { tab: "ports", channel: null };
+    } else if (input.type === "channel") {
+      target = { tab: "chat", channel: String(input.value) };
+    } else if (input.type === "agent") {
+      target = { tab: "chat", channel: null };
+    } else {
+      target = { tab: "chat", channel: null };
+    }
+  } else {
+    // Raw URL string
+    target = parseDeepLink(input);
+  }
+
+  if (!target) {
+    return;
+  }
+
+  activateTab(target.tab);
+
+  if (target.channel) {
+    state.pendingChannel = target.channel;
+    void synchronisePendingChannel();
+  }
+}
+
+function bindEvents() {
+  for (const button of elements.tabButtons) {
+    button.addEventListener("click", () => {
+      activateTab(button.dataset.tab);
+    });
+  }
+
+  for (const button of elements.popOutButtons) {
+    button.addEventListener("click", (event) => {
+      event.stopPropagation();
+      window.electronAPI?.requestPopOut?.(button.dataset.popout);
+    });
+  }
+
+  elements.chatWebview.addEventListener("dom-ready", () => {
+    state.webviewReady = true;
+    void synchronisePendingChannel();
+  });
+
+  // H-2 fix: bridge webview ipc-message to main process for notifications
+  elements.chatWebview.addEventListener("ipc-message", (event) => {
+    if (event.channel === "send-notification") {
+      window.electronAPI?.sendNotification?.(event.args[0]);
+    }
+  });
+
+  // H-3 fix: listen for pop-out-requested and other notification events
+  window.electronAPI?.onNotification?.((data) => {
+    if (data?.type === "pop-out-requested") {
+      window.electronAPI?.requestPopOut?.(data.view);
+    }
+  });
+
+  window.electronAPI?.onPortData?.((data) => {
+    state.portRows = normalisePortRows(data);
+    renderPorts();
+  });
+
+  window.electronAPI?.onDeepLink?.((url) => {
+    handleDeepLink(url);
+  });
+}
+
+function init() {
+  configureWebview();
+  bindEvents();
+  activateTab("chat");
+  renderPorts();
+}
+
+init();

--- a/electron/renderer/renderer.js
+++ b/electron/renderer/renderer.js
@@ -6,12 +6,23 @@ const state = {
   notice: null,
   pendingChannel: null,
   webviewReady: false,
+  browserPane: window.BrowserPaneState.createBrowserPaneState(),
 };
+
+const CHANNEL_SYNC_RETRY_MS = 250;
+const CHANNEL_SYNC_MAX_ATTEMPTS = 40;
 
 const elements = {
   tabButtons: Array.from(document.querySelectorAll(".tab-button")),
   popOutButtons: Array.from(document.querySelectorAll(".pop-out-button")),
+  chatShell: document.getElementById("chat-shell"),
   chatWebview: document.getElementById("chat-webview"),
+  browserPane: document.getElementById("browser-pane"),
+  browserWebview: document.getElementById("browser-webview"),
+  browserPaneMeta: document.getElementById("browser-pane-meta"),
+  browserPaneUrl: document.getElementById("browser-pane-url"),
+  browserPanePopout: document.getElementById("browser-pane-popout"),
+  browserPaneClose: document.getElementById("browser-pane-close"),
   portsContainer: document.getElementById("ports-container"),
 };
 
@@ -52,7 +63,7 @@ function activateTab(tabName) {
     button.setAttribute("aria-selected", String(isActive));
   }
 
-  elements.chatWebview.hidden = tabName !== "chat";
+  elements.chatShell.hidden = tabName !== "chat";
   elements.portsContainer.hidden = tabName !== "ports";
 }
 
@@ -246,6 +257,56 @@ function renderPorts() {
   container.appendChild(shell);
 }
 
+async function handleDesktopCommand(payload) {
+  const result = window.BrowserPaneState.reduceBrowserCommand(
+    state.browserPane,
+    payload,
+  );
+  if (result.error) {
+    return;
+  }
+
+  state.browserPane = result.state;
+  renderBrowserPane();
+
+  if (payload?.target !== "window") {
+    activateTab("chat");
+  }
+
+  if (result.effect) {
+    await runBrowserPaneEffect(result.effect);
+  }
+}
+
+async function runBrowserPaneEffect(effect) {
+  if (!effect || effect.type !== "popout" || !effect.url) {
+    return;
+  }
+
+  try {
+    await window.electronAPI?.openBrowserUrl?.(effect.url);
+  } catch (error) {
+    console.error("Unable to open browser url:", error);
+  }
+}
+
+function renderBrowserPane() {
+  const pane = state.browserPane;
+  const visible = !!pane.visible && !!pane.url;
+
+  elements.browserPane.hidden = !visible;
+  elements.browserPaneMeta.textContent = pane.requestedBy
+    ? `Requested by ${pane.requestedBy}`
+    : "No page open";
+  elements.browserPaneUrl.textContent = pane.url || "about:blank";
+  elements.browserPanePopout.disabled = !pane.url;
+  elements.browserPaneClose.disabled = !visible;
+
+  if (pane.url && elements.browserWebview.getAttribute("src") !== pane.url) {
+    elements.browserWebview.setAttribute("src", pane.url);
+  }
+}
+
 function parseDeepLink(rawUrl) {
   try {
     const url = new URL(rawUrl);
@@ -317,16 +378,26 @@ async function synchronisePendingChannel(attempt = 0) {
   try {
     const result = await elements.chatWebview.executeJavaScript(script, true);
 
-    if (result === "switched" || attempt >= 10) {
+    if (result === "switched" || attempt >= CHANNEL_SYNC_MAX_ATTEMPTS) {
       state.pendingChannel = null;
       return;
     }
 
     setTimeout(() => {
       void synchronisePendingChannel(attempt + 1);
-    }, 250);
+    }, CHANNEL_SYNC_RETRY_MS);
   } catch (error) {
-    console.error("Unable to switch channel in chat webview:", error);
+    if (attempt >= CHANNEL_SYNC_MAX_ATTEMPTS) {
+      console.error("Unable to switch channel in chat webview:", error);
+      state.pendingChannel = null;
+      return;
+    }
+
+    // The webview can still be navigating when deep-link/focus events land.
+    // Retry instead of dropping the pending channel on the first transient error.
+    setTimeout(() => {
+      void synchronisePendingChannel(attempt + 1);
+    }, CHANNEL_SYNC_RETRY_MS);
   }
 }
 
@@ -381,10 +452,28 @@ function bindEvents() {
     void synchronisePendingChannel();
   });
 
+  elements.browserPanePopout.addEventListener("click", () => {
+    const result = window.BrowserPaneState.popoutBrowserPane(state.browserPane);
+    state.browserPane = result.state;
+    renderBrowserPane();
+    if (result.effect) {
+      void runBrowserPaneEffect(result.effect);
+    }
+  });
+
+  elements.browserPaneClose.addEventListener("click", () => {
+    state.browserPane = window.BrowserPaneState.closeBrowserPane(
+      state.browserPane,
+    );
+    renderBrowserPane();
+  });
+
   // H-2 fix: bridge webview ipc-message to main process for notifications
   elements.chatWebview.addEventListener("ipc-message", (event) => {
     if (event.channel === "send-notification") {
       window.electronAPI?.sendNotification?.(event.args[0]);
+    } else if (event.channel === "desktop-command") {
+      void handleDesktopCommand(event.args[0]);
     }
   });
 
@@ -417,6 +506,7 @@ function init() {
   configureWebview();
   bindEvents();
   activateTab("chat");
+  renderBrowserPane();
   renderPorts();
 }
 

--- a/electron/renderer/renderer.js
+++ b/electron/renderer/renderer.js
@@ -403,6 +403,14 @@ function bindEvents() {
   window.electronAPI?.onDeepLink?.((url) => {
     handleDeepLink(url);
   });
+
+  window.electronAPI?.onFocusChannel?.((channel) => {
+    activateTab("chat");
+    if (channel) {
+      state.pendingChannel = channel;
+      void synchronisePendingChannel();
+    }
+  });
 }
 
 function init() {

--- a/electron/shortcuts.js
+++ b/electron/shortcuts.js
@@ -1,0 +1,70 @@
+const { globalShortcut } = require('electron');
+
+const DEFAULT_SHORTCUT = 'CommandOrControl+Shift+A';
+
+let registeredShortcut = null;
+
+function getShortcut(preferences) {
+  const configuredShortcut =
+    preferences && typeof preferences.get === 'function'
+      ? preferences.get('globalShortcut')
+      : null;
+
+  if (typeof configuredShortcut === 'string' && configuredShortcut.trim()) {
+    return configuredShortcut.trim();
+  }
+
+  return DEFAULT_SHORTCUT;
+}
+
+function toggleMainWindow(mainWindow) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  if (typeof mainWindow.isVisible === 'function' && mainWindow.isVisible()) {
+    mainWindow.hide();
+    return;
+  }
+
+  if (typeof mainWindow.isMinimized === 'function' && mainWindow.isMinimized()) {
+    mainWindow.restore();
+  }
+
+  mainWindow.show();
+  mainWindow.focus();
+}
+
+function registerShortcuts(mainWindow, preferences) {
+  const accelerator = getShortcut(preferences);
+
+  if (registeredShortcut) {
+    globalShortcut.unregister(registeredShortcut);
+    registeredShortcut = null;
+  }
+
+  try {
+    const registered = globalShortcut.register(accelerator, () => {
+      toggleMainWindow(mainWindow);
+    });
+
+    if (!registered) {
+      console.warn(`Failed to register global shortcut: ${accelerator}`);
+      return;
+    }
+
+    registeredShortcut = accelerator;
+  } catch (error) {
+    console.warn(`Failed to register global shortcut: ${accelerator}`, error);
+  }
+}
+
+function unregisterAll() {
+  registeredShortcut = null;
+  globalShortcut.unregisterAll();
+}
+
+module.exports = {
+  registerShortcuts,
+  unregisterAll,
+};

--- a/electron/tray.js
+++ b/electron/tray.js
@@ -1,0 +1,127 @@
+const fs = require('fs');
+const path = require('path');
+const { Tray, Menu, nativeImage, app } = require('electron');
+
+const ICON_PATH = path.join(__dirname, 'assets', 'icon.png');
+const FALLBACK_COLOUR = '#da7756';
+
+let trayInstance = null;
+let trackedWindow = null;
+
+function createSvgDataUrl(svgMarkup) {
+  return `data:image/svg+xml;base64,${Buffer.from(svgMarkup).toString('base64')}`;
+}
+
+function createFallbackSquareIcon() {
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <rect width="16" height="16" fill="${FALLBACK_COLOUR}" />
+    </svg>
+  `;
+
+  return nativeImage.createFromDataURL(createSvgDataUrl(svg));
+}
+
+function loadTrayIcon() {
+  if (fs.existsSync(ICON_PATH)) {
+    const icon = nativeImage.createFromPath(ICON_PATH);
+
+    if (!icon.isEmpty()) {
+      return icon;
+    }
+  }
+
+  return createFallbackSquareIcon();
+}
+
+function createBadgeImage(count) {
+  const displayCount = count > 99 ? '99+' : String(count);
+  const fontSize = displayCount.length > 2 ? 11 : 14;
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+      <circle cx="16" cy="16" r="15" fill="${FALLBACK_COLOUR}" />
+      <text
+        x="16"
+        y="16"
+        font-family="Segoe UI, sans-serif"
+        font-size="${fontSize}"
+        font-weight="700"
+        dominant-baseline="central"
+        text-anchor="middle"
+        fill="#ffffff"
+      >${displayCount}</text>
+    </svg>
+  `;
+
+  return nativeImage.createFromDataURL(createSvgDataUrl(svg));
+}
+
+function toggleWindowVisibility(mainWindow) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  if (mainWindow.isVisible()) {
+    mainWindow.hide();
+    return;
+  }
+
+  mainWindow.show();
+  mainWindow.focus();
+}
+
+function createTray(mainWindow) {
+  trackedWindow = mainWindow ?? null;
+
+  if (trayInstance) {
+    trayInstance.destroy();
+  }
+
+  trayInstance = new Tray(loadTrayIcon());
+  trayInstance.setToolTip('agentchattr');
+  trayInstance.setContextMenu(
+    Menu.buildFromTemplate([
+      {
+        label: 'Show/Hide',
+        click: () => toggleWindowVisibility(trackedWindow),
+      },
+      { type: 'separator' },
+      {
+        label: 'Quit',
+        click: () => app.quit(),
+      },
+    ])
+  );
+
+  trayInstance.on('double-click', () => {
+    if (!trackedWindow || trackedWindow.isDestroyed()) {
+      return;
+    }
+
+    trackedWindow.show();
+    trackedWindow.focus();
+  });
+
+  return trayInstance;
+}
+
+function setBadge(count) {
+  if (!trackedWindow || trackedWindow.isDestroyed()) {
+    return;
+  }
+
+  if (count > 0) {
+    trackedWindow.setOverlayIcon(
+      createBadgeImage(count),
+      `${count} unread notification${count === 1 ? '' : 's'}`
+    );
+    return;
+  }
+
+  trackedWindow.setOverlayIcon(null, '');
+}
+
+module.exports = {
+  createTray,
+  setBadge,
+};

--- a/mcp_bridge.py
+++ b/mcp_bridge.py
@@ -5,12 +5,14 @@ Serves two transports for compatibility:
   - SSE on port 8201 (Gemini)
 """
 
+import asyncio
 import json
 import os
 import time
 import logging
 import threading
 from pathlib import Path
+from urllib.parse import urlparse
 
 from mcp.server.fastmcp import Context, FastMCP
 
@@ -886,9 +888,75 @@ def chat_summary(
     return f"Unknown action: {action}. Valid actions: read, write."
 
 
+def _emit_desktop_command(payload: dict) -> bool:
+    """Broadcast a desktop-only command to connected Electron webviews."""
+    try:
+        import app as _app
+
+        loop = getattr(_app, "_event_loop", None)
+        if not loop:
+            return False
+        raw = json.dumps({"type": "desktop_command", "data": payload})
+        asyncio.run_coroutine_threadsafe(_app._broadcast(raw), loop)
+        return True
+    except Exception:
+        log.exception("Failed to emit desktop command")
+        return False
+
+
+def browser_open(
+    sender: str,
+    url: str,
+    target: str = "docked",
+    ctx: Context | None = None,
+) -> str:
+    """Open an HTTP(S) URL in the Electron desktop app, docked or in a window."""
+    sender, err = _resolve_tool_identity(sender, ctx, field_name="sender", required=True)
+    if err:
+        return err
+
+    raw_url = (url or "").strip()
+    if not raw_url:
+        return "Error: url is required."
+
+    target_mode = (target or "docked").strip().lower()
+    if target_mode not in ("docked", "window"):
+        return "Error: target must be 'docked' or 'window'"
+
+    parsed = urlparse(raw_url)
+    if parsed.scheme not in ("http", "https"):
+        return "Error: url must start with http:// or https://"
+    if not parsed.netloc:
+        return "Error: url must include a host."
+
+    payload = {
+        "command": "browser_open",
+        "url": raw_url,
+        "target": target_mode,
+        "requested_by": sender,
+    }
+    if not _emit_desktop_command(payload):
+        return "Error: desktop command bridge unavailable."
+
+    _touch_presence(sender)
+    if target_mode == "window":
+        return f"Requested browser pop-out: {raw_url}"
+    return f"Requested docked browser open: {raw_url}"
+
+
+def browser_popout(
+    sender: str,
+    url: str,
+    ctx: Context | None = None,
+) -> str:
+    """Open an HTTP(S) URL in a separate Electron browser window."""
+    return browser_open(sender=sender, url=url, target="window", ctx=ctx)
+
+
 _ALL_TOOLS = [
     chat_send, chat_read, chat_resync, chat_join, chat_who, chat_rules, chat_decision,
     chat_channels, chat_set_hat, chat_claim, chat_summary, chat_propose_job,
+    browser_open, browser_popout,
 ]
 
 

--- a/process_manager.py
+++ b/process_manager.py
@@ -11,6 +11,7 @@ import json
 import logging
 import subprocess
 import threading
+import time
 from collections import deque
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -50,16 +51,19 @@ class ManagedAgent:
 
     def __init__(
         self,
+        base: str,
         name: str,
         proc: subprocess.Popen,
         command: str,
         flags: list[str],
         extra_args: list[str],
         cwd: str,
+        instance_label: str | None = None,
         *,
         on_log: Optional[Callable[[str, str], None]] = None,
         on_state_change: Optional[Callable[[str, str, str], None]] = None,
     ):
+        self.base = base
         self.name = name
         self.proc = proc
         self.command = command
@@ -67,6 +71,8 @@ class ManagedAgent:
         self.extra_args = list(extra_args)
         self.cwd = cwd
         self.pid = proc.pid
+        self.instance_label = instance_label
+        self.started_at = time.time()
         self.log_buffer: deque[str] = deque(maxlen=100)
         self._state = "starting"
         self._on_log = on_log
@@ -154,6 +160,7 @@ class ManagedAgent:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "base": self.base,
             "name": self.name,
             "pid": self.pid,
             "state": self.state,
@@ -161,7 +168,32 @@ class ManagedAgent:
             "flags": self.flags,
             "extra_args": self.extra_args,
             "cwd": self.cwd,
+            "instance_label": self.instance_label,
+            "started_at": self.started_at,
             "log_lines": len(self.log_buffer),
+        }
+
+    def to_restore_dict(self) -> dict[str, Any]:
+        restore_flags = list(self.flags)
+        restore_extra_args = list(self.extra_args)
+
+        if restore_extra_args:
+            first_arg = Path(str(restore_extra_args[0])).name.lower()
+            if first_arg == "wrapper.py":
+                if "--" in restore_extra_args:
+                    restore_extra_args = restore_extra_args[restore_extra_args.index("--") + 1 :]
+                else:
+                    restore_extra_args = []
+                restore_flags = []
+
+        return {
+            "base": self.base,
+            "name": self.name,
+            "flags": restore_flags,
+            "extra_args": restore_extra_args,
+            "cwd": self.cwd,
+            "instance_label": self.instance_label,
+            "started_at": self.started_at,
         }
 
 
@@ -211,13 +243,7 @@ class ProcessManager:
         entries = []
         for agent in self._agents.values():
             if agent.state in ("starting", "running"):
-                entries.append({
-                    "name": agent.name,
-                    "command": agent.command,
-                    "flags": agent.flags,
-                    "extra_args": agent.extra_args,
-                    "cwd": agent.cwd,
-                })
+                entries.append(agent.to_restore_dict())
         try:
             self._state_file.write_text(
                 json.dumps(entries, indent=2), encoding="utf-8"
@@ -277,12 +303,14 @@ class ProcessManager:
             return {"ok": False, "error": str(exc)}
 
         agent = ManagedAgent(
+            base=base,
             name=name,
             proc=proc,
             command=command,
             flags=flags,
             extra_args=extra_args,
             cwd=str(cwd_path),
+            instance_label=instance_label,
             on_log=self._on_log,
             on_state_change=self._on_state_change,
         )

--- a/process_manager.py
+++ b/process_manager.py
@@ -1,0 +1,327 @@
+"""ProcessManager — spawn and track agent subprocesses.
+
+Provides ManagedAgent (per-process state machine + log ring buffer) and
+ProcessManager (launch / stop / list / persist).  Used by the FastAPI server
+to manage wrapper.py subprocesses from the web UI.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import threading
+from collections import deque
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Flag presets per agent type
+# ---------------------------------------------------------------------------
+
+AGENT_FLAG_PRESETS: dict[str, list[dict[str, str]]] = {
+    "claude": [
+        {"label": "Skip permissions", "flag": "--dangerously-skip-permissions"},
+        {"label": "Worktree", "flag": "--worktree"},
+    ],
+    "codex": [
+        {"label": "Bypass approvals", "flag": "--dangerously-bypass-approvals-and-sandbox"},
+    ],
+    "gemini": [
+        {"label": "Yolo", "flag": "--yolo"},
+        {"label": "Sandbox", "flag": "--sandbox"},
+    ],
+    "qwen": [
+        {"label": "Yolo", "flag": "--yolo"},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# ManagedAgent — wraps a single subprocess
+# ---------------------------------------------------------------------------
+
+class ManagedAgent:
+    """Tracks a single subprocess with a state machine and log ring buffer."""
+
+    VALID_STATES = ("starting", "running", "crashed", "stopped")
+
+    def __init__(
+        self,
+        name: str,
+        proc: subprocess.Popen,
+        command: str,
+        flags: list[str],
+        extra_args: list[str],
+        cwd: str,
+        *,
+        on_log: Optional[Callable[[str, str], None]] = None,
+        on_state_change: Optional[Callable[[str, str, str], None]] = None,
+    ):
+        self.name = name
+        self.proc = proc
+        self.command = command
+        self.flags = list(flags)
+        self.extra_args = list(extra_args)
+        self.cwd = cwd
+        self.pid = proc.pid
+        self.log_buffer: deque[str] = deque(maxlen=100)
+        self._state = "starting"
+        self._on_log = on_log
+        self._on_state_change = on_state_change
+        self._stop_event = threading.Event()
+
+        # Daemon threads so they don't block interpreter shutdown
+        self._reader_thread = threading.Thread(
+            target=self._drain_stdout, daemon=True, name=f"reader-{name}"
+        )
+        self._waiter_thread = threading.Thread(
+            target=self._wait_for_exit, daemon=True, name=f"waiter-{name}"
+        )
+        self._reader_thread.start()
+        self._waiter_thread.start()
+
+    # -- state property -----------------------------------------------------
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @state.setter
+    def state(self, new: str) -> None:
+        old = self._state
+        if old == new:
+            return
+        self._state = new
+        log.debug("agent %s: %s -> %s", self.name, old, new)
+        if self._on_state_change:
+            try:
+                self._on_state_change(self.name, old, new)
+            except Exception:
+                log.exception("on_state_change callback failed for %s", self.name)
+
+    # -- background threads -------------------------------------------------
+
+    def _drain_stdout(self) -> None:
+        """Read subprocess stdout line-by-line into the ring buffer."""
+        try:
+            assert self.proc.stdout is not None
+            for raw_line in self.proc.stdout:
+                if self._stop_event.is_set():
+                    break
+                line = raw_line.decode("utf-8", errors="replace").rstrip("\n\r")
+                self.log_buffer.append(line)
+                # Transition starting -> running on first output
+                if self._state == "starting":
+                    self.state = "running"
+                if self._on_log:
+                    try:
+                        self._on_log(self.name, line)
+                    except Exception:
+                        pass
+        except Exception:
+            log.exception("reader thread error for %s", self.name)
+
+    def _wait_for_exit(self) -> None:
+        """Wait for the subprocess to terminate and update state."""
+        retcode = self.proc.wait()
+        # If we explicitly stopped it, state is already "stopped"
+        if self._state != "stopped":
+            self.state = "crashed" if retcode != 0 else "stopped"
+
+    # -- public API ---------------------------------------------------------
+
+    def stop(self) -> None:
+        """Gracefully terminate the subprocess (SIGTERM, then SIGKILL after 5s)."""
+        if self.proc.poll() is not None:
+            # Already dead
+            self.state = "stopped"
+            return
+
+        self._stop_event.set()
+        self.state = "stopped"
+
+        # On Windows there is no SIGTERM for subprocesses; terminate() sends
+        # the platform-appropriate signal.
+        self.proc.terminate()
+        try:
+            self.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait(timeout=5)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "pid": self.pid,
+            "state": self.state,
+            "command": self.command,
+            "flags": self.flags,
+            "extra_args": self.extra_args,
+            "cwd": self.cwd,
+            "log_lines": len(self.log_buffer),
+        }
+
+
+# ---------------------------------------------------------------------------
+# ProcessManager
+# ---------------------------------------------------------------------------
+
+class ProcessManager:
+    """Spawn, track, and persist agent subprocesses."""
+
+    def __init__(
+        self,
+        data_dir: Path,
+        server_port: int,
+        on_log: Optional[Callable[[str, str], None]] = None,
+        on_state_change: Optional[Callable[[str, str, str], None]] = None,
+    ):
+        self.data_dir = Path(data_dir)
+        self.server_port = server_port
+        self._on_log = on_log
+        self._on_state_change = on_state_change
+        self._agents: dict[str, ManagedAgent] = {}
+        self._lock = threading.Lock()
+
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- name allocation ----------------------------------------------------
+
+    def _assign_name(self, base: str) -> str:
+        """Return *base* if unused, else base-2, base-3, ..."""
+        with self._lock:
+            if base not in self._agents:
+                return base
+            n = 2
+            while f"{base}-{n}" in self._agents:
+                n += 1
+            return f"{base}-{n}"
+
+    # -- launch state persistence -------------------------------------------
+
+    @property
+    def _state_file(self) -> Path:
+        return self.data_dir / "launch_state.json"
+
+    def _save_launch_state(self) -> None:
+        """Persist running agents' configs to launch_state.json."""
+        entries = []
+        for agent in self._agents.values():
+            if agent.state in ("starting", "running"):
+                entries.append({
+                    "name": agent.name,
+                    "command": agent.command,
+                    "flags": agent.flags,
+                    "extra_args": agent.extra_args,
+                    "cwd": agent.cwd,
+                })
+        try:
+            self._state_file.write_text(
+                json.dumps(entries, indent=2), encoding="utf-8"
+            )
+        except Exception:
+            log.exception("failed to save launch state")
+
+    def get_restore_state(self) -> list[dict[str, Any]]:
+        """Load launch_state.json if it exists, else return []."""
+        if self._state_file.exists():
+            try:
+                return json.loads(self._state_file.read_text(encoding="utf-8"))
+            except Exception:
+                log.exception("failed to read launch state")
+        return []
+
+    def clear_restore_state(self) -> None:
+        """Delete the launch state file."""
+        try:
+            self._state_file.unlink(missing_ok=True)
+        except Exception:
+            log.exception("failed to clear launch state")
+
+    # -- core API -----------------------------------------------------------
+
+    def launch(
+        self,
+        base: str,
+        command: str,
+        flags: list[str],
+        extra_args: list[str],
+        cwd: str,
+        instance_label: str | None = None,
+    ) -> dict[str, Any]:
+        """Spawn a subprocess and begin tracking it.
+
+        Returns ``{"ok": True, "name": ..., "pid": ...}`` on success,
+        or ``{"ok": False, "error": ...}`` on failure.
+        """
+        # Validate cwd
+        cwd_path = Path(cwd)
+        if not cwd_path.exists():
+            return {"ok": False, "error": f"cwd does not exist: {cwd}"}
+
+        name = self._assign_name(instance_label or base)
+
+        cmd_list = [command] + flags + extra_args
+
+        try:
+            proc = subprocess.Popen(
+                cmd_list,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                cwd=str(cwd_path),
+            )
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+        agent = ManagedAgent(
+            name=name,
+            proc=proc,
+            command=command,
+            flags=flags,
+            extra_args=extra_args,
+            cwd=str(cwd_path),
+            on_log=self._on_log,
+            on_state_change=self._on_state_change,
+        )
+
+        with self._lock:
+            self._agents[name] = agent
+
+        self._save_launch_state()
+
+        return {"ok": True, "name": name, "pid": proc.pid}
+
+    def stop(self, name: str) -> dict[str, Any]:
+        """Stop a managed agent by name."""
+        with self._lock:
+            agent = self._agents.get(name)
+        if agent is None:
+            return {"ok": False, "error": f"unknown agent: {name}"}
+
+        agent.stop()
+        self._save_launch_state()
+        return {"ok": True}
+
+    def get_logs(self, name: str) -> list[str]:
+        """Return the log ring buffer for *name*."""
+        with self._lock:
+            agent = self._agents.get(name)
+        if agent is None:
+            return []
+        return list(agent.log_buffer)
+
+    def list_managed(self) -> list[dict[str, Any]]:
+        """Return a snapshot list of all tracked agents."""
+        with self._lock:
+            agents = list(self._agents.values())
+        return [a.to_dict() for a in agents]
+
+    def shutdown(self) -> None:
+        """Stop every tracked agent."""
+        with self._lock:
+            names = list(self._agents.keys())
+        for name in names:
+            self.stop(name)

--- a/registry.py
+++ b/registry.py
@@ -52,6 +52,26 @@ class RuntimeRegistry:
             for name, cfg in agents_config.items():
                 self._bases[name] = dict(cfg)
 
+    def upsert_base(self, name: str, cfg: dict):
+        """Add or update a base template at runtime."""
+        with self._lock:
+            self._bases[name] = dict(cfg)
+        self._notify()
+
+    def remove_base(self, name: str) -> bool:
+        """Remove a base template if no live instances still depend on it."""
+        removed = False
+        with self._lock:
+            has_instances = any(inst.base == name for inst in self._instances.values())
+            if has_instances:
+                return False
+            if name in self._bases:
+                del self._bases[name]
+                removed = True
+        if removed:
+            self._notify()
+        return removed
+
     def on_change(self, cb):
         """Register a callback fired after any registry mutation."""
         self._on_change_cbs.append(cb)

--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 """Entry point — starts MCP server (port 8200) + web UI (port 8300)."""
 
 import asyncio
+import json
 import secrets
 import sys
 import threading
@@ -54,6 +55,22 @@ def main():
     mcp_bridge._load_cursors()
     mcp_bridge._ROLES_FILE = data_dir / "roles.json"
     mcp_bridge._load_roles()
+
+    # Create process manager for UI-launched agents
+    from process_manager import ProcessManager
+    import app as _app_module
+
+    def _on_agent_log(name: str, line: str):
+        loop = getattr(_app_module, '_event_loop', None)
+        if loop:
+            event = json.dumps({"type": "agent_log", "data": {"name": name, "line": line}})
+            asyncio.run_coroutine_threadsafe(_app_module._broadcast(event), loop)
+
+    _app_module.process_manager = ProcessManager(
+        data_dir=data_dir,
+        server_port=config.get("server", {}).get("port", 8300),
+        on_log=_on_agent_log,
+    )
 
     # Start MCP servers in background threads
     http_port = config.get("mcp", {}).get("http_port", 8200)

--- a/run.py
+++ b/run.py
@@ -75,15 +75,19 @@ def main():
     @app.get("/")
     async def index():
         # Read index.html fresh each request so changes take effect without restart.
-        # Inject the session token into the HTML so the browser client can use it.
-        # This is safe: same-origin policy prevents cross-origin pages from reading
-        # the response body, so only the user's own browser tab gets the token.
+        # Session token is delivered via HttpOnly cookie (not a JS global) so that
+        # XSS cannot exfiltrate it.  The browser sends the cookie automatically on
+        # every same-origin fetch and WebSocket handshake.
         html = (static_dir / "index.html").read_text("utf-8")
-        injected = html.replace(
-            "</head>",
-            f'<script>window.__SESSION_TOKEN__="{session_token}";</script>\n</head>',
+        resp = HTMLResponse(html, headers={"Cache-Control": "no-store"})
+        resp.set_cookie(
+            key="session",
+            value=session_token,
+            httponly=True,
+            samesite="strict",
+            path="/",
         )
-        return HTMLResponse(injected, headers={"Cache-Control": "no-store"})
+        return resp
 
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,1174 +1,1373 @@
 /* agentchattr — WebSocket client */
 
-// Session token injected by the server into the HTML page.
-// Sent with every API call and WebSocket connection to authenticate.
-const SESSION_TOKEN = window.__SESSION_TOKEN__ || "";
+// Session token is now delivered via HttpOnly cookie — the browser sends it
+// automatically on every same-origin fetch and WebSocket handshake.
+// No JS-accessible token variable is needed.
 
 let ws = null;
 let pendingAttachments = [];
 let autoScroll = true;
 let reconnectTimer = null;
-let username = 'user';
-let agentConfig = {};  // { name: { color, label } } — registered instances (used for pills)
-let baseColors = {};   // { name: { color, label } } — base agent colors (for message coloring)
-let todos = {};  // { msg_id: "todo" | "done" }
-let rules = [];  // array of rule objects from server
-let activeMentions = new Set();  // agent names with pre-@ toggled on
-let replyingTo = null;  // { id, sender, text } or null
-let unreadCount = 0;    // messages received while scrolled up
-let lastMessageDate = null;  // track date for dividers (general channel)
-let lastMessageDates = {};  // { channel: dateString } for per-channel dividers
-let soundEnabled = false;  // suppress sounds during initial history load
-let activeChannel = localStorage.getItem('agentchattr-channel') || 'general';
-let channelList = ['general'];
-let channelUnread = {};  // { channelName: count }
-let agentHats = {};  // { agent_name: svg_string }
-window.customRoles = [];  // saved custom roles from settings
-let colorOverrides = JSON.parse(localStorage.getItem('agentchattr-color-overrides') || '{}');
-let schedulesList = [];  // array of schedule objects from server
+let username = "user";
+let agentConfig = {}; // { name: { color, label } } — registered instances (used for pills)
+let baseColors = {}; // { name: { color, label } } — base agent colors (for message coloring)
+let todos = {}; // { msg_id: "todo" | "done" }
+let rules = []; // array of rule objects from server
+let activeMentions = new Set(); // agent names with pre-@ toggled on
+let replyingTo = null; // { id, sender, text } or null
+let unreadCount = 0; // messages received while scrolled up
+let lastMessageDate = null; // track date for dividers (general channel)
+let lastMessageDates = {}; // { channel: dateString } for per-channel dividers
+let soundEnabled = false; // suppress sounds during initial history load
+let activeChannel = localStorage.getItem("agentchattr-channel") || "general";
+let channelList = ["general"];
+let channelUnread = {}; // { channelName: count }
+let agentHats = {}; // { agent_name: svg_string }
+window.customRoles = []; // saved custom roles from settings
+let colorOverrides = JSON.parse(
+  localStorage.getItem("agentchattr-color-overrides") || "{}",
+);
+let schedulesList = []; // array of schedule objects from server
 
 // Expose globals that extracted modules (sessions.js, jobs.js) read via window.*
 // Using defineProperty so live values are always returned.
-Object.defineProperty(window, 'SESSION_TOKEN', { get() { return SESSION_TOKEN; } });
-Object.defineProperty(window, 'activeChannel', { get() { return activeChannel; } });
-Object.defineProperty(window, 'channelList', { get() { return channelList; }, set(v) { channelList = v; } });
-Object.defineProperty(window, 'channelUnread', { get() { return channelUnread; }, set(v) { channelUnread = v; } });
-window._setActiveChannel = function(v) { activeChannel = v; };
-window._setPendingChannelSwitch = function(v) { pendingChannelSwitch = v; };
+// SESSION_TOKEN no longer exists as a JS variable — auth is via HttpOnly cookie.
+Object.defineProperty(window, "activeChannel", {
+  get() {
+    return activeChannel;
+  },
+});
+Object.defineProperty(window, "channelList", {
+  get() {
+    return channelList;
+  },
+  set(v) {
+    channelList = v;
+  },
+});
+Object.defineProperty(window, "channelUnread", {
+  get() {
+    return channelUnread;
+  },
+  set(v) {
+    channelUnread = v;
+  },
+});
+window._setActiveChannel = function (v) {
+  activeChannel = v;
+};
+window._setPendingChannelSwitch = function (v) {
+  pendingChannelSwitch = v;
+};
 // scrollToBottom is set after function definition (see below)
-Object.defineProperty(window, 'username', { get() { return username; } });
-Object.defineProperty(window, 'agentConfig', { get() { return agentConfig; } });
-Object.defineProperty(window, 'ws', { get() { return ws; } });
-Object.defineProperty(window, 'soundEnabled', { get() { return soundEnabled; } });
-Object.defineProperty(window, 'rules', { get() { return rules; }, set(v) { rules = v; } });
-Object.defineProperty(window, 'autoScroll', { get() { return autoScroll; } });
-Object.defineProperty(window, '_lastMentionedAgent', {
-    get() { return _lastMentionedAgent; },
-    set(v) { _lastMentionedAgent = v; },
+Object.defineProperty(window, "username", {
+  get() {
+    return username;
+  },
+});
+Object.defineProperty(window, "agentConfig", {
+  get() {
+    return agentConfig;
+  },
+});
+Object.defineProperty(window, "ws", {
+  get() {
+    return ws;
+  },
+});
+Object.defineProperty(window, "soundEnabled", {
+  get() {
+    return soundEnabled;
+  },
+});
+Object.defineProperty(window, "rules", {
+  get() {
+    return rules;
+  },
+  set(v) {
+    rules = v;
+  },
+});
+Object.defineProperty(window, "autoScroll", {
+  get() {
+    return autoScroll;
+  },
+});
+Object.defineProperty(window, "_lastMentionedAgent", {
+  get() {
+    return _lastMentionedAgent;
+  },
+  set(v) {
+    _lastMentionedAgent = v;
+  },
 });
 
 // --- Drag-scroll for overflow containers ---
 function enableDragScroll(el) {
-    let isDown = false, startX, scrollLeft;
-    el.addEventListener('mousedown', e => {
-        if (e.button !== 0) return;  // left-click only
-        isDown = true; startX = e.pageX - el.offsetLeft; scrollLeft = el.scrollLeft;
-        el.style.cursor = 'grabbing';
-    });
-    el.addEventListener('mouseleave', () => { isDown = false; el.style.cursor = ''; });
-    el.addEventListener('mouseup', () => { isDown = false; el.style.cursor = ''; });
-    el.addEventListener('mousemove', e => {
-        if (!isDown) return;
-        e.preventDefault();
-        el.scrollLeft = scrollLeft - (e.pageX - el.offsetLeft - startX);
-    });
+  let isDown = false,
+    startX,
+    scrollLeft;
+  el.addEventListener("mousedown", (e) => {
+    if (e.button !== 0) return; // left-click only
+    isDown = true;
+    startX = e.pageX - el.offsetLeft;
+    scrollLeft = el.scrollLeft;
+    el.style.cursor = "grabbing";
+  });
+  el.addEventListener("mouseleave", () => {
+    isDown = false;
+    el.style.cursor = "";
+  });
+  el.addEventListener("mouseup", () => {
+    isDown = false;
+    el.style.cursor = "";
+  });
+  el.addEventListener("mousemove", (e) => {
+    if (!isDown) return;
+    e.preventDefault();
+    el.scrollLeft = scrollLeft - (e.pageX - el.offsetLeft - startX);
+  });
 }
 
 // --- Notification sounds ---
 const SOUND_OPTIONS = [
-    { value: 'soft-chime', label: 'Soft Chime' },
-    { value: 'bright-ping', label: 'Bright Ping' },
-    { value: 'gentle-pop', label: 'Gentle Pop' },
-    { value: 'alert-tone', label: 'Alert Tone' },
-    { value: 'pluck', label: 'Pluck' },
-    { value: 'click', label: 'Click' },
-    { value: 'warm-bell', label: 'Warm Bell' },
-    { value: 'none', label: 'None' },
+  { value: "soft-chime", label: "Soft Chime" },
+  { value: "bright-ping", label: "Bright Ping" },
+  { value: "gentle-pop", label: "Gentle Pop" },
+  { value: "alert-tone", label: "Alert Tone" },
+  { value: "pluck", label: "Pluck" },
+  { value: "click", label: "Click" },
+  { value: "warm-bell", label: "Warm Bell" },
+  { value: "none", label: "None" },
 ];
-const DEFAULT_SOUND = 'soft-chime';
-const CROSS_CHANNEL_SOUND = 'pluck';
-let soundPrefs = JSON.parse(localStorage.getItem('agentchattr-sounds') || '{}');
+const DEFAULT_SOUND = "soft-chime";
+const CROSS_CHANNEL_SOUND = "pluck";
+let soundPrefs = JSON.parse(localStorage.getItem("agentchattr-sounds") || "{}");
 const soundCache = {};
 
 function playNotificationSound(sender) {
-    const key = sender.toLowerCase();
-    const soundName = soundPrefs[key] || soundPrefs['default'] || DEFAULT_SOUND;
-    if (soundName === 'none') return;
-    if (!soundCache[soundName]) {
-        soundCache[soundName] = new Audio(`/static/sounds/${soundName}.mp3`);
-    }
-    const audio = soundCache[soundName];
-    audio.currentTime = 0;
-    audio.play().catch(() => {});  // ignore autoplay policy errors
+  const key = sender.toLowerCase();
+  const soundName = soundPrefs[key] || soundPrefs["default"] || DEFAULT_SOUND;
+  if (soundName === "none") return;
+  if (!soundCache[soundName]) {
+    soundCache[soundName] = new Audio(`/static/sounds/${soundName}.mp3`);
+  }
+  const audio = soundCache[soundName];
+  audio.currentTime = 0;
+  audio.play().catch(() => {}); // ignore autoplay policy errors
 }
 
 function playCrossChannelSound() {
-    const soundName = soundPrefs['cross-channel'] || CROSS_CHANNEL_SOUND;
-    if (soundName === 'none') return;
-    if (!soundCache[soundName]) {
-        soundCache[soundName] = new Audio(`/static/sounds/${soundName}.mp3`);
-    }
-    const audio = soundCache[soundName];
-    audio.currentTime = 0;
-    audio.play().catch(() => {});
+  const soundName = soundPrefs["cross-channel"] || CROSS_CHANNEL_SOUND;
+  if (soundName === "none") return;
+  if (!soundCache[soundName]) {
+    soundCache[soundName] = new Audio(`/static/sounds/${soundName}.mp3`);
+  }
+  const audio = soundCache[soundName];
+  audio.currentTime = 0;
+  audio.play().catch(() => {});
 }
 window.playCrossChannelSound = playCrossChannelSound;
 
 function buildSoundSettings() {
-    const container = document.getElementById('sound-settings');
-    if (!container) return;
-    container.innerHTML = '';
+  const container = document.getElementById("sound-settings");
+  if (!container) return;
+  container.innerHTML = "";
 
-    // Default sound + cross-channel sound + per-agent rows
-    const agents = ['default', 'cross-channel', ...Object.keys(agentConfig)];
-    for (const name of agents) {
-        const row = document.createElement('div');
-        row.className = 'sound-row';
-        const label = document.createElement('span');
-        label.className = 'sound-label';
-        label.textContent = name === 'default' ? 'Default sound'
-            : name === 'cross-channel' ? 'Background alerts'
-            : (agentConfig[name]?.label || name);
-        const select = document.createElement('select');
-        select.className = 'sound-select';
-        select.dataset.agent = name;
-        const currentVal = soundPrefs[name]
-            || (name === 'default' ? DEFAULT_SOUND : name === 'cross-channel' ? CROSS_CHANNEL_SOUND : '');
-        for (const opt of SOUND_OPTIONS) {
-            const o = document.createElement('option');
-            o.value = opt.value;
-            o.textContent = opt.label;
-            if (currentVal === opt.value) o.selected = true;
-            select.appendChild(o);
-        }
-        // Add "Use default" option for per-agent rows (not default or cross-channel)
-        if (name !== 'default' && name !== 'cross-channel') {
-            const o = document.createElement('option');
-            o.value = '';
-            o.textContent = 'Use default';
-            if (!soundPrefs[name]) o.selected = true;
-            select.insertBefore(o, select.firstChild);
-        }
-        // Preview on change
-        select.addEventListener('change', () => {
-            const val = select.value;
-            soundPrefs[name] = val;
-            localStorage.setItem('agentchattr-sounds', JSON.stringify(soundPrefs));
-            if (val && val !== 'none') {
-                if (!soundCache[val]) soundCache[val] = new Audio(`/static/sounds/${val}.mp3`);
-                soundCache[val].currentTime = 0;
-                soundCache[val].play().catch(() => {});
-            }
-        });
-        row.appendChild(label);
-        row.appendChild(select);
-        container.appendChild(row);
+  // Default sound + cross-channel sound + per-agent rows
+  const agents = ["default", "cross-channel", ...Object.keys(agentConfig)];
+  for (const name of agents) {
+    const row = document.createElement("div");
+    row.className = "sound-row";
+    const label = document.createElement("span");
+    label.className = "sound-label";
+    label.textContent =
+      name === "default"
+        ? "Default sound"
+        : name === "cross-channel"
+          ? "Background alerts"
+          : agentConfig[name]?.label || name;
+    const select = document.createElement("select");
+    select.className = "sound-select";
+    select.dataset.agent = name;
+    const currentVal =
+      soundPrefs[name] ||
+      (name === "default"
+        ? DEFAULT_SOUND
+        : name === "cross-channel"
+          ? CROSS_CHANNEL_SOUND
+          : "");
+    for (const opt of SOUND_OPTIONS) {
+      const o = document.createElement("option");
+      o.value = opt.value;
+      o.textContent = opt.label;
+      if (currentVal === opt.value) o.selected = true;
+      select.appendChild(o);
     }
+    // Add "Use default" option for per-agent rows (not default or cross-channel)
+    if (name !== "default" && name !== "cross-channel") {
+      const o = document.createElement("option");
+      o.value = "";
+      o.textContent = "Use default";
+      if (!soundPrefs[name]) o.selected = true;
+      select.insertBefore(o, select.firstChild);
+    }
+    // Preview on change
+    select.addEventListener("change", () => {
+      const val = select.value;
+      soundPrefs[name] = val;
+      localStorage.setItem("agentchattr-sounds", JSON.stringify(soundPrefs));
+      if (val && val !== "none") {
+        if (!soundCache[val])
+          soundCache[val] = new Audio(`/static/sounds/${val}.mp3`);
+        soundCache[val].currentTime = 0;
+        soundCache[val].play().catch(() => {});
+      }
+    });
+    row.appendChild(label);
+    row.appendChild(select);
+    container.appendChild(row);
+  }
 }
 
 // Real brand logo SVGs from Bootstrap Icons (MIT licensed)
 const BRAND_AVATARS = {
-    claude: `<svg viewBox="0 0 16 16" fill="white"><path d="m3.127 10.604 3.135-1.76.053-.153-.053-.085H6.11l-.525-.032-1.791-.048-1.554-.065-1.505-.08-.38-.081L0 7.832l.036-.234.32-.214.455.04 1.009.069 1.513.105 1.097.064 1.626.17h.259l.036-.105-.089-.065-.068-.064-1.566-1.062-1.695-1.121-.887-.646-.48-.327-.243-.306-.104-.67.435-.48.585.04.15.04.593.456 1.267.981 1.654 1.218.242.202.097-.068.012-.049-.109-.181-.9-1.626-.96-1.655-.428-.686-.113-.411a2 2 0 0 1-.068-.484l.496-.674L4.446 0l.662.089.279.242.411.94.666 1.48 1.033 2.014.302.597.162.553.06.17h.105v-.097l.085-1.134.157-1.392.154-1.792.052-.504.25-.605.497-.327.387.186.319.456-.045.294-.19 1.23-.37 1.93-.243 1.29h.142l.161-.16.654-.868 1.097-1.372.484-.545.565-.601.363-.287h.686l.505.751-.226.775-.707.895-.585.759-.839 1.13-.524.904.048.072.125-.012 1.897-.403 1.024-.186 1.223-.21.553.258.06.263-.218.536-1.307.323-1.533.307-2.284.54-.028.02.032.04 1.029.098.44.024h1.077l2.005.15.525.346.315.424-.053.323-.807.411-3.631-.863-.872-.218h-.12v.073l.726.71 1.331 1.202 1.667 1.55.084.383-.214.302-.226-.032-1.464-1.101-.565-.497-1.28-1.077h-.084v.113l.295.432 1.557 2.34.08.718-.112.234-.404.141-.444-.08-.911-1.28-.94-1.44-.759-1.291-.093.053-.448 4.821-.21.246-.484.186-.403-.307-.214-.496.214-.98.258-1.28.21-1.016.19-1.263.112-.42-.008-.028-.092.012-.953 1.307-1.448 1.957-1.146 1.227-.274.109-.477-.247.045-.44.266-.39 1.586-2.018.956-1.25.617-.723-.004-.105h-.036l-4.212 2.736-.75.096-.324-.302.04-.496.154-.162 1.267-.871z"/></svg>`,
-    codex: `<svg viewBox="0 0 16 16" fill="white"><path d="M14.949 6.547a3.94 3.94 0 0 0-.348-3.273 4.11 4.11 0 0 0-4.4-1.934A4.1 4.1 0 0 0 8.423.2 4.15 4.15 0 0 0 6.305.086a4.1 4.1 0 0 0-1.891.948 4.04 4.04 0 0 0-1.158 1.753 4.1 4.1 0 0 0-1.563.679A4 4 0 0 0 .554 4.72a3.99 3.99 0 0 0 .502 4.731 3.94 3.94 0 0 0 .346 3.274 4.11 4.11 0 0 0 4.402 1.933c.382.425.852.764 1.377.995.526.231 1.095.35 1.67.346 1.78.002 3.358-1.132 3.901-2.804a4.1 4.1 0 0 0 1.563-.68 4 4 0 0 0 1.14-1.253 3.99 3.99 0 0 0-.506-4.716m-6.097 8.406a3.05 3.05 0 0 1-1.945-.694l.096-.054 3.23-1.838a.53.53 0 0 0 .265-.455v-4.49l1.366.778q.02.011.025.035v3.722c-.003 1.653-1.361 2.992-3.037 2.996m-6.53-2.75a2.95 2.95 0 0 1-.36-2.01l.095.057L5.29 12.09a.53.53 0 0 0 .527 0l3.949-2.246v1.555a.05.05 0 0 1-.022.041L6.473 13.3c-1.454.826-3.311.335-4.15-1.098m-.85-6.94A3.02 3.02 0 0 1 3.07 3.949v3.785a.51.51 0 0 0 .262.451l3.93 2.237-1.366.779a.05.05 0 0 1-.048 0L2.585 9.342a2.98 2.98 0 0 1-1.113-4.094zm11.216 2.571L8.747 5.576l1.362-.776a.05.05 0 0 1 .048 0l3.265 1.86a3 3 0 0 1 1.173 1.207 2.96 2.96 0 0 1-.27 3.2 3.05 3.05 0 0 1-1.36.997V8.279a.52.52 0 0 0-.276-.445m1.36-2.015-.097-.057-3.226-1.855a.53.53 0 0 0-.53 0L6.249 6.153V4.598a.04.04 0 0 1 .019-.04L9.533 2.7a3.07 3.07 0 0 1 3.257.139c.474.325.843.778 1.066 1.303.223.526.289 1.103.191 1.664zM5.503 8.575 4.139 7.8a.05.05 0 0 1-.026-.037V4.049c0-.57.166-1.127.476-1.607s.752-.864 1.275-1.105a3.08 3.08 0 0 1 3.234.41l-.096.054-3.23 1.838a.53.53 0 0 0-.265.455zm.742-1.577 1.758-1 1.762 1v2l-1.755 1-1.762-1z"/></svg>`,
-    gemini: `<svg viewBox="0 0 65 65" fill="white"><path d="M32.447 0c.68 0 1.273.465 1.439 1.125a38.904 38.904 0 001.999 5.905c2.152 5 5.105 9.376 8.854 13.125 3.751 3.75 8.126 6.703 13.125 8.855a38.98 38.98 0 005.906 1.999c.66.166 1.124.758 1.124 1.438 0 .68-.464 1.273-1.125 1.439a38.902 38.902 0 00-5.905 1.999c-5 2.152-9.375 5.105-13.125 8.854-3.749 3.751-6.702 8.126-8.854 13.125a38.973 38.973 0 00-2 5.906 1.485 1.485 0 01-1.438 1.124c-.68 0-1.272-.464-1.438-1.125a38.913 38.913 0 00-2-5.905c-2.151-5-5.103-9.375-8.854-13.125-3.75-3.749-8.125-6.702-13.125-8.854a38.973 38.973 0 00-5.905-2A1.485 1.485 0 010 32.448c0-.68.465-1.272 1.125-1.438a38.903 38.903 0 005.905-2c5-2.151 9.376-5.104 13.125-8.854 3.75-3.749 6.703-8.125 8.855-13.125a38.972 38.972 0 001.999-5.905A1.485 1.485 0 0132.447 0z"/></svg>`,
-    kimi: `<svg viewBox="0 0 16 16" fill="white"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/></svg>`,
-    qwen: `<svg viewBox="0 0 331 328" fill="white"><path d="M120 8l23 39-23 39h180l-23 39H102L77 82l43-74z"/><path d="M30 86h45l88 152-25 43H53l22-39h45L30 86z"/><path d="M143 280l22 39 90-156 22 39h45l-43-74-49 0-87 152z"/></svg>`,
-    kilo: `<svg viewBox="48 48 129 132" fill="black"><path d="M66.44 63.01Q64.87 65.23 65.5 68.28A2.33 2.33 0 0 0 67.78 70.13L86.53 70.13A2.43 2.41 67.4 0 1 88.24 70.84L102.02 84.62A3.21 3.21 0 0 1 102.96 86.89L102.96 102.05A.81.81 0 0 1 102.15 102.86L89.67 102.86A.78.77 0 0 1 88.89 102.09L88.89 86.2A2.04 2.04 0 0 0 86.86 84.16Q74.44 84.1 69.34 83.99Q68.24 83.97 67.5 84.16Q65.99 84.54 66.64 85.33L66.35 87.63L65.35 102.17A.65.64 2.3 0 1 64.69 102.77L50.01 102.57L49.99 50.57A.6.59-90 0 1 50.58 49.97L66.18 49.97A.31.31 0 0 1 66.49 50.29L66.44 63.01Z"/><rect x="88.81" y="51" width="14.18" height="16.62" rx="1.08"/><path d="M122.05 63.79L122.05 51.91A1.15 1.14 90 0 1 123.19 50.76L142.37 50.76A4.57 4.56 67.6 0 1 145.61 52.11L153.94 60.44A3.97 3.94 23 0 1 155.1 63.28Q154.92 74.65 155.02 86.25C155.04 88.43 156.32 88.89 158.37 88.92Q166.52 89.04 173.16 88.88A.91.91 0 0 1 174.09 89.79L174.09 102.07A.79.79 0 0 1 173.3 102.86L123.01 102.86A.89.88-90 0 1 122.13 101.97L122.13 89.71A.8.79-89 0 1 122.95 88.91Q130.98 89.21 138 88.78Q140.89 88.61 140.89 85.47Q140.89 75.62 140.52 67.56A2.12 2.11-1.3 0 0 138.4 65.54L123.8 65.54A1.75 1.75 0 0 1 122.05 63.79Z"/><rect x="-6.95" y="-6.95" transform="translate(95.98,129.08) rotate(-0.3)" width="13.9" height="13.9" rx=".88"/><path d="M66.82 158.21Q67.07 158.47 68.12 158.47Q103 158.42 103.5 158.44A.63.62-.5 0 1 104.14 159.06L104.19 174.48A.5.5 0 0 1 103.69 174.98Q94.92 174.96 64.49 175.1C60.2 175.12 58.29 172.24 55.55 169.5C52.81 166.76 49.92 164.85 49.94 160.56Q50.03 130.13 50 121.36A.5.5 0 0 1 50.5 120.86L65.92 120.89A.63.62-89.6 0 1 66.54 121.53Q66.56 122.03 66.56 156.91Q66.56 157.96 66.82 158.21Z"/><path d="M151.27 140.92Q151.82 140.86 151.98 140.39A.33.33 0 0 0 151.67 139.95L139.26 139.95A.32.31 0 0 1 138.94 139.64L138.94 126.18A.55.55 0 0 1 139.5 125.63Q145.94 125.66 153.44 125.56Q156.57 125.51 159.56 124.49L163.35 124.52A1.49 1.48-22.2 0 1 164.36 124.94L173.85 134.44A4.03 4.02-67.7 0 1 175.04 137.3L175.04 161.14A.63.63 0 0 1 174.41 161.77L158.82 161.77A.4.39-90 0 1 158.43 161.37L158.43 141.62A.55.55 0 0 0 157.89 141.07L151.27 140.92Z"/><path d="M136.83 162.31Q137.51 162.99 138.52 163.02Q147.16 163.23 155.66 162.98A1.29 1.29 0 0 1 156.98 164.27L156.98 176.37A.7.69-.4 0 1 156.29 177.06L133.55 177.06A2.39 2.38-21.8 0 1 131.83 176.32Q131.43 175.93 127.32 171.82Q123.2 167.7 122.81 167.3A2.39 2.38-68.1 0 1 122.08 165.58L122.11 142.84A.7.69-89.5 0 1 122.8 142.15L134.9 142.16A1.29 1.29 0 0 1 136.18 143.48Q135.92 151.98 136.13 160.62Q136.15 161.63 136.83 162.31Z"/></svg>`,
+  claude: `<svg viewBox="0 0 16 16" fill="white"><path d="m3.127 10.604 3.135-1.76.053-.153-.053-.085H6.11l-.525-.032-1.791-.048-1.554-.065-1.505-.08-.38-.081L0 7.832l.036-.234.32-.214.455.04 1.009.069 1.513.105 1.097.064 1.626.17h.259l.036-.105-.089-.065-.068-.064-1.566-1.062-1.695-1.121-.887-.646-.48-.327-.243-.306-.104-.67.435-.48.585.04.15.04.593.456 1.267.981 1.654 1.218.242.202.097-.068.012-.049-.109-.181-.9-1.626-.96-1.655-.428-.686-.113-.411a2 2 0 0 1-.068-.484l.496-.674L4.446 0l.662.089.279.242.411.94.666 1.48 1.033 2.014.302.597.162.553.06.17h.105v-.097l.085-1.134.157-1.392.154-1.792.052-.504.25-.605.497-.327.387.186.319.456-.045.294-.19 1.23-.37 1.93-.243 1.29h.142l.161-.16.654-.868 1.097-1.372.484-.545.565-.601.363-.287h.686l.505.751-.226.775-.707.895-.585.759-.839 1.13-.524.904.048.072.125-.012 1.897-.403 1.024-.186 1.223-.21.553.258.06.263-.218.536-1.307.323-1.533.307-2.284.54-.028.02.032.04 1.029.098.44.024h1.077l2.005.15.525.346.315.424-.053.323-.807.411-3.631-.863-.872-.218h-.12v.073l.726.71 1.331 1.202 1.667 1.55.084.383-.214.302-.226-.032-1.464-1.101-.565-.497-1.28-1.077h-.084v.113l.295.432 1.557 2.34.08.718-.112.234-.404.141-.444-.08-.911-1.28-.94-1.44-.759-1.291-.093.053-.448 4.821-.21.246-.484.186-.403-.307-.214-.496.214-.98.258-1.28.21-1.016.19-1.263.112-.42-.008-.028-.092.012-.953 1.307-1.448 1.957-1.146 1.227-.274.109-.477-.247.045-.44.266-.39 1.586-2.018.956-1.25.617-.723-.004-.105h-.036l-4.212 2.736-.75.096-.324-.302.04-.496.154-.162 1.267-.871z"/></svg>`,
+  codex: `<svg viewBox="0 0 16 16" fill="white"><path d="M14.949 6.547a3.94 3.94 0 0 0-.348-3.273 4.11 4.11 0 0 0-4.4-1.934A4.1 4.1 0 0 0 8.423.2 4.15 4.15 0 0 0 6.305.086a4.1 4.1 0 0 0-1.891.948 4.04 4.04 0 0 0-1.158 1.753 4.1 4.1 0 0 0-1.563.679A4 4 0 0 0 .554 4.72a3.99 3.99 0 0 0 .502 4.731 3.94 3.94 0 0 0 .346 3.274 4.11 4.11 0 0 0 4.402 1.933c.382.425.852.764 1.377.995.526.231 1.095.35 1.67.346 1.78.002 3.358-1.132 3.901-2.804a4.1 4.1 0 0 0 1.563-.68 4 4 0 0 0 1.14-1.253 3.99 3.99 0 0 0-.506-4.716m-6.097 8.406a3.05 3.05 0 0 1-1.945-.694l.096-.054 3.23-1.838a.53.53 0 0 0 .265-.455v-4.49l1.366.778q.02.011.025.035v3.722c-.003 1.653-1.361 2.992-3.037 2.996m-6.53-2.75a2.95 2.95 0 0 1-.36-2.01l.095.057L5.29 12.09a.53.53 0 0 0 .527 0l3.949-2.246v1.555a.05.05 0 0 1-.022.041L6.473 13.3c-1.454.826-3.311.335-4.15-1.098m-.85-6.94A3.02 3.02 0 0 1 3.07 3.949v3.785a.51.51 0 0 0 .262.451l3.93 2.237-1.366.779a.05.05 0 0 1-.048 0L2.585 9.342a2.98 2.98 0 0 1-1.113-4.094zm11.216 2.571L8.747 5.576l1.362-.776a.05.05 0 0 1 .048 0l3.265 1.86a3 3 0 0 1 1.173 1.207 2.96 2.96 0 0 1-.27 3.2 3.05 3.05 0 0 1-1.36.997V8.279a.52.52 0 0 0-.276-.445m1.36-2.015-.097-.057-3.226-1.855a.53.53 0 0 0-.53 0L6.249 6.153V4.598a.04.04 0 0 1 .019-.04L9.533 2.7a3.07 3.07 0 0 1 3.257.139c.474.325.843.778 1.066 1.303.223.526.289 1.103.191 1.664zM5.503 8.575 4.139 7.8a.05.05 0 0 1-.026-.037V4.049c0-.57.166-1.127.476-1.607s.752-.864 1.275-1.105a3.08 3.08 0 0 1 3.234.41l-.096.054-3.23 1.838a.53.53 0 0 0-.265.455zm.742-1.577 1.758-1 1.762 1v2l-1.755 1-1.762-1z"/></svg>`,
+  gemini: `<svg viewBox="0 0 65 65" fill="white"><path d="M32.447 0c.68 0 1.273.465 1.439 1.125a38.904 38.904 0 001.999 5.905c2.152 5 5.105 9.376 8.854 13.125 3.751 3.75 8.126 6.703 13.125 8.855a38.98 38.98 0 005.906 1.999c.66.166 1.124.758 1.124 1.438 0 .68-.464 1.273-1.125 1.439a38.902 38.902 0 00-5.905 1.999c-5 2.152-9.375 5.105-13.125 8.854-3.749 3.751-6.702 8.126-8.854 13.125a38.973 38.973 0 00-2 5.906 1.485 1.485 0 01-1.438 1.124c-.68 0-1.272-.464-1.438-1.125a38.913 38.913 0 00-2-5.905c-2.151-5-5.103-9.375-8.854-13.125-3.75-3.749-8.125-6.702-13.125-8.854a38.973 38.973 0 00-5.905-2A1.485 1.485 0 010 32.448c0-.68.465-1.272 1.125-1.438a38.903 38.903 0 005.905-2c5-2.151 9.376-5.104 13.125-8.854 3.75-3.749 6.703-8.125 8.855-13.125a38.972 38.972 0 001.999-5.905A1.485 1.485 0 0132.447 0z"/></svg>`,
+  kimi: `<svg viewBox="0 0 16 16" fill="white"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/></svg>`,
+  qwen: `<svg viewBox="0 0 331 328" fill="white"><path d="M120 8l23 39-23 39h180l-23 39H102L77 82l43-74z"/><path d="M30 86h45l88 152-25 43H53l22-39h45L30 86z"/><path d="M143 280l22 39 90-156 22 39h45l-43-74-49 0-87 152z"/></svg>`,
+  kilo: `<svg viewBox="48 48 129 132" fill="black"><path d="M66.44 63.01Q64.87 65.23 65.5 68.28A2.33 2.33 0 0 0 67.78 70.13L86.53 70.13A2.43 2.41 67.4 0 1 88.24 70.84L102.02 84.62A3.21 3.21 0 0 1 102.96 86.89L102.96 102.05A.81.81 0 0 1 102.15 102.86L89.67 102.86A.78.77 0 0 1 88.89 102.09L88.89 86.2A2.04 2.04 0 0 0 86.86 84.16Q74.44 84.1 69.34 83.99Q68.24 83.97 67.5 84.16Q65.99 84.54 66.64 85.33L66.35 87.63L65.35 102.17A.65.64 2.3 0 1 64.69 102.77L50.01 102.57L49.99 50.57A.6.59-90 0 1 50.58 49.97L66.18 49.97A.31.31 0 0 1 66.49 50.29L66.44 63.01Z"/><rect x="88.81" y="51" width="14.18" height="16.62" rx="1.08"/><path d="M122.05 63.79L122.05 51.91A1.15 1.14 90 0 1 123.19 50.76L142.37 50.76A4.57 4.56 67.6 0 1 145.61 52.11L153.94 60.44A3.97 3.94 23 0 1 155.1 63.28Q154.92 74.65 155.02 86.25C155.04 88.43 156.32 88.89 158.37 88.92Q166.52 89.04 173.16 88.88A.91.91 0 0 1 174.09 89.79L174.09 102.07A.79.79 0 0 1 173.3 102.86L123.01 102.86A.89.88-90 0 1 122.13 101.97L122.13 89.71A.8.79-89 0 1 122.95 88.91Q130.98 89.21 138 88.78Q140.89 88.61 140.89 85.47Q140.89 75.62 140.52 67.56A2.12 2.11-1.3 0 0 138.4 65.54L123.8 65.54A1.75 1.75 0 0 1 122.05 63.79Z"/><rect x="-6.95" y="-6.95" transform="translate(95.98,129.08) rotate(-0.3)" width="13.9" height="13.9" rx=".88"/><path d="M66.82 158.21Q67.07 158.47 68.12 158.47Q103 158.42 103.5 158.44A.63.62-.5 0 1 104.14 159.06L104.19 174.48A.5.5 0 0 1 103.69 174.98Q94.92 174.96 64.49 175.1C60.2 175.12 58.29 172.24 55.55 169.5C52.81 166.76 49.92 164.85 49.94 160.56Q50.03 130.13 50 121.36A.5.5 0 0 1 50.5 120.86L65.92 120.89A.63.62-89.6 0 1 66.54 121.53Q66.56 122.03 66.56 156.91Q66.56 157.96 66.82 158.21Z"/><path d="M151.27 140.92Q151.82 140.86 151.98 140.39A.33.33 0 0 0 151.67 139.95L139.26 139.95A.32.31 0 0 1 138.94 139.64L138.94 126.18A.55.55 0 0 1 139.5 125.63Q145.94 125.66 153.44 125.56Q156.57 125.51 159.56 124.49L163.35 124.52A1.49 1.48-22.2 0 1 164.36 124.94L173.85 134.44A4.03 4.02-67.7 0 1 175.04 137.3L175.04 161.14A.63.63 0 0 1 174.41 161.77L158.82 161.77A.4.39-90 0 1 158.43 161.37L158.43 141.62A.55.55 0 0 0 157.89 141.07L151.27 140.92Z"/><path d="M136.83 162.31Q137.51 162.99 138.52 163.02Q147.16 163.23 155.66 162.98A1.29 1.29 0 0 1 156.98 164.27L156.98 176.37A.7.69-.4 0 1 156.29 177.06L133.55 177.06A2.39 2.38-21.8 0 1 131.83 176.32Q131.43 175.93 127.32 171.82Q123.2 167.7 122.81 167.3A2.39 2.38-68.1 0 1 122.08 165.58L122.11 142.84A.7.69-89.5 0 1 122.8 142.15L134.9 142.16A1.29 1.29 0 0 1 136.18 143.48Q135.92 151.98 136.13 160.62Q136.15 161.63 136.83 162.31Z"/></svg>`,
 };
 const USER_AVATAR = `<svg viewBox="0 0 32 32" fill="none"><circle cx="16" cy="12" r="5" fill="white" opacity="0.85"/><path d="M7 27C7 21.5 11 18 16 18C21 18 25 21.5 25 27" fill="white" opacity="0.85"/></svg>`;
 
 function getAvatarSvg(sender) {
-    const s = sender.toLowerCase();
-    const resolved = resolveAgent(s);
-    if (resolved) {
-        if (BRAND_AVATARS[resolved]) return BRAND_AVATARS[resolved];
-        // Use base field from agent config (handles custom names like "claudeypops" → claude)
-        const cfg = agentConfig[resolved];
-        if (cfg && cfg.base && BRAND_AVATARS[cfg.base]) return BRAND_AVATARS[cfg.base];
-        // Fallback: parse base-N pattern (claude-2 → claude)
-        const base = resolved.replace(/-\d+$/, '');
-        if (base !== resolved && BRAND_AVATARS[base]) return BRAND_AVATARS[base];
-    }
-    // Fall back for offline agents: check config base, then parse pattern
-    const cfg = agentConfig[s];
-    if (cfg && cfg.base && BRAND_AVATARS[cfg.base]) return BRAND_AVATARS[cfg.base];
-    const base = s.replace(/-\d+$/, '');
-    if (BRAND_AVATARS[base]) return BRAND_AVATARS[base];
-    return USER_AVATAR;
+  const s = sender.toLowerCase();
+  const resolved = resolveAgent(s);
+  if (resolved) {
+    if (BRAND_AVATARS[resolved]) return BRAND_AVATARS[resolved];
+    // Use base field from agent config (handles custom names like "claudeypops" → claude)
+    const cfg = agentConfig[resolved];
+    if (cfg && cfg.base && BRAND_AVATARS[cfg.base])
+      return BRAND_AVATARS[cfg.base];
+    // Fallback: parse base-N pattern (claude-2 → claude)
+    const base = resolved.replace(/-\d+$/, "");
+    if (base !== resolved && BRAND_AVATARS[base]) return BRAND_AVATARS[base];
+  }
+  // Fall back for offline agents: check config base, then parse pattern
+  const cfg = agentConfig[s];
+  if (cfg && cfg.base && BRAND_AVATARS[cfg.base])
+    return BRAND_AVATARS[cfg.base];
+  const base = s.replace(/-\d+$/, "");
+  if (BRAND_AVATARS[base]) return BRAND_AVATARS[base];
+  return USER_AVATAR;
 }
 
 // --- Update check ---
 
 async function checkForUpdate() {
-    try {
-        const resp = await fetch('/api/version_check', {
-            headers: { 'X-Session-Token': SESSION_TOKEN },
-        });
-        if (!resp.ok) return;
-        const data = await resp.json();
-        const pill = document.getElementById('update-pill');
-        if (!pill) return;
+  try {
+    const resp = await fetch("/api/version_check", {});
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const pill = document.getElementById("update-pill");
+    if (!pill) return;
 
-        const dismissed = localStorage.getItem('agentchattr-dismissed-version');
-        if (data.state === 'current' || data.state === 'unknown' || dismissed === data.latest) {
-            pill.classList.add('hidden');
-            return;
-        }
-
-        const label = data.state === 'upstream_update' ? 'Upstream update available' : 'Update available';
-        pill.href = data.url || 'https://github.com/bcurts/agentchattr/releases';
-        pill.innerHTML = `<span>${label}</span><button class="update-dismiss" onclick="dismissUpdate(event, '${data.latest}')" title="Dismiss">&times;</button>`;
-        pill.classList.remove('hidden');
-    } catch {
-        // Silent fail -- version check should never block the UI
+    const dismissed = localStorage.getItem("agentchattr-dismissed-version");
+    if (
+      data.state === "current" ||
+      data.state === "unknown" ||
+      dismissed === data.latest
+    ) {
+      pill.classList.add("hidden");
+      return;
     }
+
+    const label =
+      data.state === "upstream_update"
+        ? "Upstream update available"
+        : "Update available";
+    pill.href = data.url || "https://github.com/bcurts/agentchattr/releases";
+    pill.innerHTML = `<span>${label}</span><button class="update-dismiss" onclick="dismissUpdate(event, '${data.latest}')" title="Dismiss">&times;</button>`;
+    pill.classList.remove("hidden");
+  } catch {
+    // Silent fail -- version check should never block the UI
+  }
 }
 
 function dismissUpdate(e, version) {
-    e.preventDefault();
-    e.stopPropagation();
-    localStorage.setItem('agentchattr-dismissed-version', version);
-    const pill = document.getElementById('update-pill');
-    if (pill) pill.classList.add('hidden');
+  e.preventDefault();
+  e.stopPropagation();
+  localStorage.setItem("agentchattr-dismissed-version", version);
+  const pill = document.getElementById("update-pill");
+  if (pill) pill.classList.add("hidden");
 }
 
 // --- Init ---
 
 function init() {
-    // Configure marked for chat-style rendering
-    marked.setOptions({
-        breaks: true,      // single newline → <br>
-        gfm: true,         // GitHub-flavored markdown
-    });
+  // Configure marked for chat-style rendering
+  marked.setOptions({
+    breaks: true, // single newline → <br>
+    gfm: true, // GitHub-flavored markdown
+  });
 
-    detectPlatform();
-    fetchRoles();
-    connectWebSocket();
-    setupInput();
-    setupDragDrop();
-    setupPaste();
-    setupScroll();
-    setupSettingsKeys();
-    setupKeyboardShortcuts();
-    RulesPanel.init();
-    Jobs.init();
-    Sessions.init();
-    Channels.init();
-    checkForUpdate();
+  detectPlatform();
+  fetchRoles();
+  connectWebSocket();
+  setupInput();
+  setupDragDrop();
+  setupPaste();
+  setupScroll();
+  setupSettingsKeys();
+  setupKeyboardShortcuts();
+  RulesPanel.init();
+  Jobs.init();
+  Sessions.init();
+  Channels.init();
+  checkForUpdate();
 
-    // Dismiss channel edit controls when clicking outside channel bar
-    document.addEventListener('click', (e) => {
-        if (!e.target.closest('#channel-bar')) {
-            document.querySelectorAll('.channel-tab.editing').forEach(t => t.classList.remove('editing'));
-        }
-    });
+  // Dismiss channel edit controls when clicking outside channel bar
+  document.addEventListener("click", (e) => {
+    if (!e.target.closest("#channel-bar")) {
+      document
+        .querySelectorAll(".channel-tab.editing")
+        .forEach((t) => t.classList.remove("editing"));
+    }
+  });
 }
 
 function renderMarkdown(text) {
-    // Protect Windows paths from escape replacement (e.g. \tests → tab, \new → newline)
-    const pathSlots = [];
-    text = text.replace(/[A-Z]:[\\\/][\w\-.\\ \/]+/g, (m) => {
-        pathSlots.push(m);
-        return `\x00P${pathSlots.length - 1}\x00`;
-    });
-    // Unescape literal \n and \t that agents sometimes send as escaped text
-    text = text.replace(/\\\\n/g, '\n').replace(/\\n/g, '\n').replace(/\\t/g, '\t');
-    // Escape < and > outside of code blocks/inline code so raw HTML
-    // can't break layout or cause XSS, while preserving angle brackets
-    // inside backtick-delimited code where users expect them to render.
-    // Protect fenced code blocks and inline code by replacing them with placeholders
-    var codeSlots = [];
-    text = text.replace(/(```[\s\S]*?```|`[^`\n]+`)/g, function(match) {
-        codeSlots.push(match);
-        return '\x00C' + (codeSlots.length - 1) + '\x00';
-    });
-    // Escape angle brackets in non-code text only
-    text = text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    // Restore code blocks (angle brackets inside them stay unescaped)
-    text = text.replace(/\x00C(\d+)\x00/g, function(_, i) { return codeSlots[parseInt(i)]; });
-    // Restore paths
-    text = text.replace(/\x00P(\d+)\x00/g, (_, i) => pathSlots[parseInt(i)]);
-    // Parse markdown, then color @mentions, URLs, and file paths in the output
-    let html = marked.parse(text);
-    // Remove wrapping <p> tags for single-line messages to keep them inline
-    const trimmed = html.trim();
-    if (trimmed.startsWith('<p>') && trimmed.endsWith('</p>') && trimmed.indexOf('<p>', 1) === -1) {
-        html = trimmed.slice(3, -4);
-    }
-    html = colorMentions(html);
-    html = linkifyUrls(html);
-    html = linkifyPaths(html);
-    return html;
+  // Protect Windows paths from escape replacement (e.g. \tests → tab, \new → newline)
+  const pathSlots = [];
+  text = text.replace(/[A-Z]:[\\\/][\w\-.\\ \/]+/g, (m) => {
+    pathSlots.push(m);
+    return `\x00P${pathSlots.length - 1}\x00`;
+  });
+  // Unescape literal \n and \t that agents sometimes send as escaped text
+  text = text
+    .replace(/\\\\n/g, "\n")
+    .replace(/\\n/g, "\n")
+    .replace(/\\t/g, "\t");
+  // Escape < and > outside of code blocks/inline code so raw HTML
+  // can't break layout or cause XSS, while preserving angle brackets
+  // inside backtick-delimited code where users expect them to render.
+  // Protect fenced code blocks and inline code by replacing them with placeholders
+  var codeSlots = [];
+  text = text.replace(/(```[\s\S]*?```|`[^`\n]+`)/g, function (match) {
+    codeSlots.push(match);
+    return "\x00C" + (codeSlots.length - 1) + "\x00";
+  });
+  // Escape angle brackets in non-code text only
+  text = text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  // Restore code blocks (angle brackets inside them stay unescaped)
+  text = text.replace(/\x00C(\d+)\x00/g, function (_, i) {
+    return codeSlots[parseInt(i)];
+  });
+  // Restore paths
+  text = text.replace(/\x00P(\d+)\x00/g, (_, i) => pathSlots[parseInt(i)]);
+  // Parse markdown, then color @mentions, URLs, and file paths in the output
+  let html = marked.parse(text);
+  // Remove wrapping <p> tags for single-line messages to keep them inline
+  const trimmed = html.trim();
+  if (
+    trimmed.startsWith("<p>") &&
+    trimmed.endsWith("</p>") &&
+    trimmed.indexOf("<p>", 1) === -1
+  ) {
+    html = trimmed.slice(3, -4);
+  }
+  html = colorMentions(html);
+  html = linkifyUrls(html);
+  html = linkifyPaths(html);
+  return html;
 }
 
 function linkifyUrls(html) {
-    // Match http/https URLs not already inside an <a> tag.
-    // We match tags first to skip them, then capture URLs in the same pass.
-    return html.replace(/<a\b[^>]*>.*?<\/a>|(?<!["=])(https?:\/\/[^\s<>"')\]]+)/gs, (match, url) => {
-        if (url) {
-            return `<a href="${url}" target="_blank" rel="noopener">${url}</a>`;
-        }
-        return match;
-    });
+  // Match http/https URLs not already inside an <a> tag.
+  // We match tags first to skip them, then capture URLs in the same pass.
+  return html.replace(
+    /<a\b[^>]*>.*?<\/a>|(?<!["=])(https?:\/\/[^\s<>"')\]]+)/gs,
+    (match, url) => {
+      if (url) {
+        return `<a href="${url}" target="_blank" rel="noopener">${url}</a>`;
+      }
+      return match;
+    },
+  );
 }
 
-let serverPlatform = 'win32';  // default, updated on connect
+let serverPlatform = "win32"; // default, updated on connect
 async function detectPlatform() {
-    try {
-        const r = await fetch('/api/platform', { headers: { 'X-Session-Token': SESSION_TOKEN } });
-        const data = await r.json();
-        serverPlatform = data.platform || 'win32';
-    } catch (e) { /* fallback to win32 */ }
+  try {
+    const r = await fetch("/api/platform", {});
+    const data = await r.json();
+    serverPlatform = data.platform || "win32";
+  } catch (e) {
+    /* fallback to win32 */
+  }
 }
 
 function linkifyPaths(html) {
-    // Windows paths: E:\foo\bar or E:/foo/bar
-    html = html.replace(/(?<!["=\/])([A-Z]):[\\\/][\w\-.\\ \/]+/g, (match) => {
-        const escaped = match.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  // Windows paths: E:\foo\bar or E:/foo/bar
+  html = html.replace(/(?<!["=\/])([A-Z]):[\\\/][\w\-.\\ \/]+/g, (match) => {
+    const escaped = match.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+    return `<a class="file-link" href="#" onclick="openPath('${escaped}'); return false;" title="Open in file manager">${match}</a>`;
+  });
+  // Unix paths: /Users/..., /home/..., /tmp/..., /opt/..., /var/..., /etc/...
+  if (serverPlatform !== "win32") {
+    html = html.replace(
+      /(?<!["=\w])(\/(?:Users|home|tmp|opt|var|etc|usr)\/[\w\-.\/ ]+)/g,
+      (match) => {
+        const escaped = match.replace(/'/g, "\\'");
         return `<a class="file-link" href="#" onclick="openPath('${escaped}'); return false;" title="Open in file manager">${match}</a>`;
-    });
-    // Unix paths: /Users/..., /home/..., /tmp/..., /opt/..., /var/..., /etc/...
-    if (serverPlatform !== 'win32') {
-        html = html.replace(/(?<!["=\w])(\/(?:Users|home|tmp|opt|var|etc|usr)\/[\w\-.\/ ]+)/g, (match) => {
-            const escaped = match.replace(/'/g, "\\'");
-            return `<a class="file-link" href="#" onclick="openPath('${escaped}'); return false;" title="Open in file manager">${match}</a>`;
-        });
-    }
-    return html;
+      },
+    );
+  }
+  return html;
 }
 
 async function openPath(path) {
-    try {
-        await fetch('/api/open-path', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': SESSION_TOKEN },
-            body: JSON.stringify({ path: path }),
-        });
-    } catch (err) {
-        console.error('Failed to open path:', err);
-    }
+  try {
+    await fetch("/api/open-path", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ path: path }),
+    });
+  } catch (err) {
+    console.error("Failed to open path:", err);
+  }
 }
 
 function addCodeCopyButtons(container) {
-    const blocks = container.querySelectorAll('pre');
-    for (const pre of blocks) {
-        if (pre.querySelector('.code-copy-btn')) continue;
-        const btn = document.createElement('button');
-        btn.className = 'code-copy-btn';
-        btn.textContent = 'copy';
-        btn.onclick = async (e) => {
-            e.stopPropagation();
-            const code = pre.querySelector('code')?.textContent || pre.textContent;
-            try {
-                await navigator.clipboard.writeText(code);
-                btn.textContent = 'copied!';
-                setTimeout(() => { btn.textContent = 'copy'; }, 1500);
-            } catch (err) {
-                btn.textContent = 'failed';
-                setTimeout(() => { btn.textContent = 'copy'; }, 1500);
-            }
-        };
-        pre.style.position = 'relative';
-        pre.appendChild(btn);
-    }
+  const blocks = container.querySelectorAll("pre");
+  for (const pre of blocks) {
+    if (pre.querySelector(".code-copy-btn")) continue;
+    const btn = document.createElement("button");
+    btn.className = "code-copy-btn";
+    btn.textContent = "copy";
+    btn.onclick = async (e) => {
+      e.stopPropagation();
+      const code = pre.querySelector("code")?.textContent || pre.textContent;
+      try {
+        await navigator.clipboard.writeText(code);
+        btn.textContent = "copied!";
+        setTimeout(() => {
+          btn.textContent = "copy";
+        }, 1500);
+      } catch (err) {
+        btn.textContent = "failed";
+        setTimeout(() => {
+          btn.textContent = "copy";
+        }, 1500);
+      }
+    };
+    pre.style.position = "relative";
+    pre.appendChild(btn);
+  }
 }
 
 // --- WebSocket ---
 
 function connectWebSocket() {
-    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-    ws = new WebSocket(`${proto}://${location.host}/ws?token=${encodeURIComponent(SESSION_TOKEN)}`);
+  const proto = location.protocol === "https:" ? "wss" : "ws";
+  // Auth is via HttpOnly cookie — browser sends it automatically on handshake.
+  ws = new WebSocket(`${proto}://${location.host}/ws`);
 
-    ws.onopen = () => {
-        console.log('WebSocket connected');
-        if (reconnectTimer) {
-            clearTimeout(reconnectTimer);
-            reconnectTimer = null;
+  ws.onopen = () => {
+    console.log("WebSocket connected");
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+  };
+
+  ws.onmessage = (e) => {
+    const event = JSON.parse(e.data);
+    // Emit through Hub for modules to subscribe (PR 1 seam)
+    Hub.emit(event.type, event);
+    if (event.type === "message_update") {
+      // Re-render an updated message in-place (e.g. decision card resolved)
+      const updated = event.message;
+      if (updated && updated.id) {
+        const existing = document.querySelector(
+          `.message[data-id="${updated.id}"]`,
+        );
+        if (existing && updated.type === "decision") {
+          // Update just the choices area within the bubble
+          const choicesEl = existing.querySelector(".decision-choices");
+          const meta = updated.metadata || {};
+          if (choicesEl && meta.resolved) {
+            choicesEl.innerHTML = `<div class="decision-resolved">You chose: <strong>${escapeHtml(meta.chosen || "")}</strong></div>`;
+          }
         }
-    };
-
-    ws.onmessage = (e) => {
-        const event = JSON.parse(e.data);
-        // Emit through Hub for modules to subscribe (PR 1 seam)
-        Hub.emit(event.type, event);
-        if (event.type === 'message_update') {
-            // Re-render an updated message in-place (e.g. decision card resolved)
-            const updated = event.message;
-            if (updated && updated.id) {
-                const existing = document.querySelector(`.message[data-id="${updated.id}"]`);
-                if (existing && updated.type === 'decision') {
-                    // Update just the choices area within the bubble
-                    const choicesEl = existing.querySelector('.decision-choices');
-                    const meta = updated.metadata || {};
-                    if (choicesEl && meta.resolved) {
-                        choicesEl.innerHTML = `<div class="decision-resolved">You chose: <strong>${escapeHtml(meta.chosen || '')}</strong></div>`;
-                    }
-                }
+      }
+    } else if (event.type === "message") {
+      // Play notification sound for new messages from others (not joins, not when focused)
+      if (
+        soundEnabled &&
+        !document.hasFocus() &&
+        event.data.type !== "join" &&
+        event.data.type !== "leave" &&
+        event.data.type !== "summary" &&
+        event.data.sender &&
+        event.data.sender.toLowerCase() !== username.toLowerCase()
+      ) {
+        playNotificationSound(event.data.sender);
+      }
+      appendMessage(event.data);
+    } else if (event.type === "agent_renamed") {
+      // Migrate active mentions before the agents config rebuild
+      if (activeMentions.has(event.old_name)) {
+        activeMentions.delete(event.old_name);
+        activeMentions.add(event.new_name);
+      }
+      // Update sender name, color, and avatar on all existing messages in the DOM
+      const newColor = getColor(event.new_name);
+      const newAvatar = getAvatarSvg(event.new_name);
+      const newAgentKey = (
+        resolveAgent(event.new_name.toLowerCase()) || event.new_name
+      ).toLowerCase();
+      const newHat = agentHats[newAgentKey] || "";
+      document.querySelectorAll("#messages .message").forEach((el) => {
+        // Regular chat messages
+        const senderEl = el.querySelector(".msg-sender");
+        if (senderEl && senderEl.textContent === event.old_name) {
+          senderEl.textContent = event.new_name;
+          senderEl.style.color = newColor;
+          // Update bubble accent color
+          const bubble = el.querySelector(".chat-bubble");
+          if (bubble) bubble.style.setProperty("--bubble-color", newColor);
+          // Update avatar
+          const avatarWrap = el.querySelector(".avatar-wrap");
+          if (avatarWrap) {
+            avatarWrap.dataset.agent = newAgentKey;
+            const avatar = avatarWrap.querySelector(".avatar");
+            if (avatar) {
+              avatar.style.backgroundColor = newColor;
+              avatar.innerHTML = newAvatar;
             }
-        } else if (event.type === 'message') {
-            // Play notification sound for new messages from others (not joins, not when focused)
-            if (soundEnabled && !document.hasFocus() && event.data.type !== 'join' && event.data.type !== 'leave' && event.data.type !== 'summary' && event.data.sender && event.data.sender.toLowerCase() !== username.toLowerCase()) {
-                playNotificationSound(event.data.sender);
+            // Update hat
+            let hatEl = avatarWrap.querySelector(".hat-overlay");
+            if (newHat) {
+              if (!hatEl) {
+                hatEl = document.createElement("div");
+                hatEl.className = "hat-overlay";
+                avatarWrap.appendChild(hatEl);
+              }
+              hatEl.dataset.agent = newAgentKey;
+              hatEl.innerHTML = newHat;
+            } else if (hatEl) {
+              hatEl.remove();
             }
-            appendMessage(event.data);
-        } else if (event.type === 'agent_renamed') {
-            // Migrate active mentions before the agents config rebuild
-            if (activeMentions.has(event.old_name)) {
-                activeMentions.delete(event.old_name);
-                activeMentions.add(event.new_name);
-            }
-            // Update sender name, color, and avatar on all existing messages in the DOM
-            const newColor = getColor(event.new_name);
-            const newAvatar = getAvatarSvg(event.new_name);
-            const newAgentKey = (resolveAgent(event.new_name.toLowerCase()) || event.new_name).toLowerCase();
-            const newHat = agentHats[newAgentKey] || '';
-            document.querySelectorAll('#messages .message').forEach(el => {
-                // Regular chat messages
-                const senderEl = el.querySelector('.msg-sender');
-                if (senderEl && senderEl.textContent === event.old_name) {
-
-                    senderEl.textContent = event.new_name;
-                    senderEl.style.color = newColor;
-                    // Update bubble accent color
-                    const bubble = el.querySelector('.chat-bubble');
-                    if (bubble) bubble.style.setProperty('--bubble-color', newColor);
-                    // Update avatar
-                    const avatarWrap = el.querySelector('.avatar-wrap');
-                    if (avatarWrap) {
-                        avatarWrap.dataset.agent = newAgentKey;
-                        const avatar = avatarWrap.querySelector('.avatar');
-                        if (avatar) {
-                            avatar.style.backgroundColor = newColor;
-                            avatar.innerHTML = newAvatar;
-                        }
-                        // Update hat
-                        let hatEl = avatarWrap.querySelector('.hat-overlay');
-                        if (newHat) {
-                            if (!hatEl) {
-                                hatEl = document.createElement('div');
-                                hatEl.className = 'hat-overlay';
-                                avatarWrap.appendChild(hatEl);
-                            }
-                            hatEl.dataset.agent = newAgentKey;
-                            hatEl.innerHTML = newHat;
-                        } else if (hatEl) {
-                            hatEl.remove();
-                        }
-                    }
-                }
-                // Join/leave messages (separate structure, no .msg-sender)
-                const joinText = el.querySelector('.join-text strong');
-                if (joinText && joinText.textContent === event.old_name) {
-
-                    joinText.textContent = event.new_name;
-                    joinText.style.color = newColor;
-                    const joinDot = el.querySelector('.join-dot');
-                    if (joinDot) joinDot.style.background = newColor;
-                }
-            });
-        } else if (event.type === 'agents') {
-            applyAgentConfig(event.data);
-        } else if (event.type === 'base_colors') {
-            baseColors = event.data || {};
-        } else if (event.type === 'todos') {
-            todos = {};
-            for (const [id, status] of Object.entries(event.data)) {
-                todos[parseInt(id)] = status;
-            }
-        } else if (event.type === 'todo_update') {
-            const d = event.data;
-            if (d.status === null) {
-                delete todos[d.id];
-            } else {
-                todos[d.id] = d.status;
-            }
-            updateTodoState(d.id, d.status);
-        } else if (event.type === 'status') {
-            updateStatus(event.data);
-            // Status is the last event sent on connect — enable sounds after history
-            if (!soundEnabled) {
-                soundEnabled = true;
-                const loader = document.getElementById('loading-indicator');
-                if (loader) loader.classList.add('hidden');
-                filterMessagesByChannel();
-                renderChannelTabs();
-                // Ensure refresh/reconnect lands on the latest visible message.
-                requestAnimationFrame(() => {
-                    autoScroll = true;
-                    scrollToBottom();
-                });
-            }
-        } else if (event.type === 'typing') {
-            updateTyping(event.agent, event.active);
-        } else if (event.type === 'settings') {
-            applySettings(event.data);
-        } else if (event.type === 'delete') {
-            handleDeleteBroadcast(event.ids);
-        } else if (event.type === 'rules' || event.type === 'decisions') {
-            rules = event.data || [];
-            renderRulesPanel();
-            updateRulesBadge();
-        } else if (event.type === 'rule' || event.type === 'decision') {
-            handleRuleEvent(event.action, event.data);
-        } else if (event.type === 'hats') {
-            agentHats = event.data || {};
-            updateAllHats();
-        } else if (event.type === 'schedules') {
-            schedulesList = event.data || [];
-            renderSchedulesBar();
-        } else if (event.type === 'schedule') {
-            handleScheduleEvent(event.action, event.data);
-        } else if (event.type === 'pending_instance') {
-            // A new 2nd+ instance registered — queue naming lightbox
-            _pendingNameQueue.push({
-                name: event.name,
-                label: event.label || event.name,
-                color: event.color || '#888',
-                base: event.base || '',
-            });
-            _showNextPendingName();
-        } else if (event.type === 'channel_renamed') {
-            // Migrate data-channel on existing DOM elements
-            const container = document.getElementById('messages');
-            for (const el of container.children) {
-                if ((el.dataset.channel || 'general') === event.old_name) {
-                    el.dataset.channel = event.new_name;
-                }
-            }
-            // Update per-channel date tracking
-            if (lastMessageDates[event.old_name]) {
-                lastMessageDates[event.new_name] = lastMessageDates[event.old_name];
-                delete lastMessageDates[event.old_name];
-            }
-            // Update active channel if we were on the renamed one
-            if (activeChannel === event.old_name) {
-                activeChannel = event.new_name;
-                localStorage.setItem('agentchattr-channel', event.new_name);
-                Store.set('activeChannel', event.new_name);
-            }
-        } else if (event.type === 'edit') {
-            // A message was edited/demoted — re-render it in place
-            const updatedMsg = event.message;
-            if (updatedMsg && updatedMsg.id != null) {
-                const el = document.querySelector(`.message[data-id="${updatedMsg.id}"]`);
-                if (el) {
-                    // Insert a fresh message after the old one, then remove the old
-                    const placeholder = document.createElement('div');
-                    el.after(placeholder);
-                    el.remove();
-                    // Temporarily hijack container to insert at the right spot
-                    const container = document.getElementById('messages');
-                    appendMessage(updatedMsg);
-                    // Move the newly appended message to where the old one was
-                    const newEl = container.lastElementChild;
-                    if (newEl && newEl.dataset.id == updatedMsg.id) {
-                        placeholder.replaceWith(newEl);
-                    } else {
-                        placeholder.remove();
-                    }
-                }
-            }
-        } else if (event.type === 'clear') {
-            const _clearDbgList = document.getElementById('jobs-list');
-            const _clearDbgBefore = _clearDbgList ? _clearDbgList.children.length : -1;
-            console.log('CLEAR_DEBUG clear event received, channel=' + (event.channel || 'ALL'), 'jobs-panel-children-before=' + _clearDbgBefore);
-            const clearChannel = event.channel || null;
-            if (clearChannel) {
-                // Per-channel clear: remove only messages from that channel
-                const container = document.getElementById('messages');
-                const toRemove = [];
-                for (const el of container.children) {
-                    if (el.dataset.id && (el.dataset.channel || 'general') === clearChannel) {
-                        toRemove.push(el);
-                    }
-                }
-                toRemove.forEach(el => el.remove());
-                // Clean up orphaned date dividers and reset tracking
-                delete lastMessageDates[clearChannel];
-                filterMessagesByChannel();
-            } else {
-                // Full clear (all channels)
-                document.getElementById('messages').innerHTML = '';
-                lastMessageDate = null;
-                lastMessageDates = {};
-            }
-            requestAnimationFrame(() => {
-                const _clearDbgAfter = _clearDbgList ? _clearDbgList.children.length : -1;
-                console.log('CLEAR_DEBUG after clear (next frame), jobs-panel-children=' + _clearDbgAfter);
-            });
-        } else if (event.type === 'reload') {
-            // Server requests full page reload (e.g. after import)
-            location.reload();
+          }
         }
-    };
-
-    ws.onclose = (e) => {
-        // Server sends 4003 when session token is invalid (server restarted).
-        // Auto-reload to pick up the fresh token from the new HTML page.
-        if (e.code === 4003) {
-            console.warn('Session token rejected (server restarted?) — reloading page...');
-            location.reload();
-            return;
+        // Join/leave messages (separate structure, no .msg-sender)
+        const joinText = el.querySelector(".join-text strong");
+        if (joinText && joinText.textContent === event.old_name) {
+          joinText.textContent = event.new_name;
+          joinText.style.color = newColor;
+          const joinDot = el.querySelector(".join-dot");
+          if (joinDot) joinDot.style.background = newColor;
         }
-        console.log('Disconnected, reconnecting in 2s...');
-        soundEnabled = false;  // suppress sounds during reconnect history replay
-        const loader = document.getElementById('loading-indicator');
-        if (loader) loader.classList.remove('hidden');
-        reconnectTimer = setTimeout(connectWebSocket, 2000);
-    };
+      });
+    } else if (event.type === "agents") {
+      applyAgentConfig(event.data);
+    } else if (event.type === "base_colors") {
+      baseColors = event.data || {};
+    } else if (event.type === "todos") {
+      todos = {};
+      for (const [id, status] of Object.entries(event.data)) {
+        todos[parseInt(id)] = status;
+      }
+    } else if (event.type === "todo_update") {
+      const d = event.data;
+      if (d.status === null) {
+        delete todos[d.id];
+      } else {
+        todos[d.id] = d.status;
+      }
+      updateTodoState(d.id, d.status);
+    } else if (event.type === "status") {
+      updateStatus(event.data);
+      // Status is the last event sent on connect — enable sounds after history
+      if (!soundEnabled) {
+        soundEnabled = true;
+        const loader = document.getElementById("loading-indicator");
+        if (loader) loader.classList.add("hidden");
+        filterMessagesByChannel();
+        renderChannelTabs();
+        // Ensure refresh/reconnect lands on the latest visible message.
+        requestAnimationFrame(() => {
+          autoScroll = true;
+          scrollToBottom();
+        });
+      }
+    } else if (event.type === "typing") {
+      updateTyping(event.agent, event.active);
+    } else if (event.type === "settings") {
+      applySettings(event.data);
+    } else if (event.type === "delete") {
+      handleDeleteBroadcast(event.ids);
+    } else if (event.type === "rules" || event.type === "decisions") {
+      rules = event.data || [];
+      renderRulesPanel();
+      updateRulesBadge();
+    } else if (event.type === "rule" || event.type === "decision") {
+      handleRuleEvent(event.action, event.data);
+    } else if (event.type === "hats") {
+      agentHats = event.data || {};
+      updateAllHats();
+    } else if (event.type === "schedules") {
+      schedulesList = event.data || [];
+      renderSchedulesBar();
+    } else if (event.type === "schedule") {
+      handleScheduleEvent(event.action, event.data);
+    } else if (event.type === "pending_instance") {
+      // A new 2nd+ instance registered — queue naming lightbox
+      _pendingNameQueue.push({
+        name: event.name,
+        label: event.label || event.name,
+        color: event.color || "#888",
+        base: event.base || "",
+      });
+      _showNextPendingName();
+    } else if (event.type === "channel_renamed") {
+      // Migrate data-channel on existing DOM elements
+      const container = document.getElementById("messages");
+      for (const el of container.children) {
+        if ((el.dataset.channel || "general") === event.old_name) {
+          el.dataset.channel = event.new_name;
+        }
+      }
+      // Update per-channel date tracking
+      if (lastMessageDates[event.old_name]) {
+        lastMessageDates[event.new_name] = lastMessageDates[event.old_name];
+        delete lastMessageDates[event.old_name];
+      }
+      // Update active channel if we were on the renamed one
+      if (activeChannel === event.old_name) {
+        activeChannel = event.new_name;
+        localStorage.setItem("agentchattr-channel", event.new_name);
+        Store.set("activeChannel", event.new_name);
+      }
+    } else if (event.type === "edit") {
+      // A message was edited/demoted — re-render it in place
+      const updatedMsg = event.message;
+      if (updatedMsg && updatedMsg.id != null) {
+        const el = document.querySelector(
+          `.message[data-id="${updatedMsg.id}"]`,
+        );
+        if (el) {
+          // Insert a fresh message after the old one, then remove the old
+          const placeholder = document.createElement("div");
+          el.after(placeholder);
+          el.remove();
+          // Temporarily hijack container to insert at the right spot
+          const container = document.getElementById("messages");
+          appendMessage(updatedMsg);
+          // Move the newly appended message to where the old one was
+          const newEl = container.lastElementChild;
+          if (newEl && newEl.dataset.id == updatedMsg.id) {
+            placeholder.replaceWith(newEl);
+          } else {
+            placeholder.remove();
+          }
+        }
+      }
+    } else if (event.type === "clear") {
+      const _clearDbgList = document.getElementById("jobs-list");
+      const _clearDbgBefore = _clearDbgList
+        ? _clearDbgList.children.length
+        : -1;
+      console.log(
+        "CLEAR_DEBUG clear event received, channel=" + (event.channel || "ALL"),
+        "jobs-panel-children-before=" + _clearDbgBefore,
+      );
+      const clearChannel = event.channel || null;
+      if (clearChannel) {
+        // Per-channel clear: remove only messages from that channel
+        const container = document.getElementById("messages");
+        const toRemove = [];
+        for (const el of container.children) {
+          if (
+            el.dataset.id &&
+            (el.dataset.channel || "general") === clearChannel
+          ) {
+            toRemove.push(el);
+          }
+        }
+        toRemove.forEach((el) => el.remove());
+        // Clean up orphaned date dividers and reset tracking
+        delete lastMessageDates[clearChannel];
+        filterMessagesByChannel();
+      } else {
+        // Full clear (all channels)
+        document.getElementById("messages").innerHTML = "";
+        lastMessageDate = null;
+        lastMessageDates = {};
+      }
+      requestAnimationFrame(() => {
+        const _clearDbgAfter = _clearDbgList
+          ? _clearDbgList.children.length
+          : -1;
+        console.log(
+          "CLEAR_DEBUG after clear (next frame), jobs-panel-children=" +
+            _clearDbgAfter,
+        );
+      });
+    } else if (event.type === "reload") {
+      // Server requests full page reload (e.g. after import)
+      location.reload();
+    }
+  };
 
-    ws.onerror = (err) => {
-        console.error('WebSocket error:', err);
-        ws.close();
-    };
+  ws.onclose = (e) => {
+    // Server sends 4003 when session token is invalid (server restarted).
+    // Auto-reload to pick up the fresh token from the new HTML page.
+    if (e.code === 4003) {
+      console.warn(
+        "Session token rejected (server restarted?) — reloading page...",
+      );
+      location.reload();
+      return;
+    }
+    console.log("Disconnected, reconnecting in 2s...");
+    soundEnabled = false; // suppress sounds during reconnect history replay
+    const loader = document.getElementById("loading-indicator");
+    if (loader) loader.classList.remove("hidden");
+    reconnectTimer = setTimeout(connectWebSocket, 2000);
+  };
+
+  ws.onerror = (err) => {
+    console.error("WebSocket error:", err);
+    ws.close();
+  };
 }
 
 // --- Date dividers ---
 
 function getMessageDate(msg) {
-    // msg.time is "HH:MM:SS" — we also need the date
-    // Use msg.timestamp (epoch) if available, otherwise try to infer from today
-    if (msg.timestamp) {
-        return new Date(msg.timestamp * 1000).toDateString();
-    }
-    // Fallback: assume today (messages from history might not have timestamps)
-    return new Date().toDateString();
+  // msg.time is "HH:MM:SS" — we also need the date
+  // Use msg.timestamp (epoch) if available, otherwise try to infer from today
+  if (msg.timestamp) {
+    return new Date(msg.timestamp * 1000).toDateString();
+  }
+  // Fallback: assume today (messages from history might not have timestamps)
+  return new Date().toDateString();
 }
 
 function formatDateDivider(dateStr) {
-    const date = new Date(dateStr);
-    const today = new Date();
-    const yesterday = new Date(today);
-    yesterday.setDate(yesterday.getDate() - 1);
+  const date = new Date(dateStr);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
 
-    if (date.toDateString() === today.toDateString()) return 'Today';
-    if (date.toDateString() === yesterday.toDateString()) return 'Yesterday';
+  if (date.toDateString() === today.toDateString()) return "Today";
+  if (date.toDateString() === yesterday.toDateString()) return "Yesterday";
 
-    return date.toLocaleDateString('en-GB', {
-        weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'
-    });
+  return date.toLocaleDateString("en-GB", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
 }
 
 function maybeInsertDateDivider(container, msg) {
-    const msgDate = getMessageDate(msg);
-    const channel = msg.channel || 'general';
-    const lastDate = lastMessageDates[channel];
-    
-    if (msgDate !== lastDate) {
-        lastMessageDates[channel] = msgDate;
-        const divider = document.createElement('div');
-        divider.className = 'date-divider';
-        divider.dataset.channel = channel;
-        divider.innerHTML = `<span>${formatDateDivider(msgDate)}</span>`;
-        if (channel !== activeChannel) {
-            divider.style.display = 'none';
-        }
-        container.appendChild(divider);
+  const msgDate = getMessageDate(msg);
+  const channel = msg.channel || "general";
+  const lastDate = lastMessageDates[channel];
+
+  if (msgDate !== lastDate) {
+    lastMessageDates[channel] = msgDate;
+    const divider = document.createElement("div");
+    divider.className = "date-divider";
+    divider.dataset.channel = channel;
+    divider.innerHTML = `<span>${formatDateDivider(msgDate)}</span>`;
+    if (channel !== activeChannel) {
+      divider.style.display = "none";
     }
+    container.appendChild(divider);
+  }
 }
 
 // --- Messages ---
 
 function appendMessage(msg) {
-    const container = document.getElementById('messages');
+  const container = document.getElementById("messages");
 
-    // Insert date divider if needed
-    maybeInsertDateDivider(container, msg);
+  // Insert date divider if needed
+  maybeInsertDateDivider(container, msg);
 
-    const el = document.createElement('div');
-    el.className = 'message';
-    el.dataset.id = msg.id;
-    const msgChannel = msg.channel || 'general';
-    el.dataset.channel = msgChannel;
+  const el = document.createElement("div");
+  el.className = "message";
+  el.dataset.id = msg.id;
+  const msgChannel = msg.channel || "general";
+  el.dataset.channel = msgChannel;
 
-    if (msg.type === 'join' || msg.type === 'leave') {
-        el.classList.add('join-msg');
-        const color = getColor(msg.sender);
-        el.innerHTML = `<span class="join-dot" style="background: ${color}"></span><span class="join-text"><strong style="color: ${color}">${escapeHtml(msg.sender)}</strong> ${msg.type === 'join' ? 'joined' : 'left'}</span>`;
-    } else if (msg.type === 'summary') {
-        el.classList.add('summary-msg');
-        const color = getColor(msg.sender);
-        el.innerHTML = `<div class="summary-card"><span class="summary-pill">Summary</span><span class="summary-author" style="color: ${color}">${escapeHtml(msg.sender)}</span><div class="summary-text">${escapeHtml(msg.text)}</div></div>`;
-    } else if (msg.type === 'job_proposal') {
-        el.classList.add('proposal-msg');
-        const meta = msg.metadata || {};
-        const title = escapeHtml(meta.title || '');
-        const body = meta.body ? renderMarkdown(meta.body) : '';
-        const color = getColor(msg.sender);
-        const status = meta.status || 'pending';
-        const isPending = status === 'pending';
-        el.dataset.proposalTitle = meta.title || '';
-        el.dataset.proposalBody = meta.body || '';
-        el.dataset.proposalSender = msg.sender || '';
-        el.innerHTML = `
-            <div class="proposal-card ${isPending ? '' : 'proposal-resolved'}">
+  if (msg.type === "join" || msg.type === "leave") {
+    el.classList.add("join-msg");
+    const color = getColor(msg.sender);
+    el.innerHTML = `<span class="join-dot" style="background: ${color}"></span><span class="join-text"><strong style="color: ${color}">${escapeHtml(msg.sender)}</strong> ${msg.type === "join" ? "joined" : "left"}</span>`;
+  } else if (msg.type === "summary") {
+    el.classList.add("summary-msg");
+    const color = getColor(msg.sender);
+    el.innerHTML = `<div class="summary-card"><span class="summary-pill">Summary</span><span class="summary-author" style="color: ${color}">${escapeHtml(msg.sender)}</span><div class="summary-text">${escapeHtml(msg.text)}</div></div>`;
+  } else if (msg.type === "job_proposal") {
+    el.classList.add("proposal-msg");
+    const meta = msg.metadata || {};
+    const title = escapeHtml(meta.title || "");
+    const body = meta.body ? renderMarkdown(meta.body) : "";
+    const color = getColor(msg.sender);
+    const status = meta.status || "pending";
+    const isPending = status === "pending";
+    el.dataset.proposalTitle = meta.title || "";
+    el.dataset.proposalBody = meta.body || "";
+    el.dataset.proposalSender = msg.sender || "";
+    el.innerHTML = `
+            <div class="proposal-card ${isPending ? "" : "proposal-resolved"}">
                 <div class="proposal-header">
                     <span class="proposal-pill">Job Proposal</span>
                     <span class="proposal-author" style="color: ${color}">${escapeHtml(msg.sender)}</span>
                 </div>
                 <div class="proposal-title">${title}</div>
-                ${body ? `<div class="proposal-body">${body}</div>` : ''}
-                ${isPending ? `
+                ${body ? `<div class="proposal-body">${body}</div>` : ""}
+                ${
+                  isPending
+                    ? `
                     <div class="proposal-actions">
                         <button class="proposal-accept" onclick="acceptProposal(${msg.id})">Accept</button>
                         <button class="proposal-request-changes" onclick="requestChangesProposal(${msg.id})">Request Changes</button>
                         <button class="proposal-dismiss" onclick="dismissProposal(${msg.id})">Dismiss</button>
                     </div>
-                ` : `
-                    <div class="proposal-status-resolved">${status === 'accepted' ? 'Accepted' : 'Dismissed'}</div>
-                `}
+                `
+                    : `
+                    <div class="proposal-status-resolved">${status === "accepted" ? "Accepted" : "Dismissed"}</div>
+                `
+                }
             </div>
-            ${!isPending ? `<div class="msg-actions"><button class="reply-btn" onclick="startReply(${msg.id}, event)">reply</button><button class="delete-btn" onclick="deleteClick(${msg.id}, event)" title="Delete">del</button></div>` : ''}`;
-    } else if (msg.type === 'rule_proposal') {
-        el.classList.add('proposal-msg');
-        const meta = msg.metadata || {};
-        const ruleText = escapeHtml(meta.text || msg.text || '');
-        const color = getColor(msg.sender);
-        const status = meta.status || 'pending';
-        const isPending = status === 'pending';
-        el.innerHTML = `
-            <div class="proposal-card rule-proposal-card ${isPending ? '' : 'proposal-resolved'}">
+            ${!isPending ? `<div class="msg-actions"><button class="reply-btn" onclick="startReply(${msg.id}, event)">reply</button><button class="delete-btn" onclick="deleteClick(${msg.id}, event)" title="Delete">del</button></div>` : ""}`;
+  } else if (msg.type === "rule_proposal") {
+    el.classList.add("proposal-msg");
+    const meta = msg.metadata || {};
+    const ruleText = escapeHtml(meta.text || msg.text || "");
+    const color = getColor(msg.sender);
+    const status = meta.status || "pending";
+    const isPending = status === "pending";
+    el.innerHTML = `
+            <div class="proposal-card rule-proposal-card ${isPending ? "" : "proposal-resolved"}">
                 <div class="proposal-header">
                     <span class="proposal-pill rule-proposal-pill">Rule Proposal</span>
                     <span class="proposal-author" style="color: ${color}">${escapeHtml(msg.sender)}</span>
                 </div>
                 <div class="rule-proposal-text">${ruleText}</div>
-                ${isPending ? `
+                ${
+                  isPending
+                    ? `
                     <div class="proposal-actions">
                         <button class="proposal-accept" onclick="resolveRuleProposal(${msg.id}, 'activate')">Activate</button>
                         <button class="proposal-request-changes" onclick="resolveRuleProposal(${msg.id}, 'draft')">Add to drafts</button>
                         <button class="proposal-dismiss" onclick="dismissRuleProposal(${msg.id})">Dismiss</button>
                     </div>
-                ` : `
-                    <div class="proposal-status-resolved">${status === 'activated' ? 'Activated' : status === 'drafted' ? 'Added to drafts' : 'Dismissed'}</div>
-                `}
-            </div>
-            ${!isPending ? `<div class="msg-actions"><button class="reply-btn" onclick="startReply(${msg.id}, event)">reply</button><button class="delete-btn" onclick="deleteClick(${msg.id}, event)" title="Delete">del</button></div>` : ''}`;
-    } else if (window._messageRenderers && window._messageRenderers[msg.type]) {
-        window._messageRenderers[msg.type](el, msg);
-    } else if (msg.type === 'system' || msg.sender === 'system') {
-        el.classList.add('system-msg');
-        el.innerHTML = `<span class="msg-text">${escapeHtml(msg.text)}</span>`;
-    } else {
-        const isError = msg.text.startsWith('[') && msg.text.includes('error');
-        if (isError) el.classList.add('error-msg');
-
-        // Update last mentioned agent if message is from user (Ben)
-        if (msg.sender.toLowerCase() === username.toLowerCase()) {
-            const mentions = msg.text.match(/@(\w+)/g);
-            if (mentions) {
-                const lastMention = mentions[mentions.length - 1].slice(1).toLowerCase();
-                // Check against registered agents (agentConfig keys are name labels)
-                if (agentConfig[lastMention]) {
-                    _lastMentionedAgent = lastMention;
+                `
+                    : `
+                    <div class="proposal-status-resolved">${status === "activated" ? "Activated" : status === "drafted" ? "Added to drafts" : "Dismissed"}</div>
+                `
                 }
-            }
+            </div>
+            ${!isPending ? `<div class="msg-actions"><button class="reply-btn" onclick="startReply(${msg.id}, event)">reply</button><button class="delete-btn" onclick="deleteClick(${msg.id}, event)" title="Delete">del</button></div>` : ""}`;
+  } else if (window._messageRenderers && window._messageRenderers[msg.type]) {
+    window._messageRenderers[msg.type](el, msg);
+  } else if (msg.type === "system" || msg.sender === "system") {
+    el.classList.add("system-msg");
+    el.innerHTML = `<span class="msg-text">${escapeHtml(msg.text)}</span>`;
+  } else {
+    const isError = msg.text.startsWith("[") && msg.text.includes("error");
+    if (isError) el.classList.add("error-msg");
+
+    // Update last mentioned agent if message is from user (Ben)
+    if (msg.sender.toLowerCase() === username.toLowerCase()) {
+      const mentions = msg.text.match(/@(\w+)/g);
+      if (mentions) {
+        const lastMention = mentions[mentions.length - 1]
+          .slice(1)
+          .toLowerCase();
+        // Check against registered agents (agentConfig keys are name labels)
+        if (agentConfig[lastMention]) {
+          _lastMentionedAgent = lastMention;
         }
-
-        let textHtml = styleHashtags(renderMarkdown(msg.text));
-
-        const senderColor = getColor(msg.sender);
-        const isSelf = msg.sender.toLowerCase() === username.toLowerCase();
-        el.classList.add(isSelf ? 'self' : 'other');
-
-        let attachmentsHtml = '';
-        if (msg.attachments && msg.attachments.length > 0) {
-            attachmentsHtml = '<div class="msg-attachments">';
-            for (const att of msg.attachments) {
-                attachmentsHtml += `<img src="${escapeHtml(att.url)}" alt="${escapeHtml(att.name)}" onclick="openImageModal('${escapeHtml(att.url)}')">`;
-            }
-            attachmentsHtml += '</div>';
-        }
-
-        const todoStatus = todos[msg.id] || null;
-
-        // Reply quote (if this message is a reply)
-        let replyHtml = '';
-        if (msg.reply_to !== undefined && msg.reply_to !== null) {
-            const parentEl = document.querySelector(`.message[data-id="${msg.reply_to}"]`);
-            if (parentEl) {
-                const parentSender = parentEl.querySelector('.msg-sender')?.textContent || '?';
-                const parentText = parentEl.dataset.rawText || parentEl.querySelector('.msg-text')?.textContent || '';
-                const truncated = parentText.length > 80 ? parentText.slice(0, 80) + '...' : parentText;
-                const parentColor = parentEl.querySelector('.msg-sender')?.style.color || 'var(--text-dim)';
-                replyHtml = `<div class="reply-quote" onclick="scrollToMessage(${msg.reply_to})"><span class="reply-sender" style="color: ${parentColor}">${escapeHtml(parentSender)}</span> ${escapeHtml(truncated)}</div>`;
-            }
-        }
-
-        const agentKey = (resolveAgent(msg.sender.toLowerCase()) || msg.sender).toLowerCase();
-        const hatSvg = agentHats[agentKey] || '';
-        const hatHtml = hatSvg ? `<div class="hat-overlay" data-agent="${escapeHtml(agentKey)}">${hatSvg}</div>` : '';
-        const avatarHtml = `<div class="avatar-wrap" data-agent="${escapeHtml(agentKey)}"><div class="avatar" style="background-color: ${senderColor}">${getAvatarSvg(msg.sender)}</div>${hatHtml}</div>`;
-
-        const statusLabel = todoStatusLabel(todoStatus);
-        el.dataset.rawText = msg.text;
-        const senderRole = _agentRoles[msg.sender] || '';
-        const roleClass = senderRole ? 'bubble-role has-role' : 'bubble-role';
-        const rolePillHtml = !isSelf ? `<button class="${roleClass}" onclick="showBubbleRolePicker(this, '${escapeHtml(msg.sender)}')" title="${senderRole ? escapeHtml(senderRole) : 'Set role'}">${senderRole || 'choose a role'}</button>` : '';
-        // Inline decision choices (if present)
-        let choicesHtml = '';
-        const meta = msg.metadata || {};
-        const choicesList = meta.choices || [];
-        if (msg.type === 'decision' && choicesList.length > 0) {
-            if (meta.resolved) {
-                choicesHtml = `<div class="decision-choices"><div class="decision-resolved">You chose: <strong>${escapeHtml(meta.chosen || '')}</strong></div></div>`;
-            } else {
-                choicesHtml = '<div class="decision-choices">' + choicesList.map(c =>
-                    `<button class="decision-choice" onclick="resolveDecision(${msg.id}, '${escapeHtml(c).replace(/'/g, "\\'")}')">${escapeHtml(c)}</button>`
-                ).join('') + '</div>';
-            }
-        }
-        el.innerHTML = `<div class="todo-strip"></div>${isSelf ? '' : avatarHtml}<div class="chat-bubble" style="--bubble-color: ${senderColor}">${replyHtml}<div class="bubble-header"><span class="msg-sender" style="color: ${senderColor}">${escapeHtml(msg.sender)}</span>${rolePillHtml}<span class="msg-time">${msg.time || ''}</span></div><div class="msg-text">${textHtml}</div>${choicesHtml}${attachmentsHtml}<button class="convert-job-pill" onclick="startJobFromMessage(${msg.id}); event.stopPropagation();" title="Convert to job">convert to job</button><button class="bubble-copy" onclick="copyMessage(${msg.id}, event)" title="Copy message"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div><div class="msg-actions"><button class="reply-btn" onclick="startReply(${msg.id}, event)">reply</button><button class="todo-hint" onclick="todoCycle(${msg.id}); event.stopPropagation();">${statusLabel}</button><button class="delete-btn" onclick="deleteClick(${msg.id}, event)" title="Delete">del</button></div>`;
-        if (todoStatus) el.classList.add('msg-todo', `msg-todo-${todoStatus}`);
-        if (msg.metadata?.session_output) el.classList.add('session-output');
-
-        // Add copy buttons to code blocks
-        addCodeCopyButtons(el);
+      }
     }
 
-    // Hide messages from other channels
-    if (msgChannel !== activeChannel) {
-        el.style.display = 'none';
-        // Track unread for background channels (skip joins/leaves and initial history load)
-        if (soundEnabled && msg.type !== 'join' && msg.type !== 'leave') {
-            channelUnread[msgChannel] = (channelUnread[msgChannel] || 0) + 1;
-            renderChannelTabs();
-            // Play soft pluck for cross-channel chat messages from others (only when focused)
-            if (document.hasFocus() && msg.type === 'chat' && msg.sender && msg.sender.toLowerCase() !== username.toLowerCase()) {
-                playCrossChannelSound();
-            }
-        }
+    let textHtml = styleHashtags(renderMarkdown(msg.text));
+
+    const senderColor = getColor(msg.sender);
+    const isSelf = msg.sender.toLowerCase() === username.toLowerCase();
+    el.classList.add(isSelf ? "self" : "other");
+
+    let attachmentsHtml = "";
+    if (msg.attachments && msg.attachments.length > 0) {
+      attachmentsHtml = '<div class="msg-attachments">';
+      for (const att of msg.attachments) {
+        attachmentsHtml += `<img src="${escapeHtml(att.url)}" alt="${escapeHtml(att.name)}" onclick="openImageModal('${escapeHtml(att.url)}')">`;
+      }
+      attachmentsHtml += "</div>";
     }
 
-    container.appendChild(el);
+    const todoStatus = todos[msg.id] || null;
 
-    // Collapse consecutive job_created messages into a group
-    if (msg.type === 'job_created' && window._collapseJobBreadcrumbs) {
-        window._collapseJobBreadcrumbs(container, el);
+    // Reply quote (if this message is a reply)
+    let replyHtml = "";
+    if (msg.reply_to !== undefined && msg.reply_to !== null) {
+      const parentEl = document.querySelector(
+        `.message[data-id="${msg.reply_to}"]`,
+      );
+      if (parentEl) {
+        const parentSender =
+          parentEl.querySelector(".msg-sender")?.textContent || "?";
+        const parentText =
+          parentEl.dataset.rawText ||
+          parentEl.querySelector(".msg-text")?.textContent ||
+          "";
+        const truncated =
+          parentText.length > 80 ? parentText.slice(0, 80) + "..." : parentText;
+        const parentColor =
+          parentEl.querySelector(".msg-sender")?.style.color ||
+          "var(--text-dim)";
+        replyHtml = `<div class="reply-quote" onclick="scrollToMessage(${msg.reply_to})"><span class="reply-sender" style="color: ${parentColor}">${escapeHtml(parentSender)}</span> ${escapeHtml(truncated)}</div>`;
+      }
     }
 
-    if (msgChannel !== activeChannel) return;  // don't scroll for hidden messages
+    const agentKey = (
+      resolveAgent(msg.sender.toLowerCase()) || msg.sender
+    ).toLowerCase();
+    const hatSvg = agentHats[agentKey] || "";
+    const hatHtml = hatSvg
+      ? `<div class="hat-overlay" data-agent="${escapeHtml(agentKey)}">${hatSvg}</div>`
+      : "";
+    const avatarHtml = `<div class="avatar-wrap" data-agent="${escapeHtml(agentKey)}"><div class="avatar" style="background-color: ${senderColor}">${getAvatarSvg(msg.sender)}</div>${hatHtml}</div>`;
 
-    if (autoScroll) {
-        scrollToBottom();
-    } else {
-        unreadCount++;
-        updateScrollAnchor();
+    const statusLabel = todoStatusLabel(todoStatus);
+    el.dataset.rawText = msg.text;
+    const senderRole = _agentRoles[msg.sender] || "";
+    const roleClass = senderRole ? "bubble-role has-role" : "bubble-role";
+    const rolePillHtml = !isSelf
+      ? `<button class="${roleClass}" onclick="showBubbleRolePicker(this, '${escapeHtml(msg.sender)}')" title="${senderRole ? escapeHtml(senderRole) : "Set role"}">${senderRole || "choose a role"}</button>`
+      : "";
+    // Inline decision choices (if present)
+    let choicesHtml = "";
+    const meta = msg.metadata || {};
+    const choicesList = meta.choices || [];
+    if (msg.type === "decision" && choicesList.length > 0) {
+      if (meta.resolved) {
+        choicesHtml = `<div class="decision-choices"><div class="decision-resolved">You chose: <strong>${escapeHtml(meta.chosen || "")}</strong></div></div>`;
+      } else {
+        choicesHtml =
+          '<div class="decision-choices">' +
+          choicesList
+            .map(
+              (c) =>
+                `<button class="decision-choice" onclick="resolveDecision(${msg.id}, '${escapeHtml(c).replace(/'/g, "\\'")}')">${escapeHtml(c)}</button>`,
+            )
+            .join("") +
+          "</div>";
+      }
     }
+    el.innerHTML = `<div class="todo-strip"></div>${isSelf ? "" : avatarHtml}<div class="chat-bubble" style="--bubble-color: ${senderColor}">${replyHtml}<div class="bubble-header"><span class="msg-sender" style="color: ${senderColor}">${escapeHtml(msg.sender)}</span>${rolePillHtml}<span class="msg-time">${msg.time || ""}</span></div><div class="msg-text">${textHtml}</div>${choicesHtml}${attachmentsHtml}<button class="convert-job-pill" onclick="startJobFromMessage(${msg.id}); event.stopPropagation();" title="Convert to job">convert to job</button><button class="bubble-copy" onclick="copyMessage(${msg.id}, event)" title="Copy message"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div><div class="msg-actions"><button class="reply-btn" onclick="startReply(${msg.id}, event)">reply</button><button class="todo-hint" onclick="todoCycle(${msg.id}); event.stopPropagation();">${statusLabel}</button><button class="delete-btn" onclick="deleteClick(${msg.id}, event)" title="Delete">del</button></div>`;
+    if (todoStatus) el.classList.add("msg-todo", `msg-todo-${todoStatus}`);
+    if (msg.metadata?.session_output) el.classList.add("session-output");
+
+    // Add copy buttons to code blocks
+    addCodeCopyButtons(el);
+  }
+
+  // Hide messages from other channels
+  if (msgChannel !== activeChannel) {
+    el.style.display = "none";
+    // Track unread for background channels (skip joins/leaves and initial history load)
+    if (soundEnabled && msg.type !== "join" && msg.type !== "leave") {
+      channelUnread[msgChannel] = (channelUnread[msgChannel] || 0) + 1;
+      renderChannelTabs();
+      // Play soft pluck for cross-channel chat messages from others (only when focused)
+      if (
+        document.hasFocus() &&
+        msg.type === "chat" &&
+        msg.sender &&
+        msg.sender.toLowerCase() !== username.toLowerCase()
+      ) {
+        playCrossChannelSound();
+      }
+    }
+  }
+
+  container.appendChild(el);
+
+  // Collapse consecutive job_created messages into a group
+  if (msg.type === "job_created" && window._collapseJobBreadcrumbs) {
+    window._collapseJobBreadcrumbs(container, el);
+  }
+
+  if (msgChannel !== activeChannel) return; // don't scroll for hidden messages
+
+  if (autoScroll) {
+    scrollToBottom();
+  } else {
+    unreadCount++;
+    updateScrollAnchor();
+  }
 }
 
 function getSenderClass(sender) {
-    const s = sender.toLowerCase();
-    if (s === 'system') return 'system';
-    if (resolveAgent(s)) return 'agent';
-    // Check base colors for offline agents
-    const base = s.replace(/-\d+$/, '');
-    if (base in baseColors) return 'agent';
-    return 'user';
+  const s = sender.toLowerCase();
+  if (s === "system") return "system";
+  if (resolveAgent(s)) return "agent";
+  // Check base colors for offline agents
+  const base = s.replace(/-\d+$/, "");
+  if (base in baseColors) return "agent";
+  return "user";
 }
 
 function resolveAgent(name) {
-    const s = name.toLowerCase();
-    if (s in agentConfig) return s;
-    // Try prefix match: "gemini-cli" → "gemini"
-    for (const key of Object.keys(agentConfig)) {
-        if (s.startsWith(key)) return key;
-    }
-    return null;
+  const s = name.toLowerCase();
+  if (s in agentConfig) return s;
+  // Try prefix match: "gemini-cli" → "gemini"
+  for (const key of Object.keys(agentConfig)) {
+    if (s.startsWith(key)) return key;
+  }
+  return null;
 }
 
 function getColor(sender) {
-    const s = sender.toLowerCase();
-    if (s === 'system') return 'var(--system-color)';
-    const resolved = resolveAgent(s);
-    if (resolved) {
-        if (colorOverrides[resolved]) return colorOverrides[resolved];
-        return agentConfig[resolved].color;
-    }
-    // Check overrides for unresolved names too
-    if (colorOverrides[s]) return colorOverrides[s];
-    // Fall back to base agent colors (for historical messages from offline agents)
-    const base = s.replace(/-\d+$/, '');
-    if (colorOverrides[base]) return colorOverrides[base];
-    if (base in baseColors) return baseColors[base].color;
-    return 'var(--user-color)';
+  const s = sender.toLowerCase();
+  if (s === "system") return "var(--system-color)";
+  const resolved = resolveAgent(s);
+  if (resolved) {
+    if (colorOverrides[resolved]) return colorOverrides[resolved];
+    return agentConfig[resolved].color;
+  }
+  // Check overrides for unresolved names too
+  if (colorOverrides[s]) return colorOverrides[s];
+  // Fall back to base agent colors (for historical messages from offline agents)
+  const base = s.replace(/-\d+$/, "");
+  if (colorOverrides[base]) return colorOverrides[base];
+  if (base in baseColors) return baseColors[base].color;
+  return "var(--user-color)";
 }
 
 function colorMentions(textHtml) {
-    // Match any @word — we'll resolve color per match
-    return textHtml.replace(/@(\w[\w-]*)/gi, (match, name) => {
-        const lower = name.toLowerCase();
-        if (lower === 'both' || lower === 'all') {
-            return `<span class="mention" style="color: var(--accent)">@${name}</span>`;
-        }
-        const resolved = resolveAgent(lower);
-        if (resolved) {
-            const color = getColor(resolved);
-            return `<span class="mention" style="color: ${color}">@${name}</span>`;
-        }
-        // Non-agent mention (e.g. @ben, @user) — use user color
-        return `<span class="mention" style="color: var(--user-color)">@${name}</span>`;
-    });
+  // Match any @word — we'll resolve color per match
+  return textHtml.replace(/@(\w[\w-]*)/gi, (match, name) => {
+    const lower = name.toLowerCase();
+    if (lower === "both" || lower === "all") {
+      return `<span class="mention" style="color: var(--accent)">@${name}</span>`;
+    }
+    const resolved = resolveAgent(lower);
+    if (resolved) {
+      const color = getColor(resolved);
+      return `<span class="mention" style="color: ${color}">@${name}</span>`;
+    }
+    // Non-agent mention (e.g. @ben, @user) — use user color
+    return `<span class="mention" style="color: var(--user-color)">@${name}</span>`;
+  });
 }
 
 function scrollToBottom() {
-    const timeline = document.getElementById('timeline');
-    timeline.scrollTop = timeline.scrollHeight;
-    unreadCount = 0;
-    updateScrollAnchor();
+  const timeline = document.getElementById("timeline");
+  timeline.scrollTop = timeline.scrollHeight;
+  unreadCount = 0;
+  updateScrollAnchor();
 }
 window.scrollToBottom = scrollToBottom;
 window.appendMessage = appendMessage;
 
 function updateScrollAnchor() {
-    const anchor = document.getElementById('scroll-anchor');
-    if (autoScroll) {
-        anchor.classList.add('hidden');
-    } else {
-        anchor.classList.remove('hidden');
-        const badge = anchor.querySelector('.unread-badge');
-        if (badge) {
-            badge.textContent = unreadCount;
-            badge.style.display = unreadCount > 0 ? 'flex' : 'none';
-        }
+  const anchor = document.getElementById("scroll-anchor");
+  if (autoScroll) {
+    anchor.classList.add("hidden");
+  } else {
+    anchor.classList.remove("hidden");
+    const badge = anchor.querySelector(".unread-badge");
+    if (badge) {
+      badge.textContent = unreadCount;
+      badge.style.display = unreadCount > 0 ? "flex" : "none";
     }
-    repositionScrollAnchor();
+  }
+  repositionScrollAnchor();
 }
 
 function repositionScrollAnchor() {
-    const anchor = document.getElementById('scroll-anchor');
-    if (!anchor) return;
-    const footer = document.querySelector('footer');
-    if (footer) {
-        anchor.style.bottom = (footer.offsetHeight + 12) + 'px';
-    }
-    const timeline = document.getElementById('timeline');
-    if (timeline) {
-        const rect = timeline.getBoundingClientRect();
-        anchor.style.left = (rect.left + rect.width / 2) + 'px';
-    }
+  const anchor = document.getElementById("scroll-anchor");
+  if (!anchor) return;
+  const footer = document.querySelector("footer");
+  if (footer) {
+    anchor.style.bottom = footer.offsetHeight + 12 + "px";
+  }
+  const timeline = document.getElementById("timeline");
+  if (timeline) {
+    const rect = timeline.getBoundingClientRect();
+    anchor.style.left = rect.left + rect.width / 2 + "px";
+  }
 }
 
 // --- Agents ---
 
 function applyAgentConfig(data) {
-    agentConfig = {};
-    for (const [name, cfg] of Object.entries(data)) {
-        agentConfig[name.toLowerCase()] = cfg;
-    }
-    buildStatusPills();
-    buildMentionToggles();
-    buildSoundSettings();
-    // Re-color any messages already rendered (e.g. from a reconnect)
-    recolorMessages();
-    updateJobReplyTargetUI();
+  agentConfig = {};
+  for (const [name, cfg] of Object.entries(data)) {
+    agentConfig[name.toLowerCase()] = cfg;
+  }
+  buildStatusPills();
+  buildMentionToggles();
+  buildSoundSettings();
+  // Re-color any messages already rendered (e.g. from a reconnect)
+  recolorMessages();
+  updateJobReplyTargetUI();
 }
 
 function recolorMessages() {
-    const msgs = document.querySelectorAll('.message[data-id]');
-    for (const el of msgs) {
-        const sender = el.querySelector('.msg-sender');
-        if (!sender) continue;
-        const name = sender.textContent.trim();
-        const color = getColor(name);
-        sender.style.color = color;
-        // Update bubble color
-        const bubble = el.querySelector('.chat-bubble');
-        if (bubble) bubble.style.setProperty('--bubble-color', color);
-        // Update avatar color
-        const avatar = el.querySelector('.avatar');
-        if (avatar) avatar.style.backgroundColor = color;
-        // Re-render markdown with updated mention colors and hashtags
-        const textEl = el.querySelector('.msg-text');
-        if (textEl && el.dataset.rawText) {
-            textEl.innerHTML = styleHashtags(renderMarkdown(el.dataset.rawText));
-            addCodeCopyButtons(el);
-        }
+  const msgs = document.querySelectorAll(".message[data-id]");
+  for (const el of msgs) {
+    const sender = el.querySelector(".msg-sender");
+    if (!sender) continue;
+    const name = sender.textContent.trim();
+    const color = getColor(name);
+    sender.style.color = color;
+    // Update bubble color
+    const bubble = el.querySelector(".chat-bubble");
+    if (bubble) bubble.style.setProperty("--bubble-color", color);
+    // Update avatar color
+    const avatar = el.querySelector(".avatar");
+    if (avatar) avatar.style.backgroundColor = color;
+    // Re-render markdown with updated mention colors and hashtags
+    const textEl = el.querySelector(".msg-text");
+    if (textEl && el.dataset.rawText) {
+      textEl.innerHTML = styleHashtags(renderMarkdown(el.dataset.rawText));
+      addCodeCopyButtons(el);
     }
+  }
 }
 
 // --- Hats ---
 
 function updateAllHats() {
-    // Update hat overlays on all message avatars
-    document.querySelectorAll('.avatar-wrap[data-agent]').forEach(wrap => {
-        const agent = wrap.dataset.agent;
-        const svg = agentHats[agent] || '';
-        let overlay = wrap.querySelector('.hat-overlay');
+  // Update hat overlays on all message avatars
+  document.querySelectorAll(".avatar-wrap[data-agent]").forEach((wrap) => {
+    const agent = wrap.dataset.agent;
+    const svg = agentHats[agent] || "";
+    let overlay = wrap.querySelector(".hat-overlay");
 
-        if (svg) {
-            if (!overlay) {
-                overlay = document.createElement('div');
-                overlay.className = 'hat-overlay';
-                overlay.dataset.agent = agent;
-                wrap.appendChild(overlay);
-            }
-            overlay.innerHTML = svg;
-        } else {
-            if (overlay) overlay.remove();
-        }
-    });
+    if (svg) {
+      if (!overlay) {
+        overlay = document.createElement("div");
+        overlay.className = "hat-overlay";
+        overlay.dataset.agent = agent;
+        wrap.appendChild(overlay);
+      }
+      overlay.innerHTML = svg;
+    } else {
+      if (overlay) overlay.remove();
+    }
+  });
 }
 
 // --- Hat drag-to-trash ---
 
 const TRASH_SVG = `<svg viewBox="0 0 20 20" fill="none" width="20" height="20"><rect x="4" y="6" width="12" height="12" rx="1.5" stroke="currentColor" stroke-width="1.3"/><path d="M3 6h14" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/><path d="M8 3h4v3H8z" stroke="currentColor" stroke-width="1.2"/><rect class="trash-lid" x="3" y="4.5" width="14" height="2" rx="0.5" fill="currentColor" style="transform-origin: 10px 5.5px"/></svg>`;
 
-let hatDragState = null;  // { agent, ghostEl, originRect, trashEl, wrapEl }
+let hatDragState = null; // { agent, ghostEl, originRect, trashEl, wrapEl }
 
-document.addEventListener('mousedown', (e) => {
-    const overlay = e.target.closest('.hat-overlay');
-    if (!overlay || hatDragState) return;
-    e.preventDefault();
+document.addEventListener("mousedown", (e) => {
+  const overlay = e.target.closest(".hat-overlay");
+  if (!overlay || hatDragState) return;
+  e.preventDefault();
 
-    const agent = overlay.dataset.agent;
-    const wrap = overlay.closest('.avatar-wrap');
-    if (!wrap) return;
+  const agent = overlay.dataset.agent;
+  const wrap = overlay.closest(".avatar-wrap");
+  if (!wrap) return;
 
-    const rect = overlay.getBoundingClientRect();
+  const rect = overlay.getBoundingClientRect();
 
-    // Create drag ghost (fixed position, follows cursor)
-    const ghost = document.createElement('div');
-    ghost.className = 'hat-drag-ghost';
-    ghost.innerHTML = overlay.innerHTML;
-    ghost.style.width = rect.width + 'px';
-    ghost.style.height = rect.height + 'px';
-    ghost.style.left = rect.left + 'px';
-    ghost.style.top = rect.top + 'px';
-    document.body.appendChild(ghost);
+  // Create drag ghost (fixed position, follows cursor)
+  const ghost = document.createElement("div");
+  ghost.className = "hat-drag-ghost";
+  ghost.innerHTML = overlay.innerHTML;
+  ghost.style.width = rect.width + "px";
+  ghost.style.height = rect.height + "px";
+  ghost.style.left = rect.left + "px";
+  ghost.style.top = rect.top + "px";
+  document.body.appendChild(ghost);
 
-    // Hide original overlay
-    overlay.style.visibility = 'hidden';
+  // Hide original overlay
+  overlay.style.visibility = "hidden";
 
-    // Create trash can to the left of the avatar-wrap
-    const trash = document.createElement('div');
-    trash.className = 'hat-trash';
-    trash.innerHTML = TRASH_SVG;
-    wrap.appendChild(trash);
-    // Force reflow then show
-    trash.offsetHeight;
-    trash.classList.add('visible');
+  // Create trash can to the left of the avatar-wrap
+  const trash = document.createElement("div");
+  trash.className = "hat-trash";
+  trash.innerHTML = TRASH_SVG;
+  wrap.appendChild(trash);
+  // Force reflow then show
+  trash.offsetHeight;
+  trash.classList.add("visible");
 
-    hatDragState = { agent, ghostEl: ghost, originRect: rect, trashEl: trash, wrapEl: wrap, overlayEl: overlay };
+  hatDragState = {
+    agent,
+    ghostEl: ghost,
+    originRect: rect,
+    trashEl: trash,
+    wrapEl: wrap,
+    overlayEl: overlay,
+  };
 });
 
-document.addEventListener('mousemove', (e) => {
-    if (!hatDragState) return;
-    const { ghostEl, trashEl } = hatDragState;
+document.addEventListener("mousemove", (e) => {
+  if (!hatDragState) return;
+  const { ghostEl, trashEl } = hatDragState;
 
-    // Move ghost to follow cursor (centered on cursor)
-    ghostEl.style.left = (e.clientX - ghostEl.offsetWidth / 2) + 'px';
-    ghostEl.style.top = (e.clientY - ghostEl.offsetHeight / 2) + 'px';
+  // Move ghost to follow cursor (centered on cursor)
+  ghostEl.style.left = e.clientX - ghostEl.offsetWidth / 2 + "px";
+  ghostEl.style.top = e.clientY - ghostEl.offsetHeight / 2 + "px";
 
-    // Check proximity to trash for highlight
-    const trashRect = trashEl.getBoundingClientRect();
-    const ghostCX = e.clientX;
-    const ghostCY = e.clientY;
-    const overTrash = ghostCX >= trashRect.left - 12 && ghostCX <= trashRect.right + 12 &&
-                      ghostCY >= trashRect.top - 12 && ghostCY <= trashRect.bottom + 12;
-    trashEl.classList.toggle('hover', overTrash);
+  // Check proximity to trash for highlight
+  const trashRect = trashEl.getBoundingClientRect();
+  const ghostCX = e.clientX;
+  const ghostCY = e.clientY;
+  const overTrash =
+    ghostCX >= trashRect.left - 12 &&
+    ghostCX <= trashRect.right + 12 &&
+    ghostCY >= trashRect.top - 12 &&
+    ghostCY <= trashRect.bottom + 12;
+  trashEl.classList.toggle("hover", overTrash);
 });
 
-document.addEventListener('mouseup', (e) => {
-    if (!hatDragState) return;
-    const { agent, ghostEl, originRect, trashEl, wrapEl, overlayEl } = hatDragState;
+document.addEventListener("mouseup", (e) => {
+  if (!hatDragState) return;
+  const { agent, ghostEl, originRect, trashEl, wrapEl, overlayEl } =
+    hatDragState;
 
-    // Check if dropped on trash
-    const trashRect = trashEl.getBoundingClientRect();
-    const overTrash = e.clientX >= trashRect.left - 12 && e.clientX <= trashRect.right + 12 &&
-                      e.clientY >= trashRect.top - 12 && e.clientY <= trashRect.bottom + 12;
+  // Check if dropped on trash
+  const trashRect = trashEl.getBoundingClientRect();
+  const overTrash =
+    e.clientX >= trashRect.left - 12 &&
+    e.clientX <= trashRect.right + 12 &&
+    e.clientY >= trashRect.top - 12 &&
+    e.clientY <= trashRect.bottom + 12;
 
-    if (overTrash) {
-        // Snap ghost to trash center, shrink, fade out
-        ghostEl.style.transition = 'all 0.25s ease-in';
-        ghostEl.style.left = (trashRect.left + trashRect.width / 2 - ghostEl.offsetWidth / 2) + 'px';
-        ghostEl.style.top = (trashRect.top + trashRect.height / 2 - ghostEl.offsetHeight / 2) + 'px';
-        ghostEl.style.transform = 'scale(0.2)';
-        ghostEl.style.opacity = '0';
+  if (overTrash) {
+    // Snap ghost to trash center, shrink, fade out
+    ghostEl.style.transition = "all 0.25s ease-in";
+    ghostEl.style.left =
+      trashRect.left + trashRect.width / 2 - ghostEl.offsetWidth / 2 + "px";
+    ghostEl.style.top =
+      trashRect.top + trashRect.height / 2 - ghostEl.offsetHeight / 2 + "px";
+    ghostEl.style.transform = "scale(0.2)";
+    ghostEl.style.opacity = "0";
 
-        // Chomp animation on trash
-        trashEl.classList.remove('hover');
-        trashEl.classList.add('chomping');
+    // Chomp animation on trash
+    trashEl.classList.remove("hover");
+    trashEl.classList.add("chomping");
 
-        // Send DELETE to server
-        fetch(`/api/hat/${agent}`, {
-            method: 'DELETE',
-            headers: { 'X-Session-Token': SESSION_TOKEN },
-        }).catch(err => console.error('Hat delete failed:', err));
+    // Send DELETE to server
+    fetch(`/api/hat/${agent}`, {
+      method: "DELETE",
+    }).catch((err) => console.error("Hat delete failed:", err));
 
-        // Cleanup after animation
-        setTimeout(() => {
-            ghostEl.remove();
-            trashEl.remove();
-            if (overlayEl) overlayEl.remove();
-        }, 600);
-    } else {
-        // Return ghost to original position
-        ghostEl.style.transition = 'all 0.3s ease';
-        ghostEl.style.left = originRect.left + 'px';
-        ghostEl.style.top = originRect.top + 'px';
+    // Cleanup after animation
+    setTimeout(() => {
+      ghostEl.remove();
+      trashEl.remove();
+      if (overlayEl) overlayEl.remove();
+    }, 600);
+  } else {
+    // Return ghost to original position
+    ghostEl.style.transition = "all 0.3s ease";
+    ghostEl.style.left = originRect.left + "px";
+    ghostEl.style.top = originRect.top + "px";
 
-        // Fade out trash
-        trashEl.classList.remove('hover', 'visible');
+    // Fade out trash
+    trashEl.classList.remove("hover", "visible");
 
-        setTimeout(() => {
-            ghostEl.remove();
-            trashEl.remove();
-            overlayEl.style.visibility = '';
-        }, 300);
-    }
+    setTimeout(() => {
+      ghostEl.remove();
+      trashEl.remove();
+      overlayEl.style.visibility = "";
+    }, 300);
+  }
 
-    hatDragState = null;
+  hatDragState = null;
 });
 
 // Cancel hat drag on Escape
-document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && hatDragState) {
-        const { ghostEl, originRect, trashEl, overlayEl } = hatDragState;
-        ghostEl.style.transition = 'all 0.3s ease';
-        ghostEl.style.left = originRect.left + 'px';
-        ghostEl.style.top = originRect.top + 'px';
-        trashEl.classList.remove('hover', 'visible');
-        setTimeout(() => {
-            ghostEl.remove();
-            trashEl.remove();
-            overlayEl.style.visibility = '';
-        }, 300);
-        hatDragState = null;
-    }
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && hatDragState) {
+    const { ghostEl, originRect, trashEl, overlayEl } = hatDragState;
+    ghostEl.style.transition = "all 0.3s ease";
+    ghostEl.style.left = originRect.left + "px";
+    ghostEl.style.top = originRect.top + "px";
+    trashEl.classList.remove("hover", "visible");
+    setTimeout(() => {
+      ghostEl.remove();
+      trashEl.remove();
+      overlayEl.style.visibility = "";
+    }, 300);
+    hatDragState = null;
+  }
 });
 
 function buildStatusPills() {
-    const container = document.getElementById('agent-status');
-    container.innerHTML = '';
-    for (const [name, cfg] of Object.entries(agentConfig)) {
-        const pill = document.createElement('div');
-        pill.className = 'status-pill';
-        if (cfg.state === 'pending') pill.classList.add('pending');
-        pill.id = `status-${name}`;
-        pill.title = `@${name}`;  // Tooltip: canonical name for manual @-typing
-        pill.style.setProperty('--agent-color', colorOverrides[name] || cfg.color || '#4ade80');
-        pill.innerHTML = `<span class="status-dot"></span><span class="status-label">${escapeHtml(cfg.label || name)}</span>`;
-        // Left-click to toggle pill popover (rename + role + color)
-        pill.addEventListener('click', (e) => {
-            e.stopPropagation();
-            // Toggle: close if this pill's popover is already open
-            const existing = document.querySelector(`.pill-popover[data-agent="${name}"]`);
-            if (existing) { existing.remove(); return; }
-            const mode = cfg.state === 'pending' ? 'pending' : 'rename';
-            showPillPopover(pill, {
-                name, label: cfg.label || name, color: cfg.color || '#888',
-                base: cfg.base || '', mode,
-            });
-        });
-        container.appendChild(pill);
-    }
-    enableDragScroll(container);
+  const container = document.getElementById("agent-status");
+  container.innerHTML = "";
+  for (const [name, cfg] of Object.entries(agentConfig)) {
+    const pill = document.createElement("div");
+    pill.className = "status-pill";
+    if (cfg.state === "pending") pill.classList.add("pending");
+    pill.id = `status-${name}`;
+    pill.title = `@${name}`; // Tooltip: canonical name for manual @-typing
+    pill.style.setProperty(
+      "--agent-color",
+      colorOverrides[name] || cfg.color || "#4ade80",
+    );
+    pill.innerHTML = `<span class="status-dot"></span><span class="status-label">${escapeHtml(cfg.label || name)}</span>`;
+    // Left-click to toggle pill popover (rename + role + color)
+    pill.addEventListener("click", (e) => {
+      e.stopPropagation();
+      // Toggle: close if this pill's popover is already open
+      const existing = document.querySelector(
+        `.pill-popover[data-agent="${name}"]`,
+      );
+      if (existing) {
+        existing.remove();
+        return;
+      }
+      const mode = cfg.state === "pending" ? "pending" : "rename";
+      showPillPopover(pill, {
+        name,
+        label: cfg.label || name,
+        color: cfg.color || "#888",
+        base: cfg.base || "",
+        mode,
+      });
+    });
+    container.appendChild(pill);
+  }
+  enableDragScroll(container);
 }
 
 // --- Role presets (shared by pill popover + bubble picker) ---
 
 const ROLE_PRESETS = [
-    { label: 'Planner', emoji: '📋' },
-    { label: 'Designer', emoji: '✨' },
-    { label: 'Architect', emoji: '🏛️' },
-    { label: 'Builder', emoji: '🔨' },
-    { label: 'Reviewer', emoji: '🔍' },
-    { label: 'Researcher', emoji: '🔬' },
-    { label: 'Red Team', emoji: '🛡️' },
-    { label: 'Wry', emoji: '🍸' },
-    { label: 'Unhinged', emoji: '🤪' },
-    { label: 'Hype', emoji: '🎉' },
+  { label: "Planner", emoji: "📋" },
+  { label: "Designer", emoji: "✨" },
+  { label: "Architect", emoji: "🏛️" },
+  { label: "Builder", emoji: "🔨" },
+  { label: "Reviewer", emoji: "🔍" },
+  { label: "Researcher", emoji: "🔬" },
+  { label: "Red Team", emoji: "🛡️" },
+  { label: "Wry", emoji: "🍸" },
+  { label: "Unhinged", emoji: "🤪" },
+  { label: "Hype", emoji: "🎉" },
 ];
 
 // --- Agent naming lightbox ---
@@ -1177,27 +1376,27 @@ const _pendingNameQueue = [];
 let _nameModalActive = false;
 
 function _showNextPendingName() {
-    if (_nameModalActive || _pendingNameQueue.length === 0) return;
-    const next = _pendingNameQueue.shift();
-    // Only show if still pending in agentConfig
-    const cfg = agentConfig[next.name];
-    if (cfg && cfg.state === 'pending') {
-        const pillEl = document.getElementById(`status-${next.name}`);
-        showPillPopover(pillEl || null, { ...next, mode: 'pending' });
-    } else {
-        _showNextPendingName(); // skip stale entries
-    }
+  if (_nameModalActive || _pendingNameQueue.length === 0) return;
+  const next = _pendingNameQueue.shift();
+  // Only show if still pending in agentConfig
+  const cfg = agentConfig[next.name];
+  if (cfg && cfg.state === "pending") {
+    const pillEl = document.getElementById(`status-${next.name}`);
+    showPillPopover(pillEl || null, { ...next, mode: "pending" });
+  } else {
+    _showNextPendingName(); // skip stale entries
+  }
 }
 
 function showAgentNameModal(opts) {
-    // opts: { name, label, color, base, mode: 'pending' | 'rename' }
-    _nameModalActive = true;
-    let modal = document.getElementById('agent-name-modal');
-    if (!modal) {
-        modal = document.createElement('div');
-        modal.id = 'agent-name-modal';
-        modal.className = 'agent-name-modal hidden';
-        modal.innerHTML = `
+  // opts: { name, label, color, base, mode: 'pending' | 'rename' }
+  _nameModalActive = true;
+  let modal = document.getElementById("agent-name-modal");
+  if (!modal) {
+    modal = document.createElement("div");
+    modal.id = "agent-name-modal";
+    modal.className = "agent-name-modal hidden";
+    modal.innerHTML = `
             <div class="agent-name-dialog">
                 <div class="agent-name-header">
                     <div class="agent-name-avatar"></div>
@@ -1210,113 +1409,137 @@ function showAgentNameModal(opts) {
                     <button class="agent-name-confirm">Confirm</button>
                 </div>
             </div>`;
-        // Close on backdrop click
-        modal.addEventListener('click', (e) => {
-            if (e.target === modal) _closeAgentNameModal();
-        });
-        document.body.appendChild(modal);
-    }
-
-    const avatarEl = modal.querySelector('.agent-name-avatar');
-    const titleEl = modal.querySelector('.agent-name-title');
-    const subtitleEl = modal.querySelector('.agent-name-subtitle');
-    const inputEl = modal.querySelector('.agent-name-input');
-    const cancelBtn = modal.querySelector('.agent-name-cancel');
-    const confirmBtn = modal.querySelector('.agent-name-confirm');
-
-    // Set agent color accent
-    modal.style.setProperty('--agent-color', opts.color);
-
-    // Avatar from brand
-    const brandKey = opts.base || opts.name.replace(/-\d+$/, '');
-    avatarEl.innerHTML = BRAND_AVATARS[brandKey] || USER_AVATAR;
-    avatarEl.style.background = opts.color;
-
-    if (opts.mode === 'pending') {
-        const familyLabel = (baseColors[opts.base] || {}).label || opts.base || 'agent';
-        titleEl.textContent = 'Name this agent';
-        subtitleEl.textContent = `A new ${familyLabel} instance connected`;
-    } else {
-        titleEl.textContent = 'Rename agent';
-        subtitleEl.textContent = `Current ID: @${opts.name}`;
-    }
-
-    inputEl.value = opts.label;
-    inputEl.placeholder = opts.label;
-
-    // Remove old listeners by cloning
-    const newCancel = cancelBtn.cloneNode(true);
-    cancelBtn.parentNode.replaceChild(newCancel, cancelBtn);
-    const newConfirm = confirmBtn.cloneNode(true);
-    confirmBtn.parentNode.replaceChild(newConfirm, confirmBtn);
-
-    newCancel.addEventListener('click', () => _closeAgentNameModal());
-    newConfirm.addEventListener('click', () => {
-        const label = inputEl.value.trim();
-        if (!label) return;
-        if (ws && ws.readyState === WebSocket.OPEN) {
-            if (opts.mode === 'pending') {
-                ws.send(JSON.stringify({ type: 'name_pending', name: opts.name, label }));
-            } else {
-                ws.send(JSON.stringify({ type: 'rename_agent', name: opts.name, label }));
-            }
-        }
-        _closeAgentNameModal();
+    // Close on backdrop click
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) _closeAgentNameModal();
     });
+    document.body.appendChild(modal);
+  }
 
-    // Enter key confirms
-    inputEl.onkeydown = (e) => {
-        if (e.key === 'Enter') { newConfirm.click(); e.preventDefault(); }
-        if (e.key === 'Escape') { _closeAgentNameModal(); e.preventDefault(); }
-    };
+  const avatarEl = modal.querySelector(".agent-name-avatar");
+  const titleEl = modal.querySelector(".agent-name-title");
+  const subtitleEl = modal.querySelector(".agent-name-subtitle");
+  const inputEl = modal.querySelector(".agent-name-input");
+  const cancelBtn = modal.querySelector(".agent-name-cancel");
+  const confirmBtn = modal.querySelector(".agent-name-confirm");
 
-    modal.classList.remove('hidden');
-    // Focus and select input text after animation frame
-    requestAnimationFrame(() => { inputEl.focus(); inputEl.select(); });
+  // Set agent color accent
+  modal.style.setProperty("--agent-color", opts.color);
+
+  // Avatar from brand
+  const brandKey = opts.base || opts.name.replace(/-\d+$/, "");
+  avatarEl.innerHTML = BRAND_AVATARS[brandKey] || USER_AVATAR;
+  avatarEl.style.background = opts.color;
+
+  if (opts.mode === "pending") {
+    const familyLabel =
+      (baseColors[opts.base] || {}).label || opts.base || "agent";
+    titleEl.textContent = "Name this agent";
+    subtitleEl.textContent = `A new ${familyLabel} instance connected`;
+  } else {
+    titleEl.textContent = "Rename agent";
+    subtitleEl.textContent = `Current ID: @${opts.name}`;
+  }
+
+  inputEl.value = opts.label;
+  inputEl.placeholder = opts.label;
+
+  // Remove old listeners by cloning
+  const newCancel = cancelBtn.cloneNode(true);
+  cancelBtn.parentNode.replaceChild(newCancel, cancelBtn);
+  const newConfirm = confirmBtn.cloneNode(true);
+  confirmBtn.parentNode.replaceChild(newConfirm, confirmBtn);
+
+  newCancel.addEventListener("click", () => _closeAgentNameModal());
+  newConfirm.addEventListener("click", () => {
+    const label = inputEl.value.trim();
+    if (!label) return;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      if (opts.mode === "pending") {
+        ws.send(
+          JSON.stringify({ type: "name_pending", name: opts.name, label }),
+        );
+      } else {
+        ws.send(
+          JSON.stringify({ type: "rename_agent", name: opts.name, label }),
+        );
+      }
+    }
+    _closeAgentNameModal();
+  });
+
+  // Enter key confirms
+  inputEl.onkeydown = (e) => {
+    if (e.key === "Enter") {
+      newConfirm.click();
+      e.preventDefault();
+    }
+    if (e.key === "Escape") {
+      _closeAgentNameModal();
+      e.preventDefault();
+    }
+  };
+
+  modal.classList.remove("hidden");
+  // Focus and select input text after animation frame
+  requestAnimationFrame(() => {
+    inputEl.focus();
+    inputEl.select();
+  });
 }
 
 function _closeAgentNameModal() {
-    const modal = document.getElementById('agent-name-modal');
-    if (modal) modal.classList.add('hidden');
-    _nameModalActive = false;
-    // Show next pending if queued
-    setTimeout(_showNextPendingName, 200);
+  const modal = document.getElementById("agent-name-modal");
+  if (modal) modal.classList.add("hidden");
+  _nameModalActive = false;
+  // Show next pending if queued
+  setTimeout(_showNextPendingName, 200);
 }
 
 // --- Pill popover (rename + role) ---
 
 function showPillPopover(pillEl, opts) {
-    if (opts.mode === 'pending') _nameModalActive = true;
+  if (opts.mode === "pending") _nameModalActive = true;
 
-    document.querySelectorAll('.pill-popover').forEach(p => p.remove());
+  document.querySelectorAll(".pill-popover").forEach((p) => p.remove());
 
-    const popover = document.createElement('div');
-    popover.className = 'pill-popover';
-    popover.dataset.agent = opts.name;
-    popover.style.setProperty('--agent-color', colorOverrides[opts.name] || opts.color);
+  const popover = document.createElement("div");
+  popover.className = "pill-popover";
+  popover.dataset.agent = opts.name;
+  popover.style.setProperty(
+    "--agent-color",
+    colorOverrides[opts.name] || opts.color,
+  );
 
-    const currentRole = (_agentRoles[opts.name] || '').toLowerCase();
-    const roleChipsHtml = ROLE_PRESETS.map(p =>
-        `<button class="role-preset-chip pill-role-chip ${currentRole === p.label.toLowerCase() ? 'active' : ''}" data-role="${escapeHtml(p.label)}">${p.emoji} ${escapeHtml(p.label)}</button>`
-    ).join('');
-    const customChipsHtml = (window.customRoles || [])
-        .filter(r => r && !ROLE_PRESETS.some(p => p.label.toLowerCase() === r.toLowerCase()))
-        .map(r =>
-            `<button class="role-preset-chip pill-role-chip pill-custom-chip ${currentRole === r.toLowerCase() ? 'active' : ''}" data-role="${escapeHtml(r)}"><span class="pill-custom-label">${escapeHtml(r)}</span><span class="pill-custom-trash"><svg width="10" height="10" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M6 4V3h4v1M5 4v8.5h6V4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="pill-custom-confirm"><span class="pill-confirm-yes">&#10003;</span><span class="pill-confirm-no">&#10005;</span></span></button>`
-        ).join('');
+  const currentRole = (_agentRoles[opts.name] || "").toLowerCase();
+  const roleChipsHtml = ROLE_PRESETS.map(
+    (p) =>
+      `<button class="role-preset-chip pill-role-chip ${currentRole === p.label.toLowerCase() ? "active" : ""}" data-role="${escapeHtml(p.label)}">${p.emoji} ${escapeHtml(p.label)}</button>`,
+  ).join("");
+  const customChipsHtml = (window.customRoles || [])
+    .filter(
+      (r) =>
+        r &&
+        !ROLE_PRESETS.some((p) => p.label.toLowerCase() === r.toLowerCase()),
+    )
+    .map(
+      (r) =>
+        `<button class="role-preset-chip pill-role-chip pill-custom-chip ${currentRole === r.toLowerCase() ? "active" : ""}" data-role="${escapeHtml(r)}"><span class="pill-custom-label">${escapeHtml(r)}</span><span class="pill-custom-trash"><svg width="10" height="10" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M6 4V3h4v1M5 4v8.5h6V4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="pill-custom-confirm"><span class="pill-confirm-yes">&#10003;</span><span class="pill-confirm-no">&#10005;</span></span></button>`,
+    )
+    .join("");
 
-    popover.innerHTML = `
+  popover.innerHTML = `
         <div class="pill-popover-section">
-            <label class="pill-popover-label">${opts.mode === 'pending' ? 'Name this agent' : 'Rename'}</label>
+            <label class="pill-popover-label">${opts.mode === "pending" ? "Name this agent" : "Rename"}</label>
             <div class="pill-popover-rename-row">
                 <input type="text" class="pill-popover-input" value="${escapeHtml(opts.label)}" maxlength="24" spellcheck="false" />
-                <button class="pill-popover-confirm">${opts.mode === 'pending' ? 'Confirm' : 'Rename'}</button>
+                <button class="pill-popover-confirm">${opts.mode === "pending" ? "Confirm" : "Rename"}</button>
             </div>
         </div>
         <div class="pill-popover-section">
             <label class="pill-popover-label">Role</label>
             <div class="pill-popover-roles">
-                <button class="role-preset-chip pill-role-chip ${!currentRole ? 'active' : ''}" data-role="">None</button>
+                <button class="role-preset-chip pill-role-chip ${!currentRole ? "active" : ""}" data-role="">None</button>
                 ${roleChipsHtml}
                 ${customChipsHtml}
             </div>
@@ -1325,402 +1548,513 @@ function showPillPopover(pillEl, opts) {
             </div>
         </div>
         ${(() => {
-            // Resolve the actual current color: override → pill CSS var → config → fallback
-            let current = colorOverrides[opts.name] || '';
-            if (!current && pillEl) {
-                const computed = getComputedStyle(pillEl).getPropertyValue('--agent-color').trim();
-                if (computed && !computed.startsWith('var(')) current = computed;
-            }
-            if (!current) current = opts.color || '';
-            current = current.toLowerCase();
-            const swatches = ['#ef4444','#da7756','#f97316','#f59e0b','#84cc16','#10a37f','#14b8a6','#06b6d4','#1783ff','#4285f4','#6366f1','#8b5cf6','#ec4899','#ff6b35'];
-            const matchesSwatch = swatches.some(c => current === c.toLowerCase());
-            const colorInputVal = (current && !current.startsWith('var(')) ? current : (opts.color || '#888888');
-            return `<div class="pill-popover-section">
+          // Resolve the actual current color: override → pill CSS var → config → fallback
+          let current = colorOverrides[opts.name] || "";
+          if (!current && pillEl) {
+            const computed = getComputedStyle(pillEl)
+              .getPropertyValue("--agent-color")
+              .trim();
+            if (computed && !computed.startsWith("var(")) current = computed;
+          }
+          if (!current) current = opts.color || "";
+          current = current.toLowerCase();
+          const swatches = [
+            "#ef4444",
+            "#da7756",
+            "#f97316",
+            "#f59e0b",
+            "#84cc16",
+            "#10a37f",
+            "#14b8a6",
+            "#06b6d4",
+            "#1783ff",
+            "#4285f4",
+            "#6366f1",
+            "#8b5cf6",
+            "#ec4899",
+            "#ff6b35",
+          ];
+          const matchesSwatch = swatches.some(
+            (c) => current === c.toLowerCase(),
+          );
+          const colorInputVal =
+            current && !current.startsWith("var(")
+              ? current
+              : opts.color || "#888888";
+          return `<div class="pill-popover-section">
                 <label class="pill-popover-label">Color</label>
                 <div class="pill-popover-colors">
-                    ${swatches.map(c =>
-                        `<button class="color-swatch ${current === c.toLowerCase() ? 'active' : ''}" data-color="${c}" style="background:${c}" title="${c}"></button>`
-                    ).join('')}
+                    ${swatches
+                      .map(
+                        (c) =>
+                          `<button class="color-swatch ${current === c.toLowerCase() ? "active" : ""}" data-color="${c}" style="background:${c}" title="${c}"></button>`,
+                      )
+                      .join("")}
                 </div>
                 <div class="pill-popover-color-custom">
-                    <input type="color" class="pill-popover-color-input ${!matchesSwatch ? 'active' : ''}" value="${colorInputVal}" title="Pick custom color" />
+                    <input type="color" class="pill-popover-color-input ${!matchesSwatch ? "active" : ""}" value="${colorInputVal}" title="Pick custom color" />
                     <button class="pill-popover-color-reset" title="Reset to default">Reset</button>
                 </div>
             </div>`;
         })()}
     `;
 
-    const inputEl = popover.querySelector('.pill-popover-input');
-    const confirmBtn = popover.querySelector('.pill-popover-confirm');
-    const customInput = popover.querySelector('.pill-popover-custom-input');
+  const inputEl = popover.querySelector(".pill-popover-input");
+  const confirmBtn = popover.querySelector(".pill-popover-confirm");
+  const customInput = popover.querySelector(".pill-popover-custom-input");
 
-    const closePopover = () => {
-        popover.remove();
-        document.removeEventListener('click', outsideClickHandler, true);
-        if (opts.mode === 'pending') {
-            _nameModalActive = false;
-            setTimeout(_showNextPendingName, 200);
-        }
-    };
+  const closePopover = () => {
+    popover.remove();
+    document.removeEventListener("click", outsideClickHandler, true);
+    if (opts.mode === "pending") {
+      _nameModalActive = false;
+      setTimeout(_showNextPendingName, 200);
+    }
+  };
 
-    const outsideClickHandler = (e) => {
-        if (!popover.contains(e.target) && !(pillEl && pillEl.contains(e.target))) {
-            closePopover();
-        }
-    };
+  const outsideClickHandler = (e) => {
+    if (!popover.contains(e.target) && !(pillEl && pillEl.contains(e.target))) {
+      closePopover();
+    }
+  };
 
-    confirmBtn.addEventListener('click', () => {
-        const label = inputEl.value.trim();
-        if (!label) return;
-        if (ws && ws.readyState === WebSocket.OPEN) {
-            if (opts.mode === 'pending') {
-                ws.send(JSON.stringify({ type: 'name_pending', name: opts.name, label }));
-            } else {
-                ws.send(JSON.stringify({ type: 'rename_agent', name: opts.name, label }));
-            }
-        }
+  confirmBtn.addEventListener("click", () => {
+    const label = inputEl.value.trim();
+    if (!label) return;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      if (opts.mode === "pending") {
+        ws.send(
+          JSON.stringify({ type: "name_pending", name: opts.name, label }),
+        );
+      } else {
+        ws.send(
+          JSON.stringify({ type: "rename_agent", name: opts.name, label }),
+        );
+      }
+    }
+    closePopover();
+  });
+
+  inputEl.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      confirmBtn.click();
+      e.preventDefault();
+    }
+    if (e.key === "Escape") {
+      closePopover();
+      e.preventDefault();
+    }
+  });
+
+  popover.querySelectorAll(".pill-role-chip").forEach((chip) => {
+    chip.addEventListener("click", () => {
+      const role = chip.dataset.role || "";
+      _setRole(opts.name, role);
+      closePopover();
+    });
+  });
+
+  // Custom chip: trash icon → confirm mode (red chip with tick/cross)
+  popover.querySelectorAll(".pill-custom-chip").forEach((chip) => {
+    const trash = chip.querySelector(".pill-custom-trash");
+    const confirmEl = chip.querySelector(".pill-custom-confirm");
+    const yesBtn = chip.querySelector(".pill-confirm-yes");
+    const noBtn = chip.querySelector(".pill-confirm-no");
+
+    if (trash)
+      trash.addEventListener("click", (e) => {
+        e.stopPropagation();
+        chip.classList.add("confirm-delete");
+      });
+    if (yesBtn)
+      yesBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        _deleteCustomRole(chip.dataset.role);
+        chip.remove();
+      });
+    if (noBtn)
+      noBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        chip.classList.remove("confirm-delete");
+      });
+  });
+
+  customInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      const val = customInput.value.trim();
+      if (val) {
+        _setRole(opts.name, val);
         closePopover();
+      }
+      e.preventDefault();
+    }
+    if (e.key === "Escape") {
+      closePopover();
+      e.preventDefault();
+    }
+  });
+
+  // --- Color picker handlers ---
+  const applyColorOverride = (color) => {
+    colorOverrides[opts.name] = color;
+    localStorage.setItem(
+      "agentchattr-color-overrides",
+      JSON.stringify(colorOverrides),
+    );
+    // Update pill color
+    const pillToUpdate = document.getElementById(`status-${opts.name}`);
+    if (pillToUpdate) pillToUpdate.style.setProperty("--agent-color", color);
+    popover.style.setProperty("--agent-color", color);
+    // Recolor all messages
+    recolorMessages();
+    // Rebuild mention toggles with new colors
+    buildMentionToggles();
+    // Update active swatch + color input highlight
+    const swatchColors = [];
+    popover.querySelectorAll(".color-swatch").forEach((s) => {
+      const match = s.dataset.color.toLowerCase() === color.toLowerCase();
+      s.classList.toggle("active", match);
+      swatchColors.push(s.dataset.color.toLowerCase());
     });
-
-    inputEl.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') { confirmBtn.click(); e.preventDefault(); }
-        if (e.key === 'Escape') { closePopover(); e.preventDefault(); }
-    });
-
-    popover.querySelectorAll('.pill-role-chip').forEach(chip => {
-        chip.addEventListener('click', () => {
-            const role = chip.dataset.role || '';
-            _setRole(opts.name, role);
-            closePopover();
-        });
-    });
-
-    // Custom chip: trash icon → confirm mode (red chip with tick/cross)
-    popover.querySelectorAll('.pill-custom-chip').forEach(chip => {
-        const trash = chip.querySelector('.pill-custom-trash');
-        const confirmEl = chip.querySelector('.pill-custom-confirm');
-        const yesBtn = chip.querySelector('.pill-confirm-yes');
-        const noBtn = chip.querySelector('.pill-confirm-no');
-
-        if (trash) trash.addEventListener('click', (e) => {
-            e.stopPropagation();
-            chip.classList.add('confirm-delete');
-        });
-        if (yesBtn) yesBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            _deleteCustomRole(chip.dataset.role);
-            chip.remove();
-        });
-        if (noBtn) noBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            chip.classList.remove('confirm-delete');
-        });
-    });
-
-    customInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-            const val = customInput.value.trim();
-            if (val) { _setRole(opts.name, val); closePopover(); }
-            e.preventDefault();
-        }
-        if (e.key === 'Escape') { closePopover(); e.preventDefault(); }
-    });
-
-    // --- Color picker handlers ---
-    const applyColorOverride = (color) => {
-        colorOverrides[opts.name] = color;
-        localStorage.setItem('agentchattr-color-overrides', JSON.stringify(colorOverrides));
-        // Update pill color
-        const pillToUpdate = document.getElementById(`status-${opts.name}`);
-        if (pillToUpdate) pillToUpdate.style.setProperty('--agent-color', color);
-        popover.style.setProperty('--agent-color', color);
-        // Recolor all messages
-        recolorMessages();
-        // Rebuild mention toggles with new colors
-        buildMentionToggles();
-        // Update active swatch + color input highlight
-        const swatchColors = [];
-        popover.querySelectorAll('.color-swatch').forEach(s => {
-            const match = s.dataset.color.toLowerCase() === color.toLowerCase();
-            s.classList.toggle('active', match);
-            swatchColors.push(s.dataset.color.toLowerCase());
-        });
-        const colorInput = popover.querySelector('.pill-popover-color-input');
-        if (colorInput) {
-            colorInput.value = color;
-            // Highlight color input if color doesn't match any swatch
-            colorInput.classList.toggle('active', !swatchColors.includes(color.toLowerCase()));
-        }
-    };
-
-    popover.querySelectorAll('.color-swatch').forEach(swatch => {
-        swatch.addEventListener('click', (e) => {
-            e.stopPropagation();
-            applyColorOverride(swatch.dataset.color);
-        });
-    });
-
-    const colorInput = popover.querySelector('.pill-popover-color-input');
+    const colorInput = popover.querySelector(".pill-popover-color-input");
     if (colorInput) {
-        colorInput.addEventListener('input', (e) => {
-            applyColorOverride(e.target.value);
-        });
+      colorInput.value = color;
+      // Highlight color input if color doesn't match any swatch
+      colorInput.classList.toggle(
+        "active",
+        !swatchColors.includes(color.toLowerCase()),
+      );
     }
+  };
 
-    const resetBtn = popover.querySelector('.pill-popover-color-reset');
-    if (resetBtn) {
-        resetBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            delete colorOverrides[opts.name];
-            localStorage.setItem('agentchattr-color-overrides', JSON.stringify(colorOverrides));
-            const defaultColor = opts.color || '#888';
-            const pillToUpdate = document.getElementById(`status-${opts.name}`);
-            if (pillToUpdate) pillToUpdate.style.setProperty('--agent-color', defaultColor);
-            popover.style.setProperty('--agent-color', defaultColor);
-            recolorMessages();
-            buildMentionToggles();
-            popover.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('active'));
-            if (colorInput) colorInput.value = defaultColor;
-        });
-    }
+  popover.querySelectorAll(".color-swatch").forEach((swatch) => {
+    swatch.addEventListener("click", (e) => {
+      e.stopPropagation();
+      applyColorOverride(swatch.dataset.color);
+    });
+  });
 
-    document.body.appendChild(popover);
+  const colorInput = popover.querySelector(".pill-popover-color-input");
+  if (colorInput) {
+    colorInput.addEventListener("input", (e) => {
+      applyColorOverride(e.target.value);
+    });
+  }
 
-    if (pillEl) {
-        const rect = pillEl.getBoundingClientRect();
-        const popoverWidth = 280;
-        let left;
-        // If pill is in the right half of the screen, align popover's right edge to pill's right edge
-        if (rect.right + popoverWidth - rect.width > window.innerWidth - 12) {
-            left = rect.right - popoverWidth;
-        } else {
-            left = rect.left;
-        }
-        // Final clamp to keep on screen
-        left = Math.max(12, Math.min(left, window.innerWidth - popoverWidth - 12));
-        popover.style.top = `${rect.bottom + 8}px`;
-        popover.style.left = `${left}px`;
+  const resetBtn = popover.querySelector(".pill-popover-color-reset");
+  if (resetBtn) {
+    resetBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      delete colorOverrides[opts.name];
+      localStorage.setItem(
+        "agentchattr-color-overrides",
+        JSON.stringify(colorOverrides),
+      );
+      const defaultColor = opts.color || "#888";
+      const pillToUpdate = document.getElementById(`status-${opts.name}`);
+      if (pillToUpdate)
+        pillToUpdate.style.setProperty("--agent-color", defaultColor);
+      popover.style.setProperty("--agent-color", defaultColor);
+      recolorMessages();
+      buildMentionToggles();
+      popover
+        .querySelectorAll(".color-swatch")
+        .forEach((s) => s.classList.remove("active"));
+      if (colorInput) colorInput.value = defaultColor;
+    });
+  }
+
+  document.body.appendChild(popover);
+
+  if (pillEl) {
+    const rect = pillEl.getBoundingClientRect();
+    const popoverWidth = 280;
+    let left;
+    // If pill is in the right half of the screen, align popover's right edge to pill's right edge
+    if (rect.right + popoverWidth - rect.width > window.innerWidth - 12) {
+      left = rect.right - popoverWidth;
     } else {
-        popover.style.top = '50%';
-        popover.style.left = '50%';
-        popover.style.transform = 'translate(-50%, -50%)';
+      left = rect.left;
     }
+    // Final clamp to keep on screen
+    left = Math.max(12, Math.min(left, window.innerWidth - popoverWidth - 12));
+    popover.style.top = `${rect.bottom + 8}px`;
+    popover.style.left = `${left}px`;
+  } else {
+    popover.style.top = "50%";
+    popover.style.left = "50%";
+    popover.style.transform = "translate(-50%, -50%)";
+  }
 
-    setTimeout(() => document.addEventListener('click', outsideClickHandler, true), 0);
-    inputEl.focus();
+  setTimeout(
+    () => document.addEventListener("click", outsideClickHandler, true),
+    0,
+  );
+  inputEl.focus();
 }
 
 // --- Bubble role picker ---
 
 function showBubbleRolePicker(btn, agentName) {
-    // Close any existing picker and reset z-index on its parent message
-    document.querySelectorAll('.bubble-role-picker').forEach(p => {
-        const msg = p.closest('.message');
-        if (msg) msg.style.zIndex = '';
-        p.remove();
+  // Close any existing picker and reset z-index on its parent message
+  document.querySelectorAll(".bubble-role-picker").forEach((p) => {
+    const msg = p.closest(".message");
+    if (msg) msg.style.zIndex = "";
+    p.remove();
+  });
+
+  const currentRole = (_agentRoles[agentName] || "").toLowerCase();
+  const picker = document.createElement("div");
+  picker.className = "bubble-role-picker";
+  const closePicker = () => {
+    if (msgEl) msgEl.style.zIndex = "";
+    picker.remove();
+  };
+
+  // None chip
+  const noneChip = document.createElement("button");
+  noneChip.className = "role-preset-chip" + (!currentRole ? " active" : "");
+  noneChip.textContent = "None";
+  noneChip.addEventListener("click", () => {
+    _setRole(agentName, "");
+    closePicker();
+  });
+  picker.appendChild(noneChip);
+
+  for (const preset of ROLE_PRESETS) {
+    const chip = document.createElement("button");
+    chip.className =
+      "role-preset-chip" +
+      (currentRole === preset.label.toLowerCase() ? " active" : "");
+    chip.textContent = `${preset.emoji} ${preset.label}`;
+    chip.addEventListener("click", () => {
+      _setRole(agentName, preset.label);
+      closePicker();
     });
+    picker.appendChild(chip);
+  }
 
-    const currentRole = (_agentRoles[agentName] || '').toLowerCase();
-    const picker = document.createElement('div');
-    picker.className = 'bubble-role-picker';
-    const closePicker = () => { if (msgEl) msgEl.style.zIndex = ''; picker.remove(); };
+  // Saved custom roles
+  for (const r of window.customRoles || []) {
+    if (
+      !r ||
+      ROLE_PRESETS.some((p) => p.label.toLowerCase() === r.toLowerCase())
+    )
+      continue;
+    const chip = document.createElement("button");
+    chip.className =
+      "role-preset-chip" + (currentRole === r.toLowerCase() ? " active" : "");
+    chip.textContent = r;
+    chip.addEventListener("click", () => {
+      _setRole(agentName, r);
+      closePicker();
+    });
+    picker.appendChild(chip);
+  }
 
-    // None chip
-    const noneChip = document.createElement('button');
-    noneChip.className = 'role-preset-chip' + (!currentRole ? ' active' : '');
-    noneChip.textContent = 'None';
-    noneChip.addEventListener('click', () => { _setRole(agentName, ''); closePicker(); });
-    picker.appendChild(noneChip);
-
-    for (const preset of ROLE_PRESETS) {
-        const chip = document.createElement('button');
-        chip.className = 'role-preset-chip' + (currentRole === preset.label.toLowerCase() ? ' active' : '');
-        chip.textContent = `${preset.emoji} ${preset.label}`;
-        chip.addEventListener('click', () => { _setRole(agentName, preset.label); closePicker(); });
-        picker.appendChild(chip);
+  // Custom text input
+  const customRow = document.createElement("div");
+  customRow.className = "bubble-role-custom";
+  const customInput = document.createElement("input");
+  customInput.type = "text";
+  customInput.className = "bubble-role-input";
+  customInput.placeholder = "Custom...";
+  customInput.maxLength = 20;
+  customInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      const val = customInput.value.trim();
+      if (val) {
+        _setRole(agentName, val);
+        closePicker();
+      }
+      e.preventDefault();
     }
-
-    // Saved custom roles
-    for (const r of (window.customRoles || [])) {
-        if (!r || ROLE_PRESETS.some(p => p.label.toLowerCase() === r.toLowerCase())) continue;
-        const chip = document.createElement('button');
-        chip.className = 'role-preset-chip' + (currentRole === r.toLowerCase() ? ' active' : '');
-        chip.textContent = r;
-        chip.addEventListener('click', () => { _setRole(agentName, r); closePicker(); });
-        picker.appendChild(chip);
+    if (e.key === "Escape") {
+      closePicker();
     }
+  });
+  customRow.appendChild(customInput);
+  picker.appendChild(customRow);
 
-    // Custom text input
-    const customRow = document.createElement('div');
-    customRow.className = 'bubble-role-custom';
-    const customInput = document.createElement('input');
-    customInput.type = 'text';
-    customInput.className = 'bubble-role-input';
-    customInput.placeholder = 'Custom...';
-    customInput.maxLength = 20;
-    customInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-            const val = customInput.value.trim();
-            if (val) { _setRole(agentName, val); closePicker(); }
-            e.preventDefault();
-        }
-        if (e.key === 'Escape') { closePicker(); }
-    });
-    customRow.appendChild(customInput);
-    picker.appendChild(customRow);
+  // Place inside the chat-bubble, positioned below the clicked button
+  const bubble = btn.closest(".chat-bubble");
+  const msgEl = btn.closest(".message");
+  if (msgEl) msgEl.style.zIndex = "50";
+  bubble.appendChild(picker);
 
-    // Place inside the chat-bubble, positioned below the clicked button
-    const bubble = btn.closest('.chat-bubble');
-    const msgEl = btn.closest('.message');
-    if (msgEl) msgEl.style.zIndex = '50';
-    bubble.appendChild(picker);
+  // Position picker below the button that was clicked
+  requestAnimationFrame(() => {
+    const btnRect = btn.getBoundingClientRect();
+    const bubbleRect = bubble.getBoundingClientRect();
+    picker.style.top = btnRect.bottom - bubbleRect.top + 4 + "px";
+    picker.style.left = btnRect.left - bubbleRect.left + "px";
+    picker.style.right = "auto";
 
-    // Position picker below the button that was clicked
-    requestAnimationFrame(() => {
-        const btnRect = btn.getBoundingClientRect();
-        const bubbleRect = bubble.getBoundingClientRect();
-        picker.style.top = (btnRect.bottom - bubbleRect.top + 4) + 'px';
-        picker.style.left = (btnRect.left - bubbleRect.left) + 'px';
-        picker.style.right = 'auto';
+    // Flip upward if picker would overflow below the footer/viewport
+    const pickerRect = picker.getBoundingClientRect();
+    const footerEl = document.querySelector("footer");
+    const maxBottom = footerEl
+      ? footerEl.getBoundingClientRect().top
+      : window.innerHeight - 20;
+    if (pickerRect.bottom > maxBottom) {
+      picker.style.top = "auto";
+      picker.style.bottom = bubbleRect.bottom - btnRect.top + 4 + "px";
+    }
+    // Nudge left if overflowing right edge
+    if (pickerRect.right > window.innerWidth - 10) {
+      picker.style.left = "auto";
+      picker.style.right = "0";
+    }
+  });
 
-        // Flip upward if picker would overflow below the footer/viewport
-        const pickerRect = picker.getBoundingClientRect();
-        const footerEl = document.querySelector('footer');
-        const maxBottom = footerEl ? footerEl.getBoundingClientRect().top : window.innerHeight - 20;
-        if (pickerRect.bottom > maxBottom) {
-            picker.style.top = 'auto';
-            picker.style.bottom = (bubbleRect.bottom - btnRect.top + 4) + 'px';
-        }
-        // Nudge left if overflowing right edge
-        if (pickerRect.right > window.innerWidth - 10) {
-            picker.style.left = 'auto';
-            picker.style.right = '0';
-        }
-    });
-
-    // Close on outside click (next tick to avoid catching the current click)
-    setTimeout(() => {
-        const closeHandler = (e) => {
-            if (!picker.contains(e.target)) {
-                closePicker();
-                document.removeEventListener('click', closeHandler, true);
-            }
-        };
-        document.addEventListener('click', closeHandler, true);
-    }, 0);
+  // Close on outside click (next tick to avoid catching the current click)
+  setTimeout(() => {
+    const closeHandler = (e) => {
+      if (!picker.contains(e.target)) {
+        closePicker();
+        document.removeEventListener("click", closeHandler, true);
+      }
+    };
+    document.addEventListener("click", closeHandler, true);
+  }, 0);
 }
 
 function _syncBubbleRolePills(agentName) {
-    const role = String(_agentRoles[agentName] || '').trim();
-    const pillText = role || 'choose a role';
-    document.querySelectorAll('.message').forEach(msg => {
-        const senderEl = msg.querySelector('.msg-sender');
-        const btn = msg.querySelector('.bubble-role');
-        if (!btn || !senderEl || senderEl.textContent !== agentName) return;
-        btn.textContent = pillText;
-        btn.title = role || 'Set role';
-        btn.classList.toggle('has-role', !!role);
-    });
+  const role = String(_agentRoles[agentName] || "").trim();
+  const pillText = role || "choose a role";
+  document.querySelectorAll(".message").forEach((msg) => {
+    const senderEl = msg.querySelector(".msg-sender");
+    const btn = msg.querySelector(".bubble-role");
+    if (!btn || !senderEl || senderEl.textContent !== agentName) return;
+    btn.textContent = pillText;
+    btn.title = role || "Set role";
+    btn.classList.toggle("has-role", !!role);
+  });
 }
 
 function _setRole(agentName, role) {
-    fetch(`/api/roles/${agentName}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Session-Token': SESSION_TOKEN },
-        body: JSON.stringify({ role }),
-    });
-    // Optimistic update
-    _agentRoles[agentName] = role;
-    _syncBubbleRolePills(agentName);
-    // If custom role (not in presets), auto-save it
-    if (role && !ROLE_PRESETS.some(p => p.label.toLowerCase() === role.toLowerCase())) {
-        _addCustomRole(role);
-    }
+  fetch(`/api/roles/${agentName}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ role }),
+  });
+  // Optimistic update
+  _agentRoles[agentName] = role;
+  _syncBubbleRolePills(agentName);
+  // If custom role (not in presets), auto-save it
+  if (
+    role &&
+    !ROLE_PRESETS.some((p) => p.label.toLowerCase() === role.toLowerCase())
+  ) {
+    _addCustomRole(role);
+  }
 }
 
 function _addCustomRole(role) {
-    const list = window.customRoles || [];
-    const lower = role.trim().toLowerCase();
-    if (list.some(r => r.toLowerCase() === lower)) return;
-    const updated = [...list, role.trim()].slice(-20);
-    window.customRoles = updated;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'update_settings', data: { custom_roles: updated } }));
-    }
+  const list = window.customRoles || [];
+  const lower = role.trim().toLowerCase();
+  if (list.some((r) => r.toLowerCase() === lower)) return;
+  const updated = [...list, role.trim()].slice(-20);
+  window.customRoles = updated;
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(
+      JSON.stringify({
+        type: "update_settings",
+        data: { custom_roles: updated },
+      }),
+    );
+  }
 }
 
 function _deleteCustomRole(role) {
-    const lower = role.trim().toLowerCase();
-    const updated = (window.customRoles || []).filter(r => r.toLowerCase() !== lower);
-    window.customRoles = updated;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'update_settings', data: { custom_roles: updated } }));
+  const lower = role.trim().toLowerCase();
+  const updated = (window.customRoles || []).filter(
+    (r) => r.toLowerCase() !== lower,
+  );
+  window.customRoles = updated;
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(
+      JSON.stringify({
+        type: "update_settings",
+        data: { custom_roles: updated },
+      }),
+    );
+  }
+  // Unassign from any agents currently using this role
+  for (const [agentName, agentRole] of Object.entries(_agentRoles)) {
+    if (agentRole && agentRole.toLowerCase() === lower) {
+      _setRole(agentName, "");
     }
-    // Unassign from any agents currently using this role
-    for (const [agentName, agentRole] of Object.entries(_agentRoles)) {
-        if (agentRole && agentRole.toLowerCase() === lower) {
-            _setRole(agentName, '');
-        }
-    }
+  }
 }
 
 // --- Status ---
 
-const _agentRoles = {};  // name → role string
+const _agentRoles = {}; // name → role string
 
 function fetchRoles() {
-    fetch('/api/roles').then(r => r.json()).then(roles => {
-        Object.assign(_agentRoles, roles);
-        for (const name of Object.keys(roles || {})) {
-            _syncBubbleRolePills(name);
-        }
-    }).catch(() => {});
+  fetch("/api/roles")
+    .then((r) => r.json())
+    .then((roles) => {
+      Object.assign(_agentRoles, roles);
+      for (const name of Object.keys(roles || {})) {
+        _syncBubbleRolePills(name);
+      }
+    })
+    .catch(() => {});
 }
 
 const _ROLE_EMOJI = {
-    'planner': '📋', 'builder': '🔨', 'reviewer': '🔍', 'researcher': '🔬',
-    'chaos gremlin': '😈', 'red team': '🛡️', 'roast': '🔥', 'hype': '🎉',
+  planner: "📋",
+  builder: "🔨",
+  reviewer: "🔍",
+  researcher: "🔬",
+  "chaos gremlin": "😈",
+  "red team": "🛡️",
+  roast: "🔥",
+  hype: "🎉",
 };
 
 function updateStatus(data) {
-    for (const [name, info] of Object.entries(data)) {
-        if (name === 'paused') continue;
-        const pill = document.getElementById(`status-${name}`);
-        if (!pill) continue;
+  for (const [name, info] of Object.entries(data)) {
+    if (name === "paused") continue;
+    const pill = document.getElementById(`status-${name}`);
+    if (!pill) continue;
 
-        pill.classList.remove('available', 'working', 'offline');
-        // Pending pills keep their pending animation (set in buildStatusPills)
-        if (!pill.classList.contains('pending')) {
-            if (info.busy && info.available) {
-                pill.classList.add('working');
-            } else if (info.available) {
-                pill.classList.add('available');
-            } else {
-                pill.classList.add('offline');
-            }
-        }
-
-        // Keep agent color in sync
-        if (info.color) pill.style.setProperty('--agent-color', info.color);
-
-        // Track role (displayed on bubbles, not on pill)
-        if (info.role !== undefined) {
-            _agentRoles[name] = info.role;
-            _syncBubbleRolePills(name);
-        }
+    pill.classList.remove("available", "working", "offline");
+    // Pending pills keep their pending animation (set in buildStatusPills)
+    if (!pill.classList.contains("pending")) {
+      if (info.busy && info.available) {
+        pill.classList.add("working");
+      } else if (info.available) {
+        pill.classList.add("available");
+      } else {
+        pill.classList.add("offline");
+      }
     }
+
+    // Keep agent color in sync
+    if (info.color) pill.style.setProperty("--agent-color", info.color);
+
+    // Track role (displayed on bubbles, not on pill)
+    if (info.role !== undefined) {
+      _agentRoles[name] = info.role;
+      _syncBubbleRolePills(name);
+    }
+  }
 }
 
 function updateTyping(agent, active) {
-    const indicator = document.getElementById('typing-indicator');
-    if (active) {
-        indicator.querySelector('.typing-name').textContent = agent;
-        indicator.classList.remove('hidden');
-        if (autoScroll) scrollToBottom();
-    } else {
-        indicator.classList.add('hidden');
-    }
+  const indicator = document.getElementById("typing-indicator");
+  if (active) {
+    indicator.querySelector(".typing-name").textContent = agent;
+    indicator.classList.remove("hidden");
+    if (autoScroll) scrollToBottom();
+  } else {
+    indicator.classList.add("hidden");
+  }
 }
 
 // --- Settings ---
@@ -1728,869 +2062,1007 @@ function updateTyping(agent, active) {
 let pendingChannelSwitch = null;
 
 function applySettings(data) {
-    if (data.title) {
-        document.getElementById('room-title').textContent = data.title;
-        document.title = data.title;
+  if (data.title) {
+    document.getElementById("room-title").textContent = data.title;
+    document.title = data.title;
+  }
+  if (data.username) {
+    username = data.username;
+    document.getElementById("sender-label").textContent = username;
+    document.getElementById("setting-username").value = username;
+  }
+  if (data.font) {
+    document.body.classList.remove("font-mono", "font-serif", "font-sans");
+    document.body.classList.add("font-" + data.font);
+    document.getElementById("setting-font").value = data.font;
+  }
+  if (data.max_agent_hops !== undefined) {
+    document.getElementById("setting-hops").value = data.max_agent_hops;
+  }
+  if (data.history_limit !== undefined) {
+    document.getElementById("setting-history").value = String(
+      data.history_limit,
+    );
+  }
+  if (data.contrast) {
+    document.body.classList.toggle("high-contrast", data.contrast === "high");
+    document.getElementById("setting-contrast").value = data.contrast;
+  }
+  if (data.rules_refresh_interval !== undefined) {
+    document.getElementById("setting-rules-refresh").value = String(
+      data.rules_refresh_interval,
+    );
+  }
+  if (Array.isArray(data.custom_roles)) {
+    window.customRoles = data.custom_roles;
+  }
+  if (data.channels && Array.isArray(data.channels)) {
+    channelList = data.channels;
+    // If active channel was deleted, switch to general
+    if (!channelList.includes(activeChannel)) {
+      activeChannel = "general";
+      localStorage.setItem("agentchattr-channel", "general");
+      Store.set("activeChannel", "general");
+      filterMessagesByChannel();
     }
-    if (data.username) {
-        username = data.username;
-        document.getElementById('sender-label').textContent = username;
-        document.getElementById('setting-username').value = username;
-    }
-    if (data.font) {
-        document.body.classList.remove('font-mono', 'font-serif', 'font-sans');
-        document.body.classList.add('font-' + data.font);
-        document.getElementById('setting-font').value = data.font;
-    }
-    if (data.max_agent_hops !== undefined) {
-        document.getElementById('setting-hops').value = data.max_agent_hops;
-    }
-    if (data.history_limit !== undefined) {
-        document.getElementById('setting-history').value = String(data.history_limit);
-    }
-    if (data.contrast) {
-        document.body.classList.toggle('high-contrast', data.contrast === 'high');
-        document.getElementById('setting-contrast').value = data.contrast;
-    }
-    if (data.rules_refresh_interval !== undefined) {
-        document.getElementById('setting-rules-refresh').value = String(data.rules_refresh_interval);
-    }
-    if (Array.isArray(data.custom_roles)) {
-        window.customRoles = data.custom_roles;
-    }
-    if (data.channels && Array.isArray(data.channels)) {
-        channelList = data.channels;
-        // If active channel was deleted, switch to general
-        if (!channelList.includes(activeChannel)) {
-            activeChannel = 'general';
-            localStorage.setItem('agentchattr-channel', 'general');
-            Store.set('activeChannel', 'general');
-            filterMessagesByChannel();
-        }
-        renderChannelTabs();
+    renderChannelTabs();
 
-        if (pendingChannelSwitch && channelList.includes(pendingChannelSwitch)) {
-            const name = pendingChannelSwitch;
-            pendingChannelSwitch = null;
-            switchChannel(name);
-        }
+    if (pendingChannelSwitch && channelList.includes(pendingChannelSwitch)) {
+      const name = pendingChannelSwitch;
+      pendingChannelSwitch = null;
+      switchChannel(name);
     }
+  }
 }
 
 function toggleSettings() {
-    const bar = document.getElementById('settings-bar');
-    bar.classList.toggle('hidden');
-    document.getElementById('settings-toggle').classList.toggle('active', !bar.classList.contains('hidden'));
-    if (!bar.classList.contains('hidden')) {
-        document.getElementById('setting-username').focus();
-    }
+  const bar = document.getElementById("settings-bar");
+  bar.classList.toggle("hidden");
+  document
+    .getElementById("settings-toggle")
+    .classList.toggle("active", !bar.classList.contains("hidden"));
+  if (!bar.classList.contains("hidden")) {
+    document.getElementById("setting-username").focus();
+  }
 }
 
 function clearChat() {
-    if (!confirm(`Clear all messages in #${activeChannel}? This cannot be undone.`)) return;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'message', text: '/clear', sender: username, channel: activeChannel }));
-    }
-    document.getElementById('settings-bar').classList.add('hidden');
+  if (
+    !confirm(`Clear all messages in #${activeChannel}? This cannot be undone.`)
+  )
+    return;
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(
+      JSON.stringify({
+        type: "message",
+        text: "/clear",
+        sender: username,
+        channel: activeChannel,
+      }),
+    );
+  }
+  document.getElementById("settings-bar").classList.add("hidden");
 }
 
 function saveSettings() {
-    const newUsername = document.getElementById('setting-username').value.trim();
-    const newFont = document.getElementById('setting-font').value;
-    const newHops = document.getElementById('setting-hops').value;
-    const histVal = document.getElementById('setting-history').value;
-    const newHistory = histVal === 'all' ? 'all' : (parseInt(histVal) || 50);
-    const newContrast = document.getElementById('setting-contrast').value;
-    const newRulesRefresh = document.getElementById('setting-rules-refresh').value;
+  const newUsername = document.getElementById("setting-username").value.trim();
+  const newFont = document.getElementById("setting-font").value;
+  const newHops = document.getElementById("setting-hops").value;
+  const histVal = document.getElementById("setting-history").value;
+  const newHistory = histVal === "all" ? "all" : parseInt(histVal) || 50;
+  const newContrast = document.getElementById("setting-contrast").value;
+  const newRulesRefresh = document.getElementById(
+    "setting-rules-refresh",
+  ).value;
 
-    if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({
-            type: 'update_settings',
-            data: {
-                username: newUsername || 'user',
-                font: newFont,
-                max_agent_hops: parseInt(newHops) || 4,
-                history_limit: newHistory,
-                contrast: newContrast,
-                rules_refresh_interval: parseInt(newRulesRefresh) || 0,
-            }
-        }));
-    }
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(
+      JSON.stringify({
+        type: "update_settings",
+        data: {
+          username: newUsername || "user",
+          font: newFont,
+          max_agent_hops: parseInt(newHops) || 4,
+          history_limit: newHistory,
+          contrast: newContrast,
+          rules_refresh_interval: parseInt(newRulesRefresh) || 0,
+        },
+      }),
+    );
+  }
 }
 
 function setupSettingsKeys() {
-    // Auto-save on blur/Enter for text/number fields
-    for (const id of ['setting-username', 'setting-hops']) {
-        const el = document.getElementById(id);
-        el.addEventListener('blur', () => saveSettings());
-        el.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                el.blur();
-            }
-            if (e.key === 'Escape') {
-                toggleSettings();
-            }
-        });
-    }
+  // Auto-save on blur/Enter for text/number fields
+  for (const id of ["setting-username", "setting-hops"]) {
+    const el = document.getElementById(id);
+    el.addEventListener("blur", () => saveSettings());
+    el.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        el.blur();
+      }
+      if (e.key === "Escape") {
+        toggleSettings();
+      }
+    });
+  }
 
-    // Auto-save on change for selects, escape to close
-    for (const id of ['setting-font', 'setting-history', 'setting-contrast', 'setting-rules-refresh']) {
-        const el = document.getElementById(id);
-        el.addEventListener('change', () => {
-            // Apply contrast immediately (don't wait for server round-trip)
-            if (id === 'setting-contrast') {
-                document.body.classList.toggle('high-contrast', el.value === 'high');
-            }
-            saveSettings();
-        });
-        el.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape') {
-                toggleSettings();
-            }
-        });
-    }
+  // Auto-save on change for selects, escape to close
+  for (const id of [
+    "setting-font",
+    "setting-history",
+    "setting-contrast",
+    "setting-rules-refresh",
+  ]) {
+    const el = document.getElementById(id);
+    el.addEventListener("change", () => {
+      // Apply contrast immediately (don't wait for server round-trip)
+      if (id === "setting-contrast") {
+        document.body.classList.toggle("high-contrast", el.value === "high");
+      }
+      saveSettings();
+    });
+    el.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        toggleSettings();
+      }
+    });
+  }
 }
 
 // --- Toast notifications ---
 
-function showToast(message, type = 'info') {
-    const toast = document.createElement('div');
-    toast.className = `toast toast--${type}`;
-    toast.textContent = message;
-    document.body.appendChild(toast);
-    requestAnimationFrame(() => toast.classList.add('toast--visible'));
-    setTimeout(() => {
-        toast.classList.remove('toast--visible');
-        setTimeout(() => toast.remove(), 300);
-    }, 4000);
+function showToast(message, type = "info") {
+  const toast = document.createElement("div");
+  toast.className = `toast toast--${type}`;
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  requestAnimationFrame(() => toast.classList.add("toast--visible"));
+  setTimeout(() => {
+    toast.classList.remove("toast--visible");
+    setTimeout(() => toast.remove(), 300);
+  }, 4000);
 }
 
 // --- Export / Import ---
 
 async function exportHistory() {
-    try {
-        const resp = await fetch('/api/export', {
-            headers: { 'X-Session-Token': SESSION_TOKEN },
-        });
-        if (!resp.ok) {
-            const err = await resp.json().catch(() => ({}));
-            showToast(err.error || 'Export failed', 'error');
-            return;
-        }
-        const blob = await resp.blob();
-        const disposition = resp.headers.get('Content-Disposition') || '';
-        const match = disposition.match(/filename="(.+?)"/);
-        const filename = match ? match[1] : 'agentchattr-export.zip';
-        const a = document.createElement('a');
-        a.href = URL.createObjectURL(blob);
-        a.download = filename;
-        a.click();
-        URL.revokeObjectURL(a.href);
-        const counts = [];
-        // Parse counts from manifest if possible, or just show success
-        showToast('History exported', 'success');
-    } catch (e) {
-        showToast('Export failed: ' + e.message, 'error');
+  try {
+    const resp = await fetch("/api/export", {});
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      showToast(err.error || "Export failed", "error");
+      return;
     }
+    const blob = await resp.blob();
+    const disposition = resp.headers.get("Content-Disposition") || "";
+    const match = disposition.match(/filename="(.+?)"/);
+    const filename = match ? match[1] : "agentchattr-export.zip";
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(a.href);
+    const counts = [];
+    // Parse counts from manifest if possible, or just show success
+    showToast("History exported", "success");
+  } catch (e) {
+    showToast("Export failed: " + e.message, "error");
+  }
 }
 
 async function importHistory(input) {
-    const file = input.files[0];
-    if (!file) return;
-    input.value = ''; // Reset so same file can be picked again
-    const btn = document.getElementById('import-history-btn');
-    const origText = btn.textContent;
-    btn.textContent = 'Importing...';
-    btn.disabled = true;
-    try {
-        const formData = new FormData();
-        formData.append('file', file);
-        const resp = await fetch('/api/import', {
-            method: 'POST',
-            headers: { 'X-Session-Token': SESSION_TOKEN },
-            body: formData,
-        });
-        const data = await resp.json();
-        if (!resp.ok || !data.ok) {
-            showToast(data.error || 'Import failed', 'error');
-            return;
-        }
-        // Build result message
-        const parts = [];
-        const s = data.sections || {};
-        if (s.messages) parts.push(`${s.messages.created} messages`);
-        if (s.jobs) parts.push(`${s.jobs.created} jobs`);
-        if (s.rules) parts.push(`${s.rules.created} rules`);
-        if (s.summaries) parts.push(`${s.summaries.created + (s.summaries.updated || 0)} summaries`);
-        const dupes = (s.messages?.duplicates || 0) + (s.jobs?.duplicates || 0) + (s.rules?.duplicates || 0);
-        let msg = 'Imported ' + parts.join(', ');
-        if (dupes > 0) msg += ` (${dupes} duplicates skipped)`;
-        if (data.warnings && data.warnings.length > 0) {
-            msg += `. ${data.warnings.length} warning(s)`;
-        }
-        showToast(msg, 'success');
-    } catch (e) {
-        showToast('Import failed: ' + e.message, 'error');
-    } finally {
-        btn.textContent = origText;
-        btn.disabled = false;
+  const file = input.files[0];
+  if (!file) return;
+  input.value = ""; // Reset so same file can be picked again
+  const btn = document.getElementById("import-history-btn");
+  const origText = btn.textContent;
+  btn.textContent = "Importing...";
+  btn.disabled = true;
+  try {
+    const formData = new FormData();
+    formData.append("file", file);
+    const resp = await fetch("/api/import", {
+      method: "POST",
+
+      body: formData,
+    });
+    const data = await resp.json();
+    if (!resp.ok || !data.ok) {
+      showToast(data.error || "Import failed", "error");
+      return;
     }
+    // Build result message
+    const parts = [];
+    const s = data.sections || {};
+    if (s.messages) parts.push(`${s.messages.created} messages`);
+    if (s.jobs) parts.push(`${s.jobs.created} jobs`);
+    if (s.rules) parts.push(`${s.rules.created} rules`);
+    if (s.summaries)
+      parts.push(
+        `${s.summaries.created + (s.summaries.updated || 0)} summaries`,
+      );
+    const dupes =
+      (s.messages?.duplicates || 0) +
+      (s.jobs?.duplicates || 0) +
+      (s.rules?.duplicates || 0);
+    let msg = "Imported " + parts.join(", ");
+    if (dupes > 0) msg += ` (${dupes} duplicates skipped)`;
+    if (data.warnings && data.warnings.length > 0) {
+      msg += `. ${data.warnings.length} warning(s)`;
+    }
+    showToast(msg, "success");
+  } catch (e) {
+    showToast("Import failed: " + e.message, "error");
+  } finally {
+    btn.textContent = origText;
+    btn.disabled = false;
+  }
 }
 
 // --- Keyboard shortcuts ---
 
 function setupKeyboardShortcuts() {
-    document.addEventListener('keydown', (e) => {
-        const modal = document.getElementById('image-modal');
-        const modalOpen = modal && !modal.classList.contains('hidden');
+  document.addEventListener("keydown", (e) => {
+    const modal = document.getElementById("image-modal");
+    const modalOpen = modal && !modal.classList.contains("hidden");
 
-        if (e.key === 'Escape') {
-            const nameModal = document.getElementById('agent-name-modal');
-            if (nameModal && !nameModal.classList.contains('hidden')) { _closeAgentNameModal(); return; }
-            const convertModal = document.getElementById('convert-job-modal');
-            if (convertModal && !convertModal.classList.contains('hidden')) { closeConvertJobModal(); return; }
-            const deleteJobModal = document.getElementById('delete-job-modal');
-            if (deleteJobModal && !deleteJobModal.classList.contains('hidden')) { closeDeleteJobModal(); return; }
-            if (modalOpen) { closeImageModal(); return; }
-            if (replyingTo) { cancelReply(); }
-        }
-        if (modalOpen && e.key === 'ArrowLeft') { e.preventDefault(); modalPrev(e); }
-        if (modalOpen && e.key === 'ArrowRight') { e.preventDefault(); modalNext(e); }
-
-    });
+    if (e.key === "Escape") {
+      const nameModal = document.getElementById("agent-name-modal");
+      if (nameModal && !nameModal.classList.contains("hidden")) {
+        _closeAgentNameModal();
+        return;
+      }
+      const convertModal = document.getElementById("convert-job-modal");
+      if (convertModal && !convertModal.classList.contains("hidden")) {
+        closeConvertJobModal();
+        return;
+      }
+      const deleteJobModal = document.getElementById("delete-job-modal");
+      if (deleteJobModal && !deleteJobModal.classList.contains("hidden")) {
+        closeDeleteJobModal();
+        return;
+      }
+      if (modalOpen) {
+        closeImageModal();
+        return;
+      }
+      if (replyingTo) {
+        cancelReply();
+      }
+    }
+    if (modalOpen && e.key === "ArrowLeft") {
+      e.preventDefault();
+      modalPrev(e);
+    }
+    if (modalOpen && e.key === "ArrowRight") {
+      e.preventDefault();
+      modalNext(e);
+    }
+  });
 }
 
 // --- Slash command menu ---
 
 function showSlashHint(text) {
-    const input = document.getElementById('input');
-    if (!input) return;
-    const original = input.placeholder;
-    input.placeholder = text;
-    input.classList.add('slash-hint-active');
-    setTimeout(() => {
-        input.placeholder = original;
-        input.classList.remove('slash-hint-active');
-    }, 3000);
+  const input = document.getElementById("input");
+  if (!input) return;
+  const original = input.placeholder;
+  input.placeholder = text;
+  input.classList.add("slash-hint-active");
+  setTimeout(() => {
+    input.placeholder = original;
+    input.classList.remove("slash-hint-active");
+  }, 3000);
 }
 
 const SLASH_COMMANDS = [
-    { cmd: '/artchallenge', desc: 'SVG art challenge — all agents create artwork (optional theme)', broadcast: true },
-    { cmd: '/hatmaking', desc: 'All agents design a hat to wear on their avatar', broadcast: true },
-    { cmd: '/roastreview', desc: 'Get all agents to review and roast each other\'s work', broadcast: true },
-    { cmd: '/poetry haiku', desc: 'Agents write a haiku about the codebase', broadcast: true },
-    { cmd: '/poetry limerick', desc: 'Agents write a limerick about the codebase', broadcast: true },
-    { cmd: '/poetry sonnet', desc: 'Agents write a sonnet about the codebase', broadcast: true },
-    { cmd: '/summary', desc: 'Summarize recent messages — tag an agent (e.g. /summary @claude)', broadcast: false, needsMention: true },
-    { cmd: '/summarise', desc: 'Summarize recent messages — tag an agent (e.g. /summarise @claude)', broadcast: false, needsMention: true, hidden: true },
-    { cmd: '/continue', desc: 'Resume after loop guard pauses', broadcast: false },
-    { cmd: '/clear', desc: 'Clear messages in current channel', broadcast: false },
+  {
+    cmd: "/artchallenge",
+    desc: "SVG art challenge — all agents create artwork (optional theme)",
+    broadcast: true,
+  },
+  {
+    cmd: "/hatmaking",
+    desc: "All agents design a hat to wear on their avatar",
+    broadcast: true,
+  },
+  {
+    cmd: "/roastreview",
+    desc: "Get all agents to review and roast each other's work",
+    broadcast: true,
+  },
+  {
+    cmd: "/poetry haiku",
+    desc: "Agents write a haiku about the codebase",
+    broadcast: true,
+  },
+  {
+    cmd: "/poetry limerick",
+    desc: "Agents write a limerick about the codebase",
+    broadcast: true,
+  },
+  {
+    cmd: "/poetry sonnet",
+    desc: "Agents write a sonnet about the codebase",
+    broadcast: true,
+  },
+  {
+    cmd: "/summary",
+    desc: "Summarize recent messages — tag an agent (e.g. /summary @claude)",
+    broadcast: false,
+    needsMention: true,
+  },
+  {
+    cmd: "/summarise",
+    desc: "Summarize recent messages — tag an agent (e.g. /summarise @claude)",
+    broadcast: false,
+    needsMention: true,
+    hidden: true,
+  },
+  {
+    cmd: "/continue",
+    desc: "Resume after loop guard pauses",
+    broadcast: false,
+  },
+  {
+    cmd: "/clear",
+    desc: "Clear messages in current channel",
+    broadcast: false,
+  },
 ];
 
 let slashMenuIndex = 0;
 let slashMenuVisible = false;
 let mentionMenuIndex = 0;
 let mentionMenuVisible = false;
-let mentionMenuStart = -1;  // cursor position of the '@'
+let mentionMenuStart = -1; // cursor position of the '@'
 
 function updateSlashMenu(text) {
-    const menu = document.getElementById('slash-menu');
-    if (!text.startsWith('/') || text.includes(' ') && !text.startsWith('/poetry')) {
-        menu.classList.add('hidden');
-        slashMenuVisible = false;
-        return;
-    }
+  const menu = document.getElementById("slash-menu");
+  if (
+    !text.startsWith("/") ||
+    (text.includes(" ") && !text.startsWith("/poetry"))
+  ) {
+    menu.classList.add("hidden");
+    slashMenuVisible = false;
+    return;
+  }
 
-    const query = text.toLowerCase();
-    const matches = SLASH_COMMANDS.filter(c => !c.hidden && c.cmd.startsWith(query));
+  const query = text.toLowerCase();
+  const matches = SLASH_COMMANDS.filter(
+    (c) => !c.hidden && c.cmd.startsWith(query),
+  );
 
-    if (matches.length === 0 || (matches.length === 1 && matches[0].cmd === query)) {
-        menu.classList.add('hidden');
-        slashMenuVisible = false;
-        return;
-    }
+  if (
+    matches.length === 0 ||
+    (matches.length === 1 && matches[0].cmd === query)
+  ) {
+    menu.classList.add("hidden");
+    slashMenuVisible = false;
+    return;
+  }
 
-    menu.innerHTML = '';
-    slashMenuIndex = Math.min(slashMenuIndex, matches.length - 1);
+  menu.innerHTML = "";
+  slashMenuIndex = Math.min(slashMenuIndex, matches.length - 1);
 
-    matches.forEach((item, i) => {
-        const row = document.createElement('div');
-        row.className = 'slash-item' + (i === slashMenuIndex ? ' active' : '');
-        row.innerHTML = `<span class="slash-cmd">${escapeHtml(item.cmd)}</span><span class="slash-desc">${escapeHtml(item.desc)}</span>`;
-        row.addEventListener('mousedown', (e) => {
-            e.preventDefault();
-            selectSlashCommand(item.cmd);
-        });
-        row.addEventListener('mouseenter', () => {
-            slashMenuIndex = i;
-            menu.querySelectorAll('.slash-item').forEach((el, j) => el.classList.toggle('active', j === i));
-        });
-        menu.appendChild(row);
+  matches.forEach((item, i) => {
+    const row = document.createElement("div");
+    row.className = "slash-item" + (i === slashMenuIndex ? " active" : "");
+    row.innerHTML = `<span class="slash-cmd">${escapeHtml(item.cmd)}</span><span class="slash-desc">${escapeHtml(item.desc)}</span>`;
+    row.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      selectSlashCommand(item.cmd);
     });
+    row.addEventListener("mouseenter", () => {
+      slashMenuIndex = i;
+      menu
+        .querySelectorAll(".slash-item")
+        .forEach((el, j) => el.classList.toggle("active", j === i));
+    });
+    menu.appendChild(row);
+  });
 
-    menu.classList.remove('hidden');
-    slashMenuVisible = true;
+  menu.classList.remove("hidden");
+  slashMenuVisible = true;
 }
 
 function selectSlashCommand(cmd) {
-    const input = document.getElementById('input');
-    input.value = cmd;
-    input.focus();
-    document.getElementById('slash-menu').classList.add('hidden');
-    slashMenuVisible = false;
+  const input = document.getElementById("input");
+  input.value = cmd;
+  input.focus();
+  document.getElementById("slash-menu").classList.add("hidden");
+  slashMenuVisible = false;
 }
 
 // --- Mention autocomplete ---
 
 function getMentionCandidates() {
-    // Build list: registered agents + "all agents" + username (self) + known humans
-    const candidates = [];
-    for (const [name, cfg] of Object.entries(agentConfig)) {
-        if (cfg.state === 'pending') continue;
-        candidates.push({ name, label: cfg.label || name, color: cfg.color });
-    }
-    candidates.push({ name: 'all agents', label: 'all agents', color: 'var(--accent)' });
-    return candidates;
+  // Build list: registered agents + "all agents" + username (self) + known humans
+  const candidates = [];
+  for (const [name, cfg] of Object.entries(agentConfig)) {
+    if (cfg.state === "pending") continue;
+    candidates.push({ name, label: cfg.label || name, color: cfg.color });
+  }
+  candidates.push({
+    name: "all agents",
+    label: "all agents",
+    color: "var(--accent)",
+  });
+  return candidates;
 }
 
 function updateMentionMenu() {
-    const menu = document.getElementById('mention-menu');
-    const input = document.getElementById('input');
-    const text = input.value;
-    const cursor = input.selectionStart;
+  const menu = document.getElementById("mention-menu");
+  const input = document.getElementById("input");
+  const text = input.value;
+  const cursor = input.selectionStart;
 
-    // Don't show if slash menu is active
-    if (slashMenuVisible) {
-        menu.classList.add('hidden');
-        mentionMenuVisible = false;
-        return;
+  // Don't show if slash menu is active
+  if (slashMenuVisible) {
+    menu.classList.add("hidden");
+    mentionMenuVisible = false;
+    return;
+  }
+
+  // Find the '@' before cursor that starts this mention
+  let atPos = -1;
+  for (let i = cursor - 1; i >= 0; i--) {
+    if (text[i] === "@") {
+      atPos = i;
+      break;
     }
+    // Allow spaces if we are still matching a multi-word label like "all agents"
+    if (!/[\w\-\s]/.test(text[i])) break;
+    // Optimization: don't look back more than 30 chars
+    if (cursor - i > 30) break;
+  }
 
-    // Find the '@' before cursor that starts this mention
-    let atPos = -1;
-    for (let i = cursor - 1; i >= 0; i--) {
-        if (text[i] === '@') { atPos = i; break; }
-        // Allow spaces if we are still matching a multi-word label like "all agents"
-        if (!/[\w\-\s]/.test(text[i])) break;
-        // Optimization: don't look back more than 30 chars
-        if (cursor - i > 30) break;
-    }
+  if (atPos < 0 || (atPos > 0 && /\w/.test(text[atPos - 1]))) {
+    // No @ found, or @ is mid-word (e.g. email)
+    menu.classList.add("hidden");
+    mentionMenuVisible = false;
+    return;
+  }
 
-    if (atPos < 0 || (atPos > 0 && /\w/.test(text[atPos - 1]))) {
-        // No @ found, or @ is mid-word (e.g. email)
-        menu.classList.add('hidden');
-        mentionMenuVisible = false;
-        return;
-    }
+  const query = text.slice(atPos + 1, cursor).toLowerCase();
+  mentionMenuStart = atPos;
 
-    const query = text.slice(atPos + 1, cursor).toLowerCase();
-    mentionMenuStart = atPos;
+  const candidates = getMentionCandidates();
+  const matches = candidates.filter(
+    (c) =>
+      c.name.toLowerCase().includes(query) ||
+      c.label.toLowerCase().includes(query),
+  );
 
-    const candidates = getMentionCandidates();
-    const matches = candidates.filter(c =>
-        c.name.toLowerCase().includes(query) || c.label.toLowerCase().includes(query)
-    );
+  if (matches.length === 0) {
+    menu.classList.add("hidden");
+    mentionMenuVisible = false;
+    return;
+  }
 
-    if (matches.length === 0) {
-        menu.classList.add('hidden');
-        mentionMenuVisible = false;
-        return;
-    }
+  menu.innerHTML = "";
+  mentionMenuIndex = Math.min(mentionMenuIndex, matches.length - 1);
 
-    menu.innerHTML = '';
-    mentionMenuIndex = Math.min(mentionMenuIndex, matches.length - 1);
-
-    matches.forEach((item, i) => {
-        const row = document.createElement('div');
-        row.className = 'mention-item' + (i === mentionMenuIndex ? ' active' : '');
-        row.dataset.name = item.name;
-        row.innerHTML = `<span class="mention-dot" style="background: ${item.color}"></span><span class="mention-name">${escapeHtml(item.label)}</span>`;
-        row.addEventListener('mousedown', (e) => {
-            e.preventDefault();
-            selectMention(item.name);
-        });
-        row.addEventListener('mouseenter', () => {
-            mentionMenuIndex = i;
-            menu.querySelectorAll('.mention-item').forEach((el, j) => el.classList.toggle('active', j === i));
-        });
-        menu.appendChild(row);
+  matches.forEach((item, i) => {
+    const row = document.createElement("div");
+    row.className = "mention-item" + (i === mentionMenuIndex ? " active" : "");
+    row.dataset.name = item.name;
+    row.innerHTML = `<span class="mention-dot" style="background: ${item.color}"></span><span class="mention-name">${escapeHtml(item.label)}</span>`;
+    row.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      selectMention(item.name);
     });
+    row.addEventListener("mouseenter", () => {
+      mentionMenuIndex = i;
+      menu
+        .querySelectorAll(".mention-item")
+        .forEach((el, j) => el.classList.toggle("active", j === i));
+    });
+    menu.appendChild(row);
+  });
 
-    menu.classList.remove('hidden');
-    mentionMenuVisible = true;
+  menu.classList.remove("hidden");
+  mentionMenuVisible = true;
 }
 
-let _lastMentionedAgent = ''; // track most recent mention for auto-assignment
+let _lastMentionedAgent = ""; // track most recent mention for auto-assignment
 
 function selectMention(name) {
-    const input = document.getElementById('input');
-    _lastMentionedAgent = name; // remember for auto-assigning jobs
-    const text = input.value;
-    const cursor = input.selectionStart;
-    // Replace from @ to cursor with @name + space
-    const before = text.slice(0, mentionMenuStart);
-    const after = text.slice(cursor);
-    const mention = `@${name} `;
-    input.value = before + mention + after;
-    const newPos = mentionMenuStart + mention.length;
-    input.setSelectionRange(newPos, newPos);
-    input.focus();
-    document.getElementById('mention-menu').classList.add('hidden');
-    mentionMenuVisible = false;
+  const input = document.getElementById("input");
+  _lastMentionedAgent = name; // remember for auto-assigning jobs
+  const text = input.value;
+  const cursor = input.selectionStart;
+  // Replace from @ to cursor with @name + space
+  const before = text.slice(0, mentionMenuStart);
+  const after = text.slice(cursor);
+  const mention = `@${name} `;
+  input.value = before + mention + after;
+  const newPos = mentionMenuStart + mention.length;
+  input.setSelectionRange(newPos, newPos);
+  input.focus();
+  document.getElementById("mention-menu").classList.add("hidden");
+  mentionMenuVisible = false;
 }
 
 // --- Input ---
 
 function setupInput() {
-    const input = document.getElementById('input');
+  const input = document.getElementById("input");
 
-    input.addEventListener('keydown', (e) => {
-        if (mentionMenuVisible) {
-            const menu = document.getElementById('mention-menu');
-            const items = menu.querySelectorAll('.mention-item');
-            if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                mentionMenuIndex = (mentionMenuIndex - 1 + items.length) % items.length;
-                items.forEach((el, i) => el.classList.toggle('active', i === mentionMenuIndex));
-                return;
-            }
-            if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                mentionMenuIndex = (mentionMenuIndex + 1) % items.length;
-                items.forEach((el, i) => el.classList.toggle('active', i === mentionMenuIndex));
-                return;
-            }
-            if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
-                e.preventDefault();
-                const active = items[mentionMenuIndex];
-                if (active) {
-                    selectMention(active.dataset.name);
-                }
-                return;
-            }
-            if (e.key === 'Escape') {
-                menu.classList.add('hidden');
-                mentionMenuVisible = false;
-                return;
-            }
+  input.addEventListener("keydown", (e) => {
+    if (mentionMenuVisible) {
+      const menu = document.getElementById("mention-menu");
+      const items = menu.querySelectorAll(".mention-item");
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        mentionMenuIndex = (mentionMenuIndex - 1 + items.length) % items.length;
+        items.forEach((el, i) =>
+          el.classList.toggle("active", i === mentionMenuIndex),
+        );
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        mentionMenuIndex = (mentionMenuIndex + 1) % items.length;
+        items.forEach((el, i) =>
+          el.classList.toggle("active", i === mentionMenuIndex),
+        );
+        return;
+      }
+      if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) {
+        e.preventDefault();
+        const active = items[mentionMenuIndex];
+        if (active) {
+          selectMention(active.dataset.name);
         }
-        if (slashMenuVisible) {
-            const menu = document.getElementById('slash-menu');
-            const items = menu.querySelectorAll('.slash-item');
-            if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                slashMenuIndex = (slashMenuIndex - 1 + items.length) % items.length;
-                items.forEach((el, i) => el.classList.toggle('active', i === slashMenuIndex));
-                return;
-            }
-            if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                slashMenuIndex = (slashMenuIndex + 1) % items.length;
-                items.forEach((el, i) => el.classList.toggle('active', i === slashMenuIndex));
-                return;
-            }
-            if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
-                e.preventDefault();
-                const active = items[slashMenuIndex];
-                if (active) selectSlashCommand(active.querySelector('.slash-cmd').textContent);
-                if (e.key === 'Enter') sendMessage();
-                return;
-            }
-            if (e.key === 'Escape') {
-                menu.classList.add('hidden');
-                slashMenuVisible = false;
-                return;
-            }
-        }
-        if (e.key === 'Enter' && !e.shiftKey) {
-            e.preventDefault();
-            sendMessage();
-        }
-    });
-
-    // Auto-resize + slash menu + mention menu + send button state
-    function onInputChange() {
-        input.style.height = 'auto';
-        input.style.height = Math.min(input.scrollHeight, 120) + 'px';
-        updateSlashMenu(input.value);
-        updateMentionMenu();
-        updateSendButton();
+        return;
+      }
+      if (e.key === "Escape") {
+        menu.classList.add("hidden");
+        mentionMenuVisible = false;
+        return;
+      }
     }
-    input.addEventListener('input', onInputChange);
-    // Voice typing doesn't always fire 'input' — catch with additional events
-    input.addEventListener('compositionend', onInputChange);
-    input.addEventListener('change', onInputChange);
-    // Fallback poll for speech-to-text that bypasses all events
-    let _lastInputVal = '';
-    setInterval(() => {
-        if (input.value !== _lastInputVal) {
-            _lastInputVal = input.value;
-            updateSendButton();
-        }
-    }, 300);
+    if (slashMenuVisible) {
+      const menu = document.getElementById("slash-menu");
+      const items = menu.querySelectorAll(".slash-item");
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        slashMenuIndex = (slashMenuIndex - 1 + items.length) % items.length;
+        items.forEach((el, i) =>
+          el.classList.toggle("active", i === slashMenuIndex),
+        );
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        slashMenuIndex = (slashMenuIndex + 1) % items.length;
+        items.forEach((el, i) =>
+          el.classList.toggle("active", i === slashMenuIndex),
+        );
+        return;
+      }
+      if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) {
+        e.preventDefault();
+        const active = items[slashMenuIndex];
+        if (active)
+          selectSlashCommand(active.querySelector(".slash-cmd").textContent);
+        if (e.key === "Enter") sendMessage();
+        return;
+      }
+      if (e.key === "Escape") {
+        menu.classList.add("hidden");
+        slashMenuVisible = false;
+        return;
+      }
+    }
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+
+  // Auto-resize + slash menu + mention menu + send button state
+  function onInputChange() {
+    input.style.height = "auto";
+    input.style.height = Math.min(input.scrollHeight, 120) + "px";
+    updateSlashMenu(input.value);
+    updateMentionMenu();
     updateSendButton();
+  }
+  input.addEventListener("input", onInputChange);
+  // Voice typing doesn't always fire 'input' — catch with additional events
+  input.addEventListener("compositionend", onInputChange);
+  input.addEventListener("change", onInputChange);
+  // Fallback poll for speech-to-text that bypasses all events
+  let _lastInputVal = "";
+  setInterval(() => {
+    if (input.value !== _lastInputVal) {
+      _lastInputVal = input.value;
+      updateSendButton();
+    }
+  }, 300);
+  updateSendButton();
 }
 
 function updateSendButton() {
-    const input = document.getElementById('input');
-    const group = document.querySelector('.send-group');
-    if (!input || !group) return;
-    const hasContent = input.value.trim().length > 0 || pendingAttachments.length > 0;
-    group.classList.toggle('inactive', !hasContent);
+  const input = document.getElementById("input");
+  const group = document.querySelector(".send-group");
+  if (!input || !group) return;
+  const hasContent =
+    input.value.trim().length > 0 || pendingAttachments.length > 0;
+  group.classList.toggle("inactive", !hasContent);
 }
 
 function sendMessage() {
-    const input = document.getElementById('input');
-    let text = input.value.trim();
+  const input = document.getElementById("input");
+  let text = input.value.trim();
 
-    if (!text && pendingAttachments.length === 0) return;
+  if (!text && pendingAttachments.length === 0) return;
 
-    // Prepend active mention toggles if the message doesn't already mention them
-    // Skip for non-broadcast slash commands (e.g. /clear, /continue)
-    let skipMentions = false;
-    if (text.startsWith('/')) {
-        const cmdWord = text.split(/\s/)[0].toLowerCase();
-        const matchedCmd = SLASH_COMMANDS.find(c => c.cmd.startsWith(cmdWord) || cmdWord.startsWith(c.cmd.split(/\s/)[0]));
-        if (matchedCmd && !matchedCmd.broadcast) {
-            skipMentions = true;
-        }
-        // Commands that need an @mention — show hint and keep command in input
-        if (matchedCmd && matchedCmd.needsMention && !/@\w/.test(text)) {
-            const canonical = matchedCmd.cmd.split(/\s/)[0];  // e.g. '/summary'
-            input.value = canonical + ' @';
-            input.focus();
-            input.setSelectionRange(input.value.length, input.value.length);
-            showSlashHint(`Tag an agent: ${canonical} @claude`);
-            // Trigger mention autocomplete for the '@'
-            input.dispatchEvent(new Event('input', { bubbles: true }));
-            return;
-        }
+  // Prepend active mention toggles if the message doesn't already mention them
+  // Skip for non-broadcast slash commands (e.g. /clear, /continue)
+  let skipMentions = false;
+  if (text.startsWith("/")) {
+    const cmdWord = text.split(/\s/)[0].toLowerCase();
+    const matchedCmd = SLASH_COMMANDS.find(
+      (c) =>
+        c.cmd.startsWith(cmdWord) || cmdWord.startsWith(c.cmd.split(/\s/)[0]),
+    );
+    if (matchedCmd && !matchedCmd.broadcast) {
+      skipMentions = true;
     }
-    if (activeMentions.size > 0 && text && !skipMentions) {
-        const prefix = [...activeMentions].map(n => `@${n}`).join(' ');
-        // Only prepend if user didn't already @mention these agents
-        const lower = text.toLowerCase();
-        const missing = [...activeMentions].filter(n => !lower.includes(`@${n}`));
-        if (missing.length > 0) {
-            text = missing.map(n => `@${n}`).join(' ') + ' ' + text;
-        }
+    // Commands that need an @mention — show hint and keep command in input
+    if (matchedCmd && matchedCmd.needsMention && !/@\w/.test(text)) {
+      const canonical = matchedCmd.cmd.split(/\s/)[0]; // e.g. '/summary'
+      input.value = canonical + " @";
+      input.focus();
+      input.setSelectionRange(input.value.length, input.value.length);
+      showSlashHint(`Tag an agent: ${canonical} @claude`);
+      // Trigger mention autocomplete for the '@'
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      return;
     }
-
-    const payload = {
-        type: 'message',
-        text: text,
-        sender: username,
-        channel: activeChannel,
-        attachments: pendingAttachments.map(a => ({
-            path: a.path,
-            name: a.name,
-            url: a.url,
-        })),
-    };
-    if (replyingTo) {
-        payload.reply_to = replyingTo.id;
+  }
+  if (activeMentions.size > 0 && text && !skipMentions) {
+    const prefix = [...activeMentions].map((n) => `@${n}`).join(" ");
+    // Only prepend if user didn't already @mention these agents
+    const lower = text.toLowerCase();
+    const missing = [...activeMentions].filter((n) => !lower.includes(`@${n}`));
+    if (missing.length > 0) {
+      text = missing.map((n) => `@${n}`).join(" ") + " " + text;
     }
+  }
 
-    if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify(payload));
-    }
+  const payload = {
+    type: "message",
+    text: text,
+    sender: username,
+    channel: activeChannel,
+    attachments: pendingAttachments.map((a) => ({
+      path: a.path,
+      name: a.name,
+      url: a.url,
+    })),
+  };
+  if (replyingTo) {
+    payload.reply_to = replyingTo.id;
+  }
 
-    input.value = '';
-    input.style.height = 'auto';
-    clearAttachments();
-    cancelReply();
-    updateSendButton();
-    input.focus();
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(payload));
+  }
+
+  input.value = "";
+  input.style.height = "auto";
+  clearAttachments();
+  cancelReply();
+  updateSendButton();
+  input.focus();
 }
 
 // --- Image paste/drop ---
 
 function setupPaste() {
-    document.addEventListener('paste', async (e) => {
-        const items = e.clipboardData?.items;
-        if (!items) return;
+  document.addEventListener("paste", async (e) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
 
-        // Route to job upload if job input is focused
-        const jobInput = document.getElementById('jobs-conv-input-text');
-        const isJobFocused = jobInput && document.activeElement === jobInput;
+    // Route to job upload if job input is focused
+    const jobInput = document.getElementById("jobs-conv-input-text");
+    const isJobFocused = jobInput && document.activeElement === jobInput;
 
-        for (const item of items) {
-            if (item.type.startsWith('image/')) {
-                e.preventDefault();
-                const file = item.getAsFile();
-                if (isJobFocused) {
-                    await uploadJobImage(file);
-                } else {
-                    await uploadImage(file);
-                }
-            }
+    for (const item of items) {
+      if (item.type.startsWith("image/")) {
+        e.preventDefault();
+        const file = item.getAsFile();
+        if (isJobFocused) {
+          await uploadJobImage(file);
+        } else {
+          await uploadImage(file);
         }
-    });
+      }
+    }
+  });
 }
 
 function setupDragDrop() {
-    const dropzone = document.getElementById('dropzone');
-    let dragCount = 0;
+  const dropzone = document.getElementById("dropzone");
+  let dragCount = 0;
 
-    document.addEventListener('dragenter', (e) => {
-        e.preventDefault();
-        dragCount++;
-        if (e.dataTransfer?.types?.includes('Files')) {
-            dropzone.classList.remove('hidden');
-        }
-    });
+  document.addEventListener("dragenter", (e) => {
+    e.preventDefault();
+    dragCount++;
+    if (e.dataTransfer?.types?.includes("Files")) {
+      dropzone.classList.remove("hidden");
+    }
+  });
 
-    document.addEventListener('dragleave', (e) => {
-        e.preventDefault();
-        dragCount--;
-        if (dragCount <= 0) {
-            dragCount = 0;
-            dropzone.classList.add('hidden');
-        }
-    });
+  document.addEventListener("dragleave", (e) => {
+    e.preventDefault();
+    dragCount--;
+    if (dragCount <= 0) {
+      dragCount = 0;
+      dropzone.classList.add("hidden");
+    }
+  });
 
-    document.addEventListener('dragover', (e) => {
-        e.preventDefault();
-    });
+  document.addEventListener("dragover", (e) => {
+    e.preventDefault();
+  });
 
-    document.addEventListener('drop', async (e) => {
-        e.preventDefault();
-        dragCount = 0;
-        dropzone.classList.add('hidden');
+  document.addEventListener("drop", async (e) => {
+    e.preventDefault();
+    dragCount = 0;
+    dropzone.classList.add("hidden");
 
-        const files = e.dataTransfer?.files;
-        if (!files) return;
+    const files = e.dataTransfer?.files;
+    if (!files) return;
 
-        for (const file of files) {
-            if (file.type.startsWith('image/')) {
-                await uploadImage(file);
-            }
-        }
-    });
+    for (const file of files) {
+      if (file.type.startsWith("image/")) {
+        await uploadImage(file);
+      }
+    }
+  });
 }
 
 async function uploadImage(file) {
-    const form = new FormData();
-    form.append('file', file);
+  const form = new FormData();
+  form.append("file", file);
 
-    try {
-        const resp = await fetch('/api/upload', { method: 'POST', headers: { 'X-Session-Token': SESSION_TOKEN }, body: form });
-        const data = await resp.json();
+  try {
+    const resp = await fetch("/api/upload", {
+      method: "POST",
 
-        pendingAttachments.push({
-            path: data.path,
-            name: data.name,
-            url: data.url,
-        });
+      body: form,
+    });
+    const data = await resp.json();
 
-        renderAttachments();
-    } catch (err) {
-        console.error('Upload failed:', err);
-    }
+    pendingAttachments.push({
+      path: data.path,
+      name: data.name,
+      url: data.url,
+    });
+
+    renderAttachments();
+  } catch (err) {
+    console.error("Upload failed:", err);
+  }
 }
 
 function renderAttachments() {
-    const container = document.getElementById('attachments');
-    container.innerHTML = '';
+  const container = document.getElementById("attachments");
+  container.innerHTML = "";
 
-    pendingAttachments.forEach((att, i) => {
-        const wrap = document.createElement('div');
-        wrap.className = 'attachment-preview';
-        wrap.innerHTML = `
+  pendingAttachments.forEach((att, i) => {
+    const wrap = document.createElement("div");
+    wrap.className = "attachment-preview";
+    wrap.innerHTML = `
             <img src="${att.url}" alt="${escapeHtml(att.name)}" onclick="openImageModal('${escapeHtml(att.url)}')" title="Click to preview">
             <button class="remove-btn" onclick="removeAttachment(${i})">x</button>
         `;
-        container.appendChild(wrap);
-    });
-    repositionScrollAnchor();
+    container.appendChild(wrap);
+  });
+  repositionScrollAnchor();
 }
 
 function removeAttachment(index) {
-    pendingAttachments.splice(index, 1);
-    renderAttachments();
+  pendingAttachments.splice(index, 1);
+  renderAttachments();
 }
 
 function clearAttachments() {
-    pendingAttachments = [];
-    document.getElementById('attachments').innerHTML = '';
-    repositionScrollAnchor();
+  pendingAttachments = [];
+  document.getElementById("attachments").innerHTML = "";
+  repositionScrollAnchor();
 }
 
 // --- Scroll tracking ---
 
 function setupScroll() {
-    const timeline = document.getElementById('timeline');
-    const messages = document.getElementById('messages');
+  const timeline = document.getElementById("timeline");
+  const messages = document.getElementById("messages");
 
-    timeline.addEventListener('scroll', () => {
-        const distFromBottom = timeline.scrollHeight - timeline.scrollTop - timeline.clientHeight;
-        autoScroll = distFromBottom < 60;
+  timeline.addEventListener("scroll", () => {
+    const distFromBottom =
+      timeline.scrollHeight - timeline.scrollTop - timeline.clientHeight;
+    autoScroll = distFromBottom < 60;
 
-        if (autoScroll) {
-            unreadCount = 0;
-        }
-        updateScrollAnchor();
-    });
-
-    // Keep pinned to bottom when content changes (e.g. images load)
-    const resizeObserver = new ResizeObserver(() => {
-        if (autoScroll) {
-            scrollToBottom();
-        }
-    });
-    resizeObserver.observe(messages);
-
-    // Reposition scroll-anchor when window resizes or sidebars toggle
-    window.addEventListener('resize', repositionScrollAnchor);
-    const contentArea = document.querySelector('.content-area');
-    if (contentArea) {
-        new ResizeObserver(repositionScrollAnchor).observe(contentArea);
+    if (autoScroll) {
+      unreadCount = 0;
     }
+    updateScrollAnchor();
+  });
 
-    // Support button label collapses via CSS overflow (grid column shrinks naturally).
-    // No JS measurement needed.
+  // Keep pinned to bottom when content changes (e.g. images load)
+  const resizeObserver = new ResizeObserver(() => {
+    if (autoScroll) {
+      scrollToBottom();
+    }
+  });
+  resizeObserver.observe(messages);
+
+  // Reposition scroll-anchor when window resizes or sidebars toggle
+  window.addEventListener("resize", repositionScrollAnchor);
+  const contentArea = document.querySelector(".content-area");
+  if (contentArea) {
+    new ResizeObserver(repositionScrollAnchor).observe(contentArea);
+  }
+
+  // Support button label collapses via CSS overflow (grid column shrinks naturally).
+  // No JS measurement needed.
 }
 
 // --- Reply ---
 
 function copyMessage(msgId, event) {
-    if (event) event.stopPropagation();
-    const el = document.querySelector(`.message[data-id="${msgId}"]`);
-    if (!el) return;
-    const msgText = el.querySelector('.msg-text');
-    const html = msgText?.innerHTML || '';
-    const markdown = el.dataset.rawText || msgText?.innerText || '';
-    const done = () => {
-        const btn = el.querySelector('.bubble-copy');
-        if (btn) {
-            btn.classList.add('copied');
-            setTimeout(() => btn.classList.remove('copied'), 1500);
-        }
-    };
-    // Rich HTML + raw markdown — rich editors get HTML, code/markdown editors get source
-    if (navigator.clipboard.write) {
-        navigator.clipboard.write([new ClipboardItem({
-            'text/html': new Blob([html], {type: 'text/html'}),
-            'text/plain': new Blob([markdown], {type: 'text/plain'}),
-        })]).then(done);
-    } else {
-        navigator.clipboard.writeText(markdown).then(done);
+  if (event) event.stopPropagation();
+  const el = document.querySelector(`.message[data-id="${msgId}"]`);
+  if (!el) return;
+  const msgText = el.querySelector(".msg-text");
+  const html = msgText?.innerHTML || "";
+  const markdown = el.dataset.rawText || msgText?.innerText || "";
+  const done = () => {
+    const btn = el.querySelector(".bubble-copy");
+    if (btn) {
+      btn.classList.add("copied");
+      setTimeout(() => btn.classList.remove("copied"), 1500);
     }
+  };
+  // Rich HTML + raw markdown — rich editors get HTML, code/markdown editors get source
+  if (navigator.clipboard.write) {
+    navigator.clipboard
+      .write([
+        new ClipboardItem({
+          "text/html": new Blob([html], { type: "text/html" }),
+          "text/plain": new Blob([markdown], { type: "text/plain" }),
+        }),
+      ])
+      .then(done);
+  } else {
+    navigator.clipboard.writeText(markdown).then(done);
+  }
 }
 
 function startReply(msgId, event) {
-    if (event) event.stopPropagation();
-    const el = document.querySelector(`.message[data-id="${msgId}"]`);
-    if (!el) return;
-    const sender = el.querySelector('.msg-sender')?.textContent?.trim() || '?';
-    const text = el.dataset.rawText || el.querySelector('.msg-text')?.textContent || '';
-    replyingTo = { id: msgId, sender, text };
-    renderReplyPreview();
+  if (event) event.stopPropagation();
+  const el = document.querySelector(`.message[data-id="${msgId}"]`);
+  if (!el) return;
+  const sender = el.querySelector(".msg-sender")?.textContent?.trim() || "?";
+  const text =
+    el.dataset.rawText || el.querySelector(".msg-text")?.textContent || "";
+  replyingTo = { id: msgId, sender, text };
+  renderReplyPreview();
 
-    // Auto-activate mention chip for the replied-to sender, deactivate others
-    const resolved = resolveAgent(sender.toLowerCase());
-    if (resolved) {
-        for (const btn of document.querySelectorAll('.mention-toggle')) {
-            const agent = btn.dataset.agent;
-            if (agent === resolved) {
-                activeMentions.add(agent);
-                btn.classList.add('active');
-            } else {
-                activeMentions.delete(agent);
-                btn.classList.remove('active');
-            }
-        }
+  // Auto-activate mention chip for the replied-to sender, deactivate others
+  const resolved = resolveAgent(sender.toLowerCase());
+  if (resolved) {
+    for (const btn of document.querySelectorAll(".mention-toggle")) {
+      const agent = btn.dataset.agent;
+      if (agent === resolved) {
+        activeMentions.add(agent);
+        btn.classList.add("active");
+      } else {
+        activeMentions.delete(agent);
+        btn.classList.remove("active");
+      }
     }
+  }
 
-    document.getElementById('input').focus();
+  document.getElementById("input").focus();
 }
 
 function renderReplyPreview() {
-    let container = document.getElementById('reply-preview');
-    if (!replyingTo) {
-        if (container) container.remove();
-        return;
-    }
-    if (!container) {
-        container = document.createElement('div');
-        container.id = 'reply-preview';
-        const inputRow = document.getElementById('input-row');
-        inputRow.parentNode.insertBefore(container, inputRow);
-    }
-    const truncated = replyingTo.text.length > 100 ? replyingTo.text.slice(0, 100) + '...' : replyingTo.text;
-    const color = getColor(replyingTo.sender);
-    container.innerHTML = `<span class="reply-preview-label">replying to</span> <span style="color: ${color}; font-weight: 600">${escapeHtml(replyingTo.sender)}</span>: ${escapeHtml(truncated)} <button class="dismiss-btn reply-cancel" onclick="cancelReply()">&times;</button>`;
+  let container = document.getElementById("reply-preview");
+  if (!replyingTo) {
+    if (container) container.remove();
+    return;
+  }
+  if (!container) {
+    container = document.createElement("div");
+    container.id = "reply-preview";
+    const inputRow = document.getElementById("input-row");
+    inputRow.parentNode.insertBefore(container, inputRow);
+  }
+  const truncated =
+    replyingTo.text.length > 100
+      ? replyingTo.text.slice(0, 100) + "..."
+      : replyingTo.text;
+  const color = getColor(replyingTo.sender);
+  container.innerHTML = `<span class="reply-preview-label">replying to</span> <span style="color: ${color}; font-weight: 600">${escapeHtml(replyingTo.sender)}</span>: ${escapeHtml(truncated)} <button class="dismiss-btn reply-cancel" onclick="cancelReply()">&times;</button>`;
 }
 
 function cancelReply() {
-    replyingTo = null;
-    const el = document.getElementById('reply-preview');
-    if (el) el.remove();
+  replyingTo = null;
+  const el = document.getElementById("reply-preview");
+  if (el) el.remove();
 }
 
 function scrollToMessage(msgId) {
-    const el = document.querySelector(`.message[data-id="${msgId}"]`);
-    if (!el) return;
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    el.classList.add('highlight');
-    setTimeout(() => el.classList.remove('highlight'), 1500);
+  const el = document.querySelector(`.message[data-id="${msgId}"]`);
+  if (!el) return;
+  el.scrollIntoView({ behavior: "smooth", block: "center" });
+  el.classList.add("highlight");
+  setTimeout(() => el.classList.remove("highlight"), 1500);
 }
 
 // --- Todos ---
 
 function todoStatusLabel(status) {
-    if (!status) return 'pin';
-    if (status === 'todo') return 'done?';
-    return 'unpin';
+  if (!status) return "pin";
+  if (status === "todo") return "done?";
+  return "unpin";
 }
 
 function todoCycle(msgId) {
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    const status = todos[msgId] || null;
-    if (!status) {
-        ws.send(JSON.stringify({ type: 'todo_add', id: msgId }));
-    } else if (status === 'todo') {
-        ws.send(JSON.stringify({ type: 'todo_toggle', id: msgId }));
-    } else {
-        // done → remove
-        ws.send(JSON.stringify({ type: 'todo_remove', id: msgId }));
-    }
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  const status = todos[msgId] || null;
+  if (!status) {
+    ws.send(JSON.stringify({ type: "todo_add", id: msgId }));
+  } else if (status === "todo") {
+    ws.send(JSON.stringify({ type: "todo_toggle", id: msgId }));
+  } else {
+    // done → remove
+    ws.send(JSON.stringify({ type: "todo_remove", id: msgId }));
+  }
 }
 
 function todoAdd(msgId) {
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send(JSON.stringify({ type: 'todo_add', id: msgId }));
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: "todo_add", id: msgId }));
 }
 
 function todoToggle(msgId) {
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send(JSON.stringify({ type: 'todo_toggle', id: msgId }));
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: "todo_toggle", id: msgId }));
 }
 
 function todoRemove(msgId) {
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send(JSON.stringify({ type: 'todo_remove', id: msgId }));
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: "todo_remove", id: msgId }));
 }
 
 function updateTodoState(msgId, status) {
-    const el = document.querySelector(`.message[data-id="${msgId}"]`);
-    if (!el) return;
+  const el = document.querySelector(`.message[data-id="${msgId}"]`);
+  if (!el) return;
 
-    el.classList.remove('msg-todo', 'msg-todo-todo', 'msg-todo-done');
+  el.classList.remove("msg-todo", "msg-todo-todo", "msg-todo-done");
 
-    if (status === 'todo') {
-        el.classList.add('msg-todo', 'msg-todo-todo');
-    } else if (status === 'done') {
-        el.classList.add('msg-todo', 'msg-todo-done');
-    }
+  if (status === "todo") {
+    el.classList.add("msg-todo", "msg-todo-todo");
+  } else if (status === "done") {
+    el.classList.add("msg-todo", "msg-todo-done");
+  }
 
-    const hint = el.querySelector('.todo-hint');
-    if (hint) hint.textContent = todoStatusLabel(status);
+  const hint = el.querySelector(".todo-hint");
+  if (hint) hint.textContent = todoStatusLabel(status);
 
-    // Update panel if open
-    const panel = document.getElementById('pins-panel');
-    if (!panel.classList.contains('hidden')) renderTodosPanel();
+  // Update panel if open
+  const panel = document.getElementById("pins-panel");
+  if (!panel.classList.contains("hidden")) renderTodosPanel();
 }
 
 // --- Delete mode ---
@@ -2600,288 +3072,305 @@ let deleteSelected = new Set();
 let deleteDragging = false;
 
 function deleteClick(msgId, event) {
-    event.stopPropagation();
-    enterDeleteMode(msgId);
+  event.stopPropagation();
+  enterDeleteMode(msgId);
 }
 
 function enterDeleteMode(initialId) {
-    if (deleteMode) return;
-    deleteMode = true;
-    deleteSelected.clear();
-    if (initialId != null) deleteSelected.add(initialId);
+  if (deleteMode) return;
+  deleteMode = true;
+  deleteSelected.clear();
+  if (initialId != null) deleteSelected.add(initialId);
 
-    // Add delete-mode class — children transform right (no layout reflow)
-    document.getElementById('messages').classList.add('delete-mode');
+  // Add delete-mode class — children transform right (no layout reflow)
+  document.getElementById("messages").classList.add("delete-mode");
 
-    // Add radio circles to all messages (not joins)
-    document.querySelectorAll('.message[data-id]').forEach(el => {
-        if (el.classList.contains('join-msg') || el.classList.contains('summary-msg')) return;
-        // system-msg is excluded UNLESS it's a deletable subtype (banners, breadcrumbs, drafts)
-        if (el.classList.contains('system-msg')
-            && !el.classList.contains('session-banner')
-            && !el.classList.contains('session-draft-card')
-            && !el.classList.contains('job-breadcrumb')) return;
-        const id = parseInt(el.dataset.id);
-        const circle = document.createElement('div');
-        circle.className = 'delete-radio' + (deleteSelected.has(id) ? ' selected' : '');
-        circle.addEventListener('mousedown', (e) => {
-            e.preventDefault();
-            toggleDeleteSelect(id);
-            deleteDragging = true;
-        });
-        circle.addEventListener('mouseenter', () => {
-            if (deleteDragging) toggleDeleteSelect(id, true);
-        });
-        el.prepend(circle);
+  // Add radio circles to all messages (not joins)
+  document.querySelectorAll(".message[data-id]").forEach((el) => {
+    if (
+      el.classList.contains("join-msg") ||
+      el.classList.contains("summary-msg")
+    )
+      return;
+    // system-msg is excluded UNLESS it's a deletable subtype (banners, breadcrumbs, drafts)
+    if (
+      el.classList.contains("system-msg") &&
+      !el.classList.contains("session-banner") &&
+      !el.classList.contains("session-draft-card") &&
+      !el.classList.contains("job-breadcrumb")
+    )
+      return;
+    const id = parseInt(el.dataset.id);
+    const circle = document.createElement("div");
+    circle.className =
+      "delete-radio" + (deleteSelected.has(id) ? " selected" : "");
+    circle.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      toggleDeleteSelect(id);
+      deleteDragging = true;
     });
-
-    // Add radio circles to collapsed job-groups (selects all children)
-    document.querySelectorAll('.job-group').forEach(group => {
-        const ids = [...group.querySelectorAll('.job-breadcrumb[data-id]')].map(el => parseInt(el.dataset.id));
-        if (ids.length === 0) return;
-        const circle = document.createElement('div');
-        circle.className = 'delete-radio';
-        circle.addEventListener('mousedown', (e) => {
-            e.preventDefault();
-            const allSelected = ids.every(id => deleteSelected.has(id));
-            ids.forEach(id => {
-                if (allSelected) deleteSelected.delete(id); else deleteSelected.add(id);
-                const child = group.querySelector(`.job-breadcrumb[data-id="${id}"] .delete-radio`);
-                if (child) child.classList.toggle('selected', !allSelected);
-            });
-            circle.classList.toggle('selected', !allSelected);
-            updateDeleteBar();
-            deleteDragging = true;
-        });
-        circle.addEventListener('mouseenter', () => {
-            if (deleteDragging) {
-                ids.forEach(id => deleteSelected.add(id));
-                circle.classList.add('selected');
-                updateDeleteBar();
-            }
-        });
-        group.prepend(circle);
+    circle.addEventListener("mouseenter", () => {
+      if (deleteDragging) toggleDeleteSelect(id, true);
     });
+    el.prepend(circle);
+  });
 
-    // Show floating delete bar
-    showDeleteBar();
-    updateDeleteBar();
-    repositionScrollAnchor();
+  // Add radio circles to collapsed job-groups (selects all children)
+  document.querySelectorAll(".job-group").forEach((group) => {
+    const ids = [...group.querySelectorAll(".job-breadcrumb[data-id]")].map(
+      (el) => parseInt(el.dataset.id),
+    );
+    if (ids.length === 0) return;
+    const circle = document.createElement("div");
+    circle.className = "delete-radio";
+    circle.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      const allSelected = ids.every((id) => deleteSelected.has(id));
+      ids.forEach((id) => {
+        if (allSelected) deleteSelected.delete(id);
+        else deleteSelected.add(id);
+        const child = group.querySelector(
+          `.job-breadcrumb[data-id="${id}"] .delete-radio`,
+        );
+        if (child) child.classList.toggle("selected", !allSelected);
+      });
+      circle.classList.toggle("selected", !allSelected);
+      updateDeleteBar();
+      deleteDragging = true;
+    });
+    circle.addEventListener("mouseenter", () => {
+      if (deleteDragging) {
+        ids.forEach((id) => deleteSelected.add(id));
+        circle.classList.add("selected");
+        updateDeleteBar();
+      }
+    });
+    group.prepend(circle);
+  });
+
+  // Show floating delete bar
+  showDeleteBar();
+  updateDeleteBar();
+  repositionScrollAnchor();
 }
 
 function toggleDeleteSelect(id, dragForceSelect) {
-    const el = document.querySelector(`.message[data-id="${id}"]`);
-    if (!el) return;
-    const circle = el.querySelector('.delete-radio');
+  const el = document.querySelector(`.message[data-id="${id}"]`);
+  if (!el) return;
+  const circle = el.querySelector(".delete-radio");
 
-    if (dragForceSelect) {
-        deleteSelected.add(id);
-        if (circle) circle.classList.add('selected');
+  if (dragForceSelect) {
+    deleteSelected.add(id);
+    if (circle) circle.classList.add("selected");
+  } else {
+    if (deleteSelected.has(id)) {
+      deleteSelected.delete(id);
+      if (circle) circle.classList.remove("selected");
     } else {
-        if (deleteSelected.has(id)) {
-            deleteSelected.delete(id);
-            if (circle) circle.classList.remove('selected');
-        } else {
-            deleteSelected.add(id);
-            if (circle) circle.classList.add('selected');
-        }
+      deleteSelected.add(id);
+      if (circle) circle.classList.add("selected");
     }
-    updateDeleteBar();
+  }
+  updateDeleteBar();
 }
 
 function showDeleteBar() {
-    let bar = document.getElementById('delete-bar');
-    if (!bar) {
-        bar = document.createElement('div');
-        bar.id = 'delete-bar';
-        bar.innerHTML = `<button class="delete-bar-cancel" onclick="exitDeleteMode()">Cancel</button><span class="delete-bar-count"></span><button class="delete-bar-confirm" onclick="confirmDelete()">Delete</button>`;
-        const footer = document.querySelector('footer');
-        footer.parentNode.insertBefore(bar, footer);
-    }
-    bar.classList.remove('hidden');
+  let bar = document.getElementById("delete-bar");
+  if (!bar) {
+    bar = document.createElement("div");
+    bar.id = "delete-bar";
+    bar.innerHTML = `<button class="delete-bar-cancel" onclick="exitDeleteMode()">Cancel</button><span class="delete-bar-count"></span><button class="delete-bar-confirm" onclick="confirmDelete()">Delete</button>`;
+    const footer = document.querySelector("footer");
+    footer.parentNode.insertBefore(bar, footer);
+  }
+  bar.classList.remove("hidden");
 }
 
 function updateDeleteBar() {
-    const count = deleteSelected.size;
-    const span = document.querySelector('.delete-bar-count');
-    if (span) span.textContent = count > 0 ? `${count} selected` : 'Select messages';
-    const btn = document.querySelector('.delete-bar-confirm');
-    if (btn) {
-        btn.textContent = count > 0 ? `Delete (${count})` : 'Delete';
-        btn.disabled = count === 0;
-    }
+  const count = deleteSelected.size;
+  const span = document.querySelector(".delete-bar-count");
+  if (span)
+    span.textContent = count > 0 ? `${count} selected` : "Select messages";
+  const btn = document.querySelector(".delete-bar-confirm");
+  if (btn) {
+    btn.textContent = count > 0 ? `Delete (${count})` : "Delete";
+    btn.disabled = count === 0;
+  }
 }
 
 function confirmDelete() {
-    if (!ws || deleteSelected.size === 0) return;
-    ws.send(JSON.stringify({ type: 'delete', ids: [...deleteSelected] }));
-    exitDeleteMode();
+  if (!ws || deleteSelected.size === 0) return;
+  ws.send(JSON.stringify({ type: "delete", ids: [...deleteSelected] }));
+  exitDeleteMode();
 }
 
 function exitDeleteMode() {
-    deleteMode = false;
-    deleteSelected.clear();
-    deleteDragging = false;
+  deleteMode = false;
+  deleteSelected.clear();
+  deleteDragging = false;
 
-    // Remove delete-mode — children transform back (no layout reflow)
-    document.getElementById('messages').classList.remove('delete-mode');
+  // Remove delete-mode — children transform back (no layout reflow)
+  document.getElementById("messages").classList.remove("delete-mode");
 
-    // Collapse bar
-    const bar = document.getElementById('delete-bar');
-    if (bar) {
-        bar.classList.add('hidden');
-    }
+  // Collapse bar
+  const bar = document.getElementById("delete-bar");
+  if (bar) {
+    bar.classList.add("hidden");
+  }
 
-    // Fade out radios then remove
-    document.querySelectorAll('.delete-radio').forEach(el => {
-        el.style.opacity = '0';
-        el.style.transition = 'opacity 0.2s';
-        setTimeout(() => el.remove(), 200);
-    });
+  // Fade out radios then remove
+  document.querySelectorAll(".delete-radio").forEach((el) => {
+    el.style.opacity = "0";
+    el.style.transition = "opacity 0.2s";
+    setTimeout(() => el.remove(), 200);
+  });
 
-    repositionScrollAnchor();
+  repositionScrollAnchor();
 }
 
 // Auto-scroll while dragging near edges
 let deleteScrollInterval = null;
-document.addEventListener('mousemove', (e) => {
-    if (!deleteDragging) return;
-    const timeline = document.getElementById('timeline');
-    const rect = timeline.getBoundingClientRect();
-    const edgeZone = 60;
+document.addEventListener("mousemove", (e) => {
+  if (!deleteDragging) return;
+  const timeline = document.getElementById("timeline");
+  const rect = timeline.getBoundingClientRect();
+  const edgeZone = 60;
 
-    if (e.clientY < rect.top + edgeZone) {
-        // Near top — scroll up
-        if (!deleteScrollInterval) {
-            deleteScrollInterval = setInterval(() => timeline.scrollTop -= 8, 16);
-        }
-    } else if (e.clientY > rect.bottom - edgeZone) {
-        // Near bottom — scroll down
-        if (!deleteScrollInterval) {
-            deleteScrollInterval = setInterval(() => timeline.scrollTop += 8, 16);
-        }
-    } else if (deleteScrollInterval) {
-        clearInterval(deleteScrollInterval);
-        deleteScrollInterval = null;
+  if (e.clientY < rect.top + edgeZone) {
+    // Near top — scroll up
+    if (!deleteScrollInterval) {
+      deleteScrollInterval = setInterval(() => (timeline.scrollTop -= 8), 16);
     }
+  } else if (e.clientY > rect.bottom - edgeZone) {
+    // Near bottom — scroll down
+    if (!deleteScrollInterval) {
+      deleteScrollInterval = setInterval(() => (timeline.scrollTop += 8), 16);
+    }
+  } else if (deleteScrollInterval) {
+    clearInterval(deleteScrollInterval);
+    deleteScrollInterval = null;
+  }
 });
 
 // Stop drag on mouseup
-document.addEventListener('mouseup', () => {
-    deleteDragging = false;
-    if (deleteScrollInterval) {
-        clearInterval(deleteScrollInterval);
-        deleteScrollInterval = null;
-    }
+document.addEventListener("mouseup", () => {
+  deleteDragging = false;
+  if (deleteScrollInterval) {
+    clearInterval(deleteScrollInterval);
+    deleteScrollInterval = null;
+  }
 });
-document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && deleteMode) exitDeleteMode();
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && deleteMode) exitDeleteMode();
 });
 
 function handleDeleteBroadcast(ids) {
-    for (const id of ids) {
-        const el = document.querySelector(`.message[data-id="${id}"]`);
-        if (el) el.remove();
-        // Clean from todos
-        delete todos[id];
-    }
-    // Refresh todos panel if open
-    const panel = document.getElementById('pins-panel');
-    if (panel && !panel.classList.contains('hidden')) renderTodosPanel();
+  for (const id of ids) {
+    const el = document.querySelector(`.message[data-id="${id}"]`);
+    if (el) el.remove();
+    // Clean from todos
+    delete todos[id];
+  }
+  // Refresh todos panel if open
+  const panel = document.getElementById("pins-panel");
+  if (panel && !panel.classList.contains("hidden")) renderTodosPanel();
 }
 
 function togglePinsPanel() {
-    _preserveScroll(() => {
-        const panel = document.getElementById('pins-panel');
-        panel.classList.toggle('hidden');
-        document.getElementById('pins-toggle').classList.toggle('active', !panel.classList.contains('hidden'));
-        if (!panel.classList.contains('hidden')) {
-            renderTodosPanel();
-        }
-    });
+  _preserveScroll(() => {
+    const panel = document.getElementById("pins-panel");
+    panel.classList.toggle("hidden");
+    document
+      .getElementById("pins-toggle")
+      .classList.toggle("active", !panel.classList.contains("hidden"));
+    if (!panel.classList.contains("hidden")) {
+      renderTodosPanel();
+    }
+  });
 }
 
 function renderTodosPanel() {
-    const list = document.getElementById('pins-list');
-    list.innerHTML = '';
+  const list = document.getElementById("pins-list");
+  list.innerHTML = "";
 
-    const todoIds = Object.keys(todos);
-    if (todoIds.length === 0) {
-        list.innerHTML = '<div class="pins-empty">No pinned messages</div>';
-        return;
-    }
+  const todoIds = Object.keys(todos);
+  if (todoIds.length === 0) {
+    list.innerHTML = '<div class="pins-empty">No pinned messages</div>';
+    return;
+  }
 
-    // Chronological order (by message ID)
-    const sorted = todoIds.map(Number).sort((a, b) => a - b);
+  // Chronological order (by message ID)
+  const sorted = todoIds.map(Number).sort((a, b) => a - b);
 
-    for (const id of sorted) {
-        const el = document.querySelector(`.message[data-id="${id}"]`);
-        if (!el) continue;
+  for (const id of sorted) {
+    const el = document.querySelector(`.message[data-id="${id}"]`);
+    if (!el) continue;
 
-        const status = todos[id];
-        const item = document.createElement('div');
-        item.className = `todo-item ${status === 'done' ? 'todo-done' : ''}`;
+    const status = todos[id];
+    const item = document.createElement("div");
+    item.className = `todo-item ${status === "done" ? "todo-done" : ""}`;
 
-        const time = el.querySelector('.msg-time')?.textContent || '';
-        const sender = (el.querySelector('.msg-sender')?.textContent || '').trim();
-        const text = el.querySelector('.msg-text')?.textContent || '';
-        const senderColor = el.querySelector('.msg-sender')?.style.color || 'var(--text)';
+    const time = el.querySelector(".msg-time")?.textContent || "";
+    const sender = (el.querySelector(".msg-sender")?.textContent || "").trim();
+    const text = el.querySelector(".msg-text")?.textContent || "";
+    const senderColor =
+      el.querySelector(".msg-sender")?.style.color || "var(--text)";
 
-        const check = status === 'done' ? '&#10003;' : '&#9675;';
-        const checkClass = status === 'done' ? 'todo-check done' : 'todo-check';
-        const msgChannel = el.dataset.channel || 'general';
+    const check = status === "done" ? "&#10003;" : "&#9675;";
+    const checkClass = status === "done" ? "todo-check done" : "todo-check";
+    const msgChannel = el.dataset.channel || "general";
 
-        item.innerHTML = `<button class="${checkClass}" onclick="todoToggle(${id})">${check}</button><span class="msg-time" style="color:var(--accent);font-weight:600;margin-right:4px">#${msgChannel}</span> <span class="msg-time">${escapeHtml(time)}</span> <span class="msg-sender" style="color: ${senderColor}">${escapeHtml(sender)}</span> <span class="msg-text">${escapeHtml(text)}</span><button class="dismiss-btn danger" onclick="todoRemove(${id})" title="Remove from todos">&times;</button>`;
-        item.addEventListener('click', (e) => {
-            if (e.target.closest('button')) return;
-            // Cross-channel pin: switch channel if needed
-            const msgChannel = el.dataset.channel || 'general';
-            if (msgChannel !== activeChannel) {
-                switchChannel(msgChannel);
-            }
-            scrollToMessage(id);
-            togglePinsPanel();
-        });
-        list.appendChild(item);
-    }
+    item.innerHTML = `<button class="${checkClass}" onclick="todoToggle(${id})">${check}</button><span class="msg-time" style="color:var(--accent);font-weight:600;margin-right:4px">#${msgChannel}</span> <span class="msg-time">${escapeHtml(time)}</span> <span class="msg-sender" style="color: ${senderColor}">${escapeHtml(sender)}</span> <span class="msg-text">${escapeHtml(text)}</span><button class="dismiss-btn danger" onclick="todoRemove(${id})" title="Remove from todos">&times;</button>`;
+    item.addEventListener("click", (e) => {
+      if (e.target.closest("button")) return;
+      // Cross-channel pin: switch channel if needed
+      const msgChannel = el.dataset.channel || "general";
+      if (msgChannel !== activeChannel) {
+        switchChannel(msgChannel);
+      }
+      scrollToMessage(id);
+      togglePinsPanel();
+    });
+    list.appendChild(item);
+  }
 }
 
 // --- Mention toggles ---
 
 function buildMentionToggles() {
-    const container = document.getElementById('mention-toggles');
-    container.innerHTML = '';
+  const container = document.getElementById("mention-toggles");
+  container.innerHTML = "";
 
-    // Prune stale mentions for agents no longer in config
-    for (const name of activeMentions) {
-        if (!(name in agentConfig)) activeMentions.delete(name);
-    }
+  // Prune stale mentions for agents no longer in config
+  for (const name of activeMentions) {
+    if (!(name in agentConfig)) activeMentions.delete(name);
+  }
 
-    for (const [name, cfg] of Object.entries(agentConfig)) {
-        if (cfg.state === 'pending') continue;  // skip pending instances
-        const btn = document.createElement('button');
-        btn.className = 'mention-toggle';
-        btn.dataset.agent = name;
-        btn.textContent = `@${cfg.label || name}`;
-        btn.title = `@${name}`;  // Tooltip: canonical name
-        btn.style.setProperty('--agent-color', colorOverrides[name] || cfg.color);
-        // Restore active state for mentions that survived the rebuild
-        if (activeMentions.has(name)) {
-            btn.classList.add('active');
-        }
-        btn.onclick = () => {
-            if (activeMentions.has(name)) {
-                activeMentions.delete(name);
-                btn.classList.remove('active');
-            } else {
-                activeMentions.add(name);
-                btn.classList.add('active');
-            }
-            updateSchedulePopoverState();
-        };
-        container.appendChild(btn);
+  for (const [name, cfg] of Object.entries(agentConfig)) {
+    if (cfg.state === "pending") continue; // skip pending instances
+    const btn = document.createElement("button");
+    btn.className = "mention-toggle";
+    btn.dataset.agent = name;
+    btn.textContent = `@${cfg.label || name}`;
+    btn.title = `@${name}`; // Tooltip: canonical name
+    btn.style.setProperty("--agent-color", colorOverrides[name] || cfg.color);
+    // Restore active state for mentions that survived the rebuild
+    if (activeMentions.has(name)) {
+      btn.classList.add("active");
     }
-    enableDragScroll(container);
+    btn.onclick = () => {
+      if (activeMentions.has(name)) {
+        activeMentions.delete(name);
+        btn.classList.remove("active");
+      } else {
+        activeMentions.add(name);
+        btn.classList.add("active");
+      }
+      updateSchedulePopoverState();
+    };
+    container.appendChild(btn);
+  }
+  enableDragScroll(container);
 }
 
 // --- Voice typing ---
@@ -2890,687 +3379,761 @@ let recognition = null;
 let isListening = false;
 
 function focusComposerInput() {
-    const input = document.getElementById('input');
-    if (!input) return null;
-    try {
-        input.focus({ preventScroll: true });
-    } catch (_) {
-        input.focus();
-    }
-    return input;
+  const input = document.getElementById("input");
+  if (!input) return null;
+  try {
+    input.focus({ preventScroll: true });
+  } catch (_) {
+    input.focus();
+  }
+  return input;
 }
 
 function toggleVoice() {
-    if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)) {
-        alert('Speech recognition not supported — use Chrome or Edge.');
-        return;
-    }
+  if (
+    !("webkitSpeechRecognition" in window) &&
+    !("SpeechRecognition" in window)
+  ) {
+    alert("Speech recognition not supported — use Chrome or Edge.");
+    return;
+  }
 
+  if (isListening) {
+    stopVoice();
+    return;
+  }
+
+  const SpeechRecognition =
+    window.SpeechRecognition || window.webkitSpeechRecognition;
+  recognition = new SpeechRecognition();
+  recognition.lang = "en-GB";
+  recognition.continuous = true;
+  recognition.interimResults = true;
+
+  const input = focusComposerInput();
+  if (!input) return;
+  const baseText = input.value;
+  let finalTranscript = "";
+  const micButton = document.getElementById("mic");
+
+  recognition.onstart = () => {
+    isListening = true;
+    micButton.classList.add("recording");
+    micButton.setAttribute("aria-pressed", "true");
+    focusComposerInput();
+  };
+
+  recognition.onresult = (e) => {
+    let interim = "";
+    finalTranscript = "";
+    for (let i = 0; i < e.results.length; i++) {
+      const t = e.results[i][0].transcript;
+      if (e.results[i].isFinal) {
+        finalTranscript += t;
+      } else {
+        interim += t;
+      }
+    }
+    input.value = baseText + (baseText ? " " : "") + finalTranscript + interim;
+    focusComposerInput();
+    input.style.height = "auto";
+    input.style.height = Math.min(input.scrollHeight, 120) + "px";
+  };
+
+  recognition.onerror = (e) => {
+    console.error("Speech error:", e.error);
+    if (e.error === "not-allowed" || e.error === "service-not-allowed") {
+      alert(
+        "Microphone access was blocked. Allow microphone access in Chrome and try again.",
+      );
+      stopVoice();
+    } else if (e.error === "no-speech" || e.error === "aborted") {
+      // no-speech: Chrome fires after ~5s silence — keep listening
+      // aborted: fires during restart cycle — safe to ignore
+      console.log("Speech:", e.error, "— still listening...");
+    } else {
+      stopVoice();
+    }
+  };
+
+  recognition.onend = () => {
+    // If still supposed to be listening (e.g. after no-speech), restart
     if (isListening) {
-        stopVoice();
-        return;
-    }
-
-    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-    recognition = new SpeechRecognition();
-    recognition.lang = 'en-GB';
-    recognition.continuous = true;
-    recognition.interimResults = true;
-
-    const input = focusComposerInput();
-    if (!input) return;
-    const baseText = input.value;
-    let finalTranscript = '';
-    const micButton = document.getElementById('mic');
-
-    recognition.onstart = () => {
-        isListening = true;
-        micButton.classList.add('recording');
-        micButton.setAttribute('aria-pressed', 'true');
-        focusComposerInput();
-    };
-
-    recognition.onresult = (e) => {
-        let interim = '';
-        finalTranscript = '';
-        for (let i = 0; i < e.results.length; i++) {
-            const t = e.results[i][0].transcript;
-            if (e.results[i].isFinal) {
-                finalTranscript += t;
-            } else {
-                interim += t;
-            }
-        }
-        input.value = baseText + (baseText ? ' ' : '') + finalTranscript + interim;
-        focusComposerInput();
-        input.style.height = 'auto';
-        input.style.height = Math.min(input.scrollHeight, 120) + 'px';
-    };
-
-    recognition.onerror = (e) => {
-        console.error('Speech error:', e.error);
-        if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
-            alert('Microphone access was blocked. Allow microphone access in Chrome and try again.');
-            stopVoice();
-        } else if (e.error === 'no-speech' || e.error === 'aborted') {
-            // no-speech: Chrome fires after ~5s silence — keep listening
-            // aborted: fires during restart cycle — safe to ignore
-            console.log('Speech:', e.error, '— still listening...');
-        } else {
-            stopVoice();
-        }
-    };
-
-    recognition.onend = () => {
-        // If still supposed to be listening (e.g. after no-speech), restart
-        if (isListening) {
-            try { recognition.start(); } catch (_) { stopVoice(); }
-        } else {
-            stopVoice();
-        }
-    };
-
-    try {
+      try {
         recognition.start();
-    } catch (e) {
-        console.error('Speech start failed:', e);
+      } catch (_) {
         stopVoice();
+      }
+    } else {
+      stopVoice();
     }
+  };
+
+  try {
+    recognition.start();
+  } catch (e) {
+    console.error("Speech start failed:", e);
+    stopVoice();
+  }
 }
 
 function stopVoice() {
-    isListening = false;
-    const micButton = document.getElementById('mic');
-    if (micButton) {
-        micButton.classList.remove('recording');
-        micButton.setAttribute('aria-pressed', 'false');
-    }
-    if (recognition) {
-        try { recognition.stop(); } catch (_) {}
-        recognition = null;
-    }
-    focusComposerInput();
+  isListening = false;
+  const micButton = document.getElementById("mic");
+  if (micButton) {
+    micButton.classList.remove("recording");
+    micButton.setAttribute("aria-pressed", "false");
+  }
+  if (recognition) {
+    try {
+      recognition.stop();
+    } catch (_) {}
+    recognition = null;
+  }
+  focusComposerInput();
 }
 
 // --- Image modal ---
 
-let modalImages = [];  // all image URLs in chat
-let modalIndex = 0;    // current image index
+let modalImages = []; // all image URLs in chat
+let modalIndex = 0; // current image index
 
 function getAllChatImages() {
-    const imgs = document.querySelectorAll('.msg-attachments img, .job-msg-attachments img');
-    return [...imgs].map(img => img.src);
+  const imgs = document.querySelectorAll(
+    ".msg-attachments img, .job-msg-attachments img",
+  );
+  return [...imgs].map((img) => img.src);
 }
 
 function openImageModal(url) {
-    modalImages = getAllChatImages();
-    // Match by endsWith since onclick passes relative URL but img.src is absolute
-    modalIndex = modalImages.findIndex(src => src.endsWith(url) || src === url);
-    if (modalIndex === -1) {
-        // Image not in chat gallery (e.g. composer preview) — show it standalone
-        modalImages = [url];
-        modalIndex = 0;
-    }
+  modalImages = getAllChatImages();
+  // Match by endsWith since onclick passes relative URL but img.src is absolute
+  modalIndex = modalImages.findIndex((src) => src.endsWith(url) || src === url);
+  if (modalIndex === -1) {
+    // Image not in chat gallery (e.g. composer preview) — show it standalone
+    modalImages = [url];
+    modalIndex = 0;
+  }
 
-    let modal = document.getElementById('image-modal');
-    if (!modal) {
-        modal = document.createElement('div');
-        modal.id = 'image-modal';
-        modal.className = 'hidden';
-        modal.innerHTML = `<button class="modal-nav modal-prev" onclick="modalPrev(event)">&lsaquo;</button><img onclick="event.stopPropagation()"><button class="modal-nav modal-next" onclick="modalNext(event)">&rsaquo;</button><span class="modal-counter"></span>`;
-        modal.addEventListener('click', closeImageModal);
-        document.body.appendChild(modal);
-    }
-    updateModalImage(modal);
-    modal.classList.remove('hidden');
+  let modal = document.getElementById("image-modal");
+  if (!modal) {
+    modal = document.createElement("div");
+    modal.id = "image-modal";
+    modal.className = "hidden";
+    modal.innerHTML = `<button class="modal-nav modal-prev" onclick="modalPrev(event)">&lsaquo;</button><img onclick="event.stopPropagation()"><button class="modal-nav modal-next" onclick="modalNext(event)">&rsaquo;</button><span class="modal-counter"></span>`;
+    modal.addEventListener("click", closeImageModal);
+    document.body.appendChild(modal);
+  }
+  updateModalImage(modal);
+  modal.classList.remove("hidden");
 }
 
 function updateModalImage(modal) {
-    if (!modal) modal = document.getElementById('image-modal');
-    if (!modal || modalImages.length === 0) return;
-    modal.querySelector('img').src = modalImages[modalIndex];
-    const counter = modal.querySelector('.modal-counter');
-    if (counter) {
-        counter.textContent = `${modalIndex + 1} / ${modalImages.length}`;
-    }
-    // Hide arrows at beginning/end, or if only one image
-    const prev = modal.querySelector('.modal-prev');
-    const next = modal.querySelector('.modal-next');
-    if (prev) prev.style.display = modalIndex > 0 ? 'flex' : 'none';
-    if (next) next.style.display = modalIndex < modalImages.length - 1 ? 'flex' : 'none';
+  if (!modal) modal = document.getElementById("image-modal");
+  if (!modal || modalImages.length === 0) return;
+  modal.querySelector("img").src = modalImages[modalIndex];
+  const counter = modal.querySelector(".modal-counter");
+  if (counter) {
+    counter.textContent = `${modalIndex + 1} / ${modalImages.length}`;
+  }
+  // Hide arrows at beginning/end, or if only one image
+  const prev = modal.querySelector(".modal-prev");
+  const next = modal.querySelector(".modal-next");
+  if (prev) prev.style.display = modalIndex > 0 ? "flex" : "none";
+  if (next)
+    next.style.display = modalIndex < modalImages.length - 1 ? "flex" : "none";
 }
 
 function modalPrev(event) {
-    event.stopPropagation();
-    if (modalIndex <= 0) return;
-    modalIndex--;
-    updateModalImage();
+  event.stopPropagation();
+  if (modalIndex <= 0) return;
+  modalIndex--;
+  updateModalImage();
 }
 
 function modalNext(event) {
-    event.stopPropagation();
-    if (modalIndex >= modalImages.length - 1) return;
-    modalIndex++;
-    updateModalImage();
+  event.stopPropagation();
+  if (modalIndex >= modalImages.length - 1) return;
+  modalIndex++;
+  updateModalImage();
 }
 
 function closeImageModal() {
-    const modal = document.getElementById('image-modal');
-    if (modal) modal.classList.add('hidden');
+  const modal = document.getElementById("image-modal");
+  if (modal) modal.classList.add("hidden");
 }
 
 async function _preserveScroll(fn) {
-    const timeline = document.getElementById('timeline');
-    if (!timeline) { await fn(); return; }
-
-    // Check if we are at the bottom (with a small buffer)
-    const wasAtBottom = autoScroll || (timeline.scrollHeight - timeline.scrollTop - timeline.clientHeight < 60);
-    const topId = _getTopVisibleMsgId();
-
-    // Save the exact pixel offset of the top visible message
-    let savedOffset = 0;
-    if (topId) {
-        const el = document.querySelector(`.message[data-id="${topId}"]`);
-        if (el) {
-            savedOffset = el.getBoundingClientRect().top - timeline.getBoundingClientRect().top;
-        }
-    }
-
-    // Disable smooth scrolling for instant correction
-    const oldSmooth = timeline.style.scrollBehavior;
-    timeline.style.scrollBehavior = 'auto';
-
+  const timeline = document.getElementById("timeline");
+  if (!timeline) {
     await fn();
+    return;
+  }
 
-    // Continuously correct scroll during sidebar CSS transition
-    function correctScroll() {
-        if (wasAtBottom) {
-            timeline.scrollTop = timeline.scrollHeight;
-        } else if (topId) {
-            const el = document.querySelector(`.message[data-id="${topId}"]`);
-            if (el) {
-                const newRect = el.getBoundingClientRect();
-                const timelineRect = timeline.getBoundingClientRect();
-                timeline.scrollTop += (newRect.top - timelineRect.top) - savedOffset;
-            }
-        }
+  // Check if we are at the bottom (with a small buffer)
+  const wasAtBottom =
+    autoScroll ||
+    timeline.scrollHeight - timeline.scrollTop - timeline.clientHeight < 60;
+  const topId = _getTopVisibleMsgId();
+
+  // Save the exact pixel offset of the top visible message
+  let savedOffset = 0;
+  if (topId) {
+    const el = document.querySelector(`.message[data-id="${topId}"]`);
+    if (el) {
+      savedOffset =
+        el.getBoundingClientRect().top - timeline.getBoundingClientRect().top;
     }
+  }
 
-    // Correct immediately
-    void timeline.scrollHeight;
+  // Disable smooth scrolling for instant correction
+  const oldSmooth = timeline.style.scrollBehavior;
+  timeline.style.scrollBehavior = "auto";
+
+  await fn();
+
+  // Continuously correct scroll during sidebar CSS transition
+  function correctScroll() {
+    if (wasAtBottom) {
+      timeline.scrollTop = timeline.scrollHeight;
+    } else if (topId) {
+      const el = document.querySelector(`.message[data-id="${topId}"]`);
+      if (el) {
+        const newRect = el.getBoundingClientRect();
+        const timelineRect = timeline.getBoundingClientRect();
+        timeline.scrollTop += newRect.top - timelineRect.top - savedOffset;
+      }
+    }
+  }
+
+  // Correct immediately
+  void timeline.scrollHeight;
+  correctScroll();
+
+  // Keep correcting each frame during the transition (~300ms)
+  let frames = 0;
+  function tick() {
     correctScroll();
-
-    // Keep correcting each frame during the transition (~300ms)
-    let frames = 0;
-    function tick() {
-        correctScroll();
-        if (++frames < 20) requestAnimationFrame(tick); // ~333ms at 60fps
-        else timeline.style.scrollBehavior = oldSmooth;
-    }
-    requestAnimationFrame(tick);
+    if (++frames < 20)
+      requestAnimationFrame(tick); // ~333ms at 60fps
+    else timeline.style.scrollBehavior = oldSmooth;
+  }
+  requestAnimationFrame(tick);
 }
 window._preserveScroll = _preserveScroll;
 
 // Style #hashtags in rendered message text
 function styleHashtags(html) {
-    // "Match and skip" pattern: consume HTML tags first (to skip hex colors in
-    // style attributes like color: #da7756), then match real hashtags in text.
-    return html.replace(/<[^>]*>|((?:^|\s))(#([a-zA-Z][a-zA-Z0-9_-]{0,39}))\b/g,
-        (match, prefix, fullHash, tag) => {
-            if (tag === undefined) return match; // HTML tag — skip
-            const lower = tag.toLowerCase();
-            if (['clear', 'off', 'none', 'end'].includes(lower)) {
-                return `${prefix}<span class="msg-hashtag" style="opacity:0.5">#${tag}</span>`;
-            }
-            return `${prefix}<span class="msg-hashtag">#${tag}</span>`;
-        });
+  // "Match and skip" pattern: consume HTML tags first (to skip hex colors in
+  // style attributes like color: #da7756), then match real hashtags in text.
+  return html.replace(
+    /<[^>]*>|((?:^|\s))(#([a-zA-Z][a-zA-Z0-9_-]{0,39}))\b/g,
+    (match, prefix, fullHash, tag) => {
+      if (tag === undefined) return match; // HTML tag — skip
+      const lower = tag.toLowerCase();
+      if (["clear", "off", "none", "end"].includes(lower)) {
+        return `${prefix}<span class="msg-hashtag" style="opacity:0.5">#${tag}</span>`;
+      }
+      return `${prefix}<span class="msg-hashtag">#${tag}</span>`;
+    },
+  );
 }
 
 // --- Helpers ---
 
-
 function escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
 }
 window.escapeHtml = escapeHtml;
 
 // --- Schedules strip ---
 
 function handleScheduleEvent(action, schedule) {
-    if (action === 'create') {
-        schedulesList = schedulesList.filter(s => s.id !== schedule.id);
-        schedulesList.push(schedule);
-    } else if (action === 'update') {
-        schedulesList = schedulesList.map(s => s.id === schedule.id ? schedule : s);
-    } else if (action === 'delete') {
-        schedulesList = schedulesList.filter(s => s.id !== schedule.id);
-    }
-    renderSchedulesBar();
+  if (action === "create") {
+    schedulesList = schedulesList.filter((s) => s.id !== schedule.id);
+    schedulesList.push(schedule);
+  } else if (action === "update") {
+    schedulesList = schedulesList.map((s) =>
+      s.id === schedule.id ? schedule : s,
+    );
+  } else if (action === "delete") {
+    schedulesList = schedulesList.filter((s) => s.id !== schedule.id);
+  }
+  renderSchedulesBar();
 }
 
 function renderSchedulesBar() {
-    const bar = document.getElementById('schedules-bar');
-    if (!bar) return;
+  const bar = document.getElementById("schedules-bar");
+  if (!bar) return;
 
-    const active = schedulesList.filter(s => s.active !== false);
-    if (schedulesList.length === 0) {
-        bar.classList.add('hidden');
-        bar.classList.remove('expanded');
-        document.getElementById('schedules-list')?.classList.add('hidden');
-        repositionScrollAnchor();
-        return;
-    }
-
-    bar.classList.remove('hidden');
-
-    // Summary line -- Slack-style: describe the next firing
-    const countEl = document.getElementById('schedules-count');
-    const nextEl = document.getElementById('schedules-next');
-
-    // Clean up inline controls from previous render
-    const summaryDiv = bar.querySelector('.schedules-bar-summary');
-    summaryDiv.querySelector('.schedule-toggle-inline')?.remove();
-    summaryDiv.querySelector('.schedule-delete-inline')?.remove();
-
-    if (schedulesList.length === 1) {
-        const s = schedulesList[0];
-        const isPaused = s.active === false;
-        const targetStr = (s.targets || []).map(t => '@' + t).join(', ');
-        countEl.textContent = `${targetStr} "${s.prompt}"` + (isPaused ? ' (paused)' : '');
-        const nextStr = (!isPaused && s.next_run) ? formatScheduleTime(s.next_run) : '';
-        nextEl.textContent = nextStr
-            ? formatScheduleInterval(s) + ' -- next in ' + nextStr
-            : formatScheduleInterval(s);
-    } else if (active.length > 0) {
-        const paused = schedulesList.length - active.length;
-        const parts = [`${active.length} active`];
-        if (paused > 0) parts.push(`${paused} paused`);
-        countEl.textContent = parts.join(', ');
-        const futureRuns = active.filter(s => s.next_run && s.next_run * 1000 > Date.now()).map(s => s.next_run);
-        const nextTimeStr = futureRuns.length > 0 ? formatScheduleTime(Math.min(...futureRuns)) : '';
-        nextEl.textContent = nextTimeStr ? 'next in ' + nextTimeStr : '';
-    } else {
-        const paused = schedulesList.length;
-        countEl.textContent = `${paused} paused schedule${paused !== 1 ? 's' : ''}`;
-        nextEl.textContent = '';
-    }
-
-    // Inline pause + trash when only 1 schedule; hide "See all" link
-    const seeAllLink = summaryDiv.querySelector('.schedules-see-all');
-    if (schedulesList.length === 1) {
-        const s = schedulesList[0];
-        const isPaused = s.active === false;
-
-        const pauseBtn = document.createElement('button');
-        pauseBtn.className = 'schedule-toggle-inline' + (isPaused ? ' paused' : '');
-        pauseBtn.innerHTML = isPaused
-            ? '<svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M5 3l8 5-8 5V3z" fill="currentColor"/></svg>'
-            : '<svg width="13" height="13" viewBox="0 0 16 16" fill="none"><rect x="4" y="3" width="3" height="10" rx="0.5" fill="currentColor"/><rect x="9" y="3" width="3" height="10" rx="0.5" fill="currentColor"/></svg>';
-        pauseBtn.title = isPaused ? 'Resume' : 'Pause';
-        pauseBtn.onclick = () => toggleSchedule(s.id);
-
-        const trashBtn = document.createElement('button');
-        trashBtn.className = 'schedule-delete-inline';
-        trashBtn.innerHTML = '<svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M5.5 4V3a1 1 0 011-1h3a1 1 0 011 1v1M6 7v5M10 7v5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/><path d="M4 4l.5 9a1 1 0 001 1h5a1 1 0 001-1L12 4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-        trashBtn.title = 'Delete';
-        trashBtn.onclick = () => deleteSchedule(s.id);
-
-        summaryDiv.append(pauseBtn, trashBtn);
-        if (seeAllLink) seeAllLink.style.display = 'none';
-        // Collapse expanded list — summary has everything
-        bar.classList.remove('expanded');
-        document.getElementById('schedules-list')?.classList.add('hidden');
-        if (seeAllLink) seeAllLink.textContent = 'See all';
-    } else {
-        if (seeAllLink) seeAllLink.style.display = '';
-    }
-
-    // Adjust scroll-anchor so it sits above the footer
+  const active = schedulesList.filter((s) => s.active !== false);
+  if (schedulesList.length === 0) {
+    bar.classList.add("hidden");
+    bar.classList.remove("expanded");
+    document.getElementById("schedules-list")?.classList.add("hidden");
     repositionScrollAnchor();
+    return;
+  }
 
-    // Expanded list
-    const list = document.getElementById('schedules-list');
-    list.innerHTML = '';
-    for (const s of schedulesList) {
-        const row = document.createElement('div');
-        row.className = 'schedule-row' + (s.active === false ? ' paused' : '');
+  bar.classList.remove("hidden");
 
-        const targets = document.createElement('span');
-        targets.className = 'schedule-targets';
-        targets.textContent = (s.targets || []).map(t => '@' + t).join(' ');
+  // Summary line -- Slack-style: describe the next firing
+  const countEl = document.getElementById("schedules-count");
+  const nextEl = document.getElementById("schedules-next");
 
-        const prompt = document.createElement('span');
-        prompt.className = 'schedule-prompt';
-        prompt.textContent = s.prompt || '';
-        prompt.title = s.prompt || '';
+  // Clean up inline controls from previous render
+  const summaryDiv = bar.querySelector(".schedules-bar-summary");
+  summaryDiv.querySelector(".schedule-toggle-inline")?.remove();
+  summaryDiv.querySelector(".schedule-delete-inline")?.remove();
 
-        const interval = document.createElement('span');
-        interval.className = 'schedule-interval';
-        interval.textContent = formatScheduleInterval(s);
+  if (schedulesList.length === 1) {
+    const s = schedulesList[0];
+    const isPaused = s.active === false;
+    const targetStr = (s.targets || []).map((t) => "@" + t).join(", ");
+    countEl.textContent =
+      `${targetStr} "${s.prompt}"` + (isPaused ? " (paused)" : "");
+    const nextStr =
+      !isPaused && s.next_run ? formatScheduleTime(s.next_run) : "";
+    nextEl.textContent = nextStr
+      ? formatScheduleInterval(s) + " -- next in " + nextStr
+      : formatScheduleInterval(s);
+  } else if (active.length > 0) {
+    const paused = schedulesList.length - active.length;
+    const parts = [`${active.length} active`];
+    if (paused > 0) parts.push(`${paused} paused`);
+    countEl.textContent = parts.join(", ");
+    const futureRuns = active
+      .filter((s) => s.next_run && s.next_run * 1000 > Date.now())
+      .map((s) => s.next_run);
+    const nextTimeStr =
+      futureRuns.length > 0 ? formatScheduleTime(Math.min(...futureRuns)) : "";
+    nextEl.textContent = nextTimeStr ? "next in " + nextTimeStr : "";
+  } else {
+    const paused = schedulesList.length;
+    countEl.textContent = `${paused} paused schedule${paused !== 1 ? "s" : ""}`;
+    nextEl.textContent = "";
+  }
 
-        const toggleBtn = document.createElement('button');
-        toggleBtn.className = 'schedule-toggle';
-        toggleBtn.textContent = s.active === false ? '▶' : '⏸';
-        toggleBtn.title = s.active === false ? 'Resume' : 'Pause';
-        toggleBtn.onclick = () => toggleSchedule(s.id);
+  // Inline pause + trash when only 1 schedule; hide "See all" link
+  const seeAllLink = summaryDiv.querySelector(".schedules-see-all");
+  if (schedulesList.length === 1) {
+    const s = schedulesList[0];
+    const isPaused = s.active === false;
 
-        const deleteBtn = document.createElement('button');
-        deleteBtn.className = 'schedule-delete';
-        deleteBtn.innerHTML = '<svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M5.5 4V3a1 1 0 011-1h3a1 1 0 011 1v1M6 7v5M10 7v5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/><path d="M4 4l.5 9a1 1 0 001 1h5a1 1 0 001-1L12 4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-        deleteBtn.title = 'Delete';
-        deleteBtn.onclick = () => deleteSchedule(s.id);
+    const pauseBtn = document.createElement("button");
+    pauseBtn.className = "schedule-toggle-inline" + (isPaused ? " paused" : "");
+    pauseBtn.innerHTML = isPaused
+      ? '<svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M5 3l8 5-8 5V3z" fill="currentColor"/></svg>'
+      : '<svg width="13" height="13" viewBox="0 0 16 16" fill="none"><rect x="4" y="3" width="3" height="10" rx="0.5" fill="currentColor"/><rect x="9" y="3" width="3" height="10" rx="0.5" fill="currentColor"/></svg>';
+    pauseBtn.title = isPaused ? "Resume" : "Pause";
+    pauseBtn.onclick = () => toggleSchedule(s.id);
 
-        row.append(targets, prompt, interval, toggleBtn, deleteBtn);
-        list.appendChild(row);
-    }
+    const trashBtn = document.createElement("button");
+    trashBtn.className = "schedule-delete-inline";
+    trashBtn.innerHTML =
+      '<svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M5.5 4V3a1 1 0 011-1h3a1 1 0 011 1v1M6 7v5M10 7v5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/><path d="M4 4l.5 9a1 1 0 001 1h5a1 1 0 001-1L12 4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    trashBtn.title = "Delete";
+    trashBtn.onclick = () => deleteSchedule(s.id);
+
+    summaryDiv.append(pauseBtn, trashBtn);
+    if (seeAllLink) seeAllLink.style.display = "none";
+    // Collapse expanded list — summary has everything
+    bar.classList.remove("expanded");
+    document.getElementById("schedules-list")?.classList.add("hidden");
+    if (seeAllLink) seeAllLink.textContent = "See all";
+  } else {
+    if (seeAllLink) seeAllLink.style.display = "";
+  }
+
+  // Adjust scroll-anchor so it sits above the footer
+  repositionScrollAnchor();
+
+  // Expanded list
+  const list = document.getElementById("schedules-list");
+  list.innerHTML = "";
+  for (const s of schedulesList) {
+    const row = document.createElement("div");
+    row.className = "schedule-row" + (s.active === false ? " paused" : "");
+
+    const targets = document.createElement("span");
+    targets.className = "schedule-targets";
+    targets.textContent = (s.targets || []).map((t) => "@" + t).join(" ");
+
+    const prompt = document.createElement("span");
+    prompt.className = "schedule-prompt";
+    prompt.textContent = s.prompt || "";
+    prompt.title = s.prompt || "";
+
+    const interval = document.createElement("span");
+    interval.className = "schedule-interval";
+    interval.textContent = formatScheduleInterval(s);
+
+    const toggleBtn = document.createElement("button");
+    toggleBtn.className = "schedule-toggle";
+    toggleBtn.textContent = s.active === false ? "▶" : "⏸";
+    toggleBtn.title = s.active === false ? "Resume" : "Pause";
+    toggleBtn.onclick = () => toggleSchedule(s.id);
+
+    const deleteBtn = document.createElement("button");
+    deleteBtn.className = "schedule-delete";
+    deleteBtn.innerHTML =
+      '<svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M5.5 4V3a1 1 0 011-1h3a1 1 0 011 1v1M6 7v5M10 7v5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/><path d="M4 4l.5 9a1 1 0 001 1h5a1 1 0 001-1L12 4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    deleteBtn.title = "Delete";
+    deleteBtn.onclick = () => deleteSchedule(s.id);
+
+    row.append(targets, prompt, interval, toggleBtn, deleteBtn);
+    list.appendChild(row);
+  }
 }
 
 function formatScheduleTime(ts) {
-    const d = new Date(ts * 1000);
-    const now = new Date();
-    const diffMs = d - now;
-    if (diffMs < 0) return '';
-    if (diffMs < 60000) return '<1m';
-    if (diffMs < 3600000) return Math.ceil(diffMs / 60000) + 'm';
-    if (diffMs < 86400000) {
-        const h = Math.floor(diffMs / 3600000);
-        const m = Math.ceil((diffMs % 3600000) / 60000);
-        return m > 0 ? `${h}h ${m}m` : `${h}h`;
-    }
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const d = new Date(ts * 1000);
+  const now = new Date();
+  const diffMs = d - now;
+  if (diffMs < 0) return "";
+  if (diffMs < 60000) return "<1m";
+  if (diffMs < 3600000) return Math.ceil(diffMs / 60000) + "m";
+  if (diffMs < 86400000) {
+    const h = Math.floor(diffMs / 3600000);
+    const m = Math.ceil((diffMs % 3600000) / 60000);
+    return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  }
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
 function formatScheduleInterval(s) {
-    if (s.daily_at) return 'daily at ' + s.daily_at;
-    const sec = s.interval_seconds || 0;
-    if (sec < 3600) return 'every ' + Math.round(sec / 60) + 'm';
-    if (sec < 86400) return 'every ' + Math.round(sec / 3600) + 'h';
-    return 'every ' + Math.round(sec / 86400) + 'd';
+  if (s.daily_at) return "daily at " + s.daily_at;
+  const sec = s.interval_seconds || 0;
+  if (sec < 3600) return "every " + Math.round(sec / 60) + "m";
+  if (sec < 86400) return "every " + Math.round(sec / 3600) + "h";
+  return "every " + Math.round(sec / 86400) + "d";
 }
 
 function toggleSchedulesExpand() {
-    const bar = document.getElementById('schedules-bar');
-    const list = document.getElementById('schedules-list');
-    if (!bar || !list) return;
-    const expanded = bar.classList.toggle('expanded');
-    list.classList.toggle('hidden', !expanded);
-    const link = bar.querySelector('.schedules-see-all');
-    if (link) link.textContent = expanded ? 'Hide' : 'See all';
+  const bar = document.getElementById("schedules-bar");
+  const list = document.getElementById("schedules-list");
+  if (!bar || !list) return;
+  const expanded = bar.classList.toggle("expanded");
+  list.classList.toggle("hidden", !expanded);
+  const link = bar.querySelector(".schedules-see-all");
+  if (link) link.textContent = expanded ? "Hide" : "See all";
 }
 
 async function toggleSchedule(id) {
-    try {
-        await fetch(`/api/schedules/${id}/toggle`, {
-            method: 'PATCH',
-            headers: { 'X-Session-Token': SESSION_TOKEN },
-        });
-    } catch (e) {
-        console.error('Failed to toggle schedule:', e);
-    }
+  try {
+    await fetch(`/api/schedules/${id}/toggle`, {
+      method: "PATCH",
+    });
+  } catch (e) {
+    console.error("Failed to toggle schedule:", e);
+  }
 }
 
 async function deleteSchedule(id) {
-    try {
-        await fetch(`/api/schedules/${id}`, {
-            method: 'DELETE',
-            headers: { 'X-Session-Token': SESSION_TOKEN },
-        });
-    } catch (e) {
-        console.error('Failed to delete schedule:', e);
-    }
+  try {
+    await fetch(`/api/schedules/${id}`, {
+      method: "DELETE",
+    });
+  } catch (e) {
+    console.error("Failed to delete schedule:", e);
+  }
 }
 
 function showScheduleConfirmation() {
-    const bar = document.getElementById('schedules-bar');
-    if (!bar) return;
-    bar.classList.remove('hidden');
-    // Flash the bar green for 2s then transition back
-    bar.classList.add('sched-flash');
-    setTimeout(() => bar.classList.remove('sched-flash'), 2000);
+  const bar = document.getElementById("schedules-bar");
+  if (!bar) return;
+  bar.classList.remove("hidden");
+  // Flash the bar green for 2s then transition back
+  bar.classList.add("sched-flash");
+  setTimeout(() => bar.classList.remove("sched-flash"), 2000);
 }
 
 // --- Schedule popover ---
 
 function toggleSchedulePopover(e) {
-    if (e) e.stopPropagation();
-    const pop = document.getElementById('schedule-popover');
-    if (!pop) return;
-    const opening = pop.classList.contains('hidden');
-    pop.classList.toggle('hidden');
-    if (opening) {
-        populateScheduleDropdowns();
-        updateSchedulePopoverState();
-    }
+  if (e) e.stopPropagation();
+  const pop = document.getElementById("schedule-popover");
+  if (!pop) return;
+  const opening = pop.classList.contains("hidden");
+  pop.classList.toggle("hidden");
+  if (opening) {
+    populateScheduleDropdowns();
+    updateSchedulePopoverState();
+  }
 }
 
 function closeSchedulePopover() {
-    const pop = document.getElementById('schedule-popover');
-    if (pop) pop.classList.add('hidden');
+  const pop = document.getElementById("schedule-popover");
+  if (pop) pop.classList.add("hidden");
 }
 
 function stepNumInput(id, delta) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    const min = parseInt(el.min) || 1;
-    const max = parseInt(el.max) || 99;
-    const val = Math.max(min, Math.min(max, (parseInt(el.value) || min) + delta));
-    el.value = val;
-    el.dispatchEvent(new Event('input', { bubbles: true }));
-    el.dispatchEvent(new Event('change', { bubbles: true }));
+  const el = document.getElementById(id);
+  if (!el) return;
+  const min = parseInt(el.min) || 1;
+  const max = parseInt(el.max) || 99;
+  const val = Math.max(min, Math.min(max, (parseInt(el.value) || min) + delta));
+  el.value = val;
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  el.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
 function stepSchedNum(delta) {
-    stepNumInput('sched-interval-val', delta);
+  stepNumInput("sched-interval-val", delta);
 }
 
 function toggleRecurringFields() {
-    const checked = document.getElementById('sched-recurring')?.checked;
-    const fields = document.getElementById('sched-recurring-fields');
-    if (fields) fields.classList.toggle('hidden', !checked);
-    // Dim both "When" and "At" rows when recurring is active
-    const whenRow = document.getElementById('sched-date')?.closest('.sched-pop-row');
-    const atRow = document.getElementById('sched-hour')?.closest('.sched-pop-row');
-    if (whenRow) whenRow.classList.toggle('sched-dimmed', !!checked);
-    if (atRow) atRow.classList.toggle('sched-dimmed', !!checked);
+  const checked = document.getElementById("sched-recurring")?.checked;
+  const fields = document.getElementById("sched-recurring-fields");
+  if (fields) fields.classList.toggle("hidden", !checked);
+  // Dim both "When" and "At" rows when recurring is active
+  const whenRow = document
+    .getElementById("sched-date")
+    ?.closest(".sched-pop-row");
+  const atRow = document
+    .getElementById("sched-hour")
+    ?.closest(".sched-pop-row");
+  if (whenRow) whenRow.classList.toggle("sched-dimmed", !!checked);
+  if (atRow) atRow.classList.toggle("sched-dimmed", !!checked);
 }
 
 function populateScheduleDropdowns() {
-    const dateEl = document.getElementById('sched-date');
-    const hourEl = document.getElementById('sched-hour');
-    const minEl = document.getElementById('sched-minute');
-    const ampmEl = document.getElementById('sched-ampm');
-    if (!dateEl || !hourEl || !minEl || !ampmEl) return;
+  const dateEl = document.getElementById("sched-date");
+  const hourEl = document.getElementById("sched-hour");
+  const minEl = document.getElementById("sched-minute");
+  const ampmEl = document.getElementById("sched-ampm");
+  if (!dateEl || !hourEl || !minEl || !ampmEl) return;
 
-    // Date options: Today, Tomorrow, then next 5 weekdays
-    dateEl.innerHTML = '';
-    const days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
-    const now = new Date();
-    for (let i = 0; i < 7; i++) {
-        const d = new Date(now);
-        d.setDate(d.getDate() + i);
-        const opt = document.createElement('option');
-        opt.value = d.toISOString().slice(0, 10);
-        opt.textContent = i === 0 ? 'Today' : i === 1 ? 'Tomorrow' : days[d.getDay()];
-        dateEl.appendChild(opt);
-    }
+  // Date options: Today, Tomorrow, then next 5 weekdays
+  dateEl.innerHTML = "";
+  const days = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+  const now = new Date();
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(now);
+    d.setDate(d.getDate() + i);
+    const opt = document.createElement("option");
+    opt.value = d.toISOString().slice(0, 10);
+    opt.textContent =
+      i === 0 ? "Today" : i === 1 ? "Tomorrow" : days[d.getDay()];
+    dateEl.appendChild(opt);
+  }
 
-    // Default to next rounded quarter hour
-    const nextQuarter = new Date(now);
-    nextQuarter.setMinutes(Math.ceil(nextQuarter.getMinutes() / 15) * 15 + 15, 0, 0);
-    const defHr = nextQuarter.getHours();
-    const defMin = nextQuarter.getMinutes();
+  // Default to next rounded quarter hour
+  const nextQuarter = new Date(now);
+  nextQuarter.setMinutes(
+    Math.ceil(nextQuarter.getMinutes() / 15) * 15 + 15,
+    0,
+    0,
+  );
+  const defHr = nextQuarter.getHours();
+  const defMin = nextQuarter.getMinutes();
 
-    // Hour (1-12)
-    hourEl.innerHTML = '';
-    for (let h = 1; h <= 12; h++) {
-        const opt = document.createElement('option');
-        opt.value = h;
-        opt.textContent = h;
-        const match24 = defHr === 0 ? 12 : defHr > 12 ? defHr - 12 : defHr;
-        if (h === match24) opt.selected = true;
-        hourEl.appendChild(opt);
-    }
+  // Hour (1-12)
+  hourEl.innerHTML = "";
+  for (let h = 1; h <= 12; h++) {
+    const opt = document.createElement("option");
+    opt.value = h;
+    opt.textContent = h;
+    const match24 = defHr === 0 ? 12 : defHr > 12 ? defHr - 12 : defHr;
+    if (h === match24) opt.selected = true;
+    hourEl.appendChild(opt);
+  }
 
-    // Minute (00, 15, 30, 45)
-    minEl.innerHTML = '';
-    for (const m of [0, 15, 30, 45]) {
-        const opt = document.createElement('option');
-        opt.value = m;
-        opt.textContent = String(m).padStart(2, '0');
-        if (m === defMin) opt.selected = true;
-        minEl.appendChild(opt);
-    }
+  // Minute (00, 15, 30, 45)
+  minEl.innerHTML = "";
+  for (const m of [0, 15, 30, 45]) {
+    const opt = document.createElement("option");
+    opt.value = m;
+    opt.textContent = String(m).padStart(2, "0");
+    if (m === defMin) opt.selected = true;
+    minEl.appendChild(opt);
+  }
 
-    // AM/PM
-    ampmEl.innerHTML = '';
-    for (const p of ['AM', 'PM']) {
-        const opt = document.createElement('option');
-        opt.value = p;
-        opt.textContent = p;
-        if ((defHr < 12 && p === 'AM') || (defHr >= 12 && p === 'PM')) opt.selected = true;
-        ampmEl.appendChild(opt);
-    }
+  // AM/PM
+  ampmEl.innerHTML = "";
+  for (const p of ["AM", "PM"]) {
+    const opt = document.createElement("option");
+    opt.value = p;
+    opt.textContent = p;
+    if ((defHr < 12 && p === "AM") || (defHr >= 12 && p === "PM"))
+      opt.selected = true;
+    ampmEl.appendChild(opt);
+  }
 }
 
 function getScheduleTime24() {
-    let h = parseInt(document.getElementById('sched-hour')?.value) || 12;
-    const m = parseInt(document.getElementById('sched-minute')?.value) || 0;
-    const ampm = document.getElementById('sched-ampm')?.value || 'AM';
-    if (ampm === 'PM' && h < 12) h += 12;
-    if (ampm === 'AM' && h === 12) h = 0;
-    return String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0');
+  let h = parseInt(document.getElementById("sched-hour")?.value) || 12;
+  const m = parseInt(document.getElementById("sched-minute")?.value) || 0;
+  const ampm = document.getElementById("sched-ampm")?.value || "AM";
+  if (ampm === "PM" && h < 12) h += 12;
+  if (ampm === "AM" && h === 12) h = 0;
+  return String(h).padStart(2, "0") + ":" + String(m).padStart(2, "0");
 }
 
 function updateSchedulePopoverState() {
-    const pop = document.getElementById('schedule-popover');
-    if (!pop || pop.classList.contains('hidden')) return;
-    const errEl = document.getElementById('sched-pop-error');
-    const submitBtn = pop.querySelector('.sched-pop-submit');
-    const input = document.getElementById('input');
-    const text = input ? input.value.trim() : '';
-    const mentionMatches = text.match(/@(\w+)/g) || [];
-    const targets = new Set(mentionMatches.map(m => m.slice(1)));
-    for (const name of activeMentions) targets.add(name);
-    if (targets.size === 0) {
-        if (errEl) { errEl.textContent = 'Toggle an agent to set a target'; errEl.classList.remove('hidden'); }
-        if (submitBtn) { submitBtn.disabled = true; }
-    } else {
-        if (errEl) { errEl.classList.add('hidden'); errEl.textContent = ''; }
-        if (submitBtn) { submitBtn.disabled = false; }
+  const pop = document.getElementById("schedule-popover");
+  if (!pop || pop.classList.contains("hidden")) return;
+  const errEl = document.getElementById("sched-pop-error");
+  const submitBtn = pop.querySelector(".sched-pop-submit");
+  const input = document.getElementById("input");
+  const text = input ? input.value.trim() : "";
+  const mentionMatches = text.match(/@(\w+)/g) || [];
+  const targets = new Set(mentionMatches.map((m) => m.slice(1)));
+  for (const name of activeMentions) targets.add(name);
+  if (targets.size === 0) {
+    if (errEl) {
+      errEl.textContent = "Toggle an agent to set a target";
+      errEl.classList.remove("hidden");
     }
+    if (submitBtn) {
+      submitBtn.disabled = true;
+    }
+  } else {
+    if (errEl) {
+      errEl.classList.add("hidden");
+      errEl.textContent = "";
+    }
+    if (submitBtn) {
+      submitBtn.disabled = false;
+    }
+  }
 }
 
 async function submitSchedulePopover() {
-    const input = document.getElementById('input');
-    const text = input ? input.value.trim() : '';
+  const input = document.getElementById("input");
+  const text = input ? input.value.trim() : "";
 
-    // Gather targets
-    const mentionMatches = text.match(/@(\w+)/g) || [];
-    const targets = new Set(mentionMatches.map(m => m.slice(1)));
-    for (const name of activeMentions) targets.add(name);
-    let prompt = text.replace(/@\w+/g, '').trim();
+  // Gather targets
+  const mentionMatches = text.match(/@(\w+)/g) || [];
+  const targets = new Set(mentionMatches.map((m) => m.slice(1)));
+  for (const name of activeMentions) targets.add(name);
+  let prompt = text.replace(/@\w+/g, "").trim();
 
-    const errEl = document.getElementById('sched-pop-error');
+  const errEl = document.getElementById("sched-pop-error");
 
-    if (targets.size === 0) return; // button should be disabled anyway
-    if (!prompt) {
-        if (errEl) { errEl.textContent = 'Type a message first'; errEl.classList.remove('hidden'); }
-        return;
+  if (targets.size === 0) return; // button should be disabled anyway
+  if (!prompt) {
+    if (errEl) {
+      errEl.textContent = "Type a message first";
+      errEl.classList.remove("hidden");
     }
+    return;
+  }
 
-    const recurring = document.getElementById('sched-recurring')?.checked;
-    const dateVal = document.getElementById('sched-date')?.value;
-    const timeVal = getScheduleTime24();
-    const intervalVal = parseInt(document.getElementById('sched-interval-val')?.value) || 1;
-    const intervalUnit = document.getElementById('sched-interval-unit')?.value || 'hours';
+  const recurring = document.getElementById("sched-recurring")?.checked;
+  const dateVal = document.getElementById("sched-date")?.value;
+  const timeVal = getScheduleTime24();
+  const intervalVal =
+    parseInt(document.getElementById("sched-interval-val")?.value) || 1;
+  const intervalUnit =
+    document.getElementById("sched-interval-unit")?.value || "hours";
 
-    // Build spec for the API
-    let spec, confirmText;
-    if (recurring) {
-        const unitShort = intervalUnit === 'minutes' ? 'm' : intervalUnit === 'hours' ? 'h' : 'd';
-        spec = `every ${intervalVal}${unitShort}`;
-        confirmText = spec;
+  // Build spec for the API
+  let spec, confirmText;
+  if (recurring) {
+    const unitShort =
+      intervalUnit === "minutes" ? "m" : intervalUnit === "hours" ? "h" : "d";
+    spec = `every ${intervalVal}${unitShort}`;
+    confirmText = spec;
+  } else {
+    // One-shot: "daily at HH:MM" with one_shot flag
+    spec = `daily at ${timeVal}`;
+    confirmText = `${dateVal} at ${timeVal}`;
+  }
+
+  closeSchedulePopover();
+
+  try {
+    const body = {
+      prompt: prompt,
+      targets: [...targets],
+      channel: activeChannel,
+      spec: spec,
+      created_by: username,
+    };
+    if (!recurring) body.one_shot = true;
+    if (!recurring && dateVal) body.send_at_date = dateVal;
+
+    const resp = await fetch("/api/schedules", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (resp.ok) {
+      input.value = "";
+      input.style.height = "auto";
+      updateSendButton();
+      showScheduleConfirmation();
     } else {
-        // One-shot: "daily at HH:MM" with one_shot flag
-        spec = `daily at ${timeVal}`;
-        confirmText = `${dateVal} at ${timeVal}`;
+      const err = await resp.json().catch(() => ({}));
+      showSlashHint(err.error || "Failed to schedule");
     }
-
-    closeSchedulePopover();
-
-    try {
-        const body = {
-            prompt: prompt,
-            targets: [...targets],
-            channel: activeChannel,
-            spec: spec,
-            created_by: username,
-        };
-        if (!recurring) body.one_shot = true;
-        if (!recurring && dateVal) body.send_at_date = dateVal;
-
-        const resp = await fetch('/api/schedules', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Session-Token': SESSION_TOKEN,
-            },
-            body: JSON.stringify(body),
-        });
-        if (resp.ok) {
-            input.value = '';
-            input.style.height = 'auto';
-            updateSendButton();
-            showScheduleConfirmation();
-        } else {
-            const err = await resp.json().catch(() => ({}));
-            showSlashHint(err.error || 'Failed to schedule');
-        }
-    } catch (e) {
-        console.error('Failed to create schedule:', e);
-        showSlashHint('Failed to create schedule');
-    }
+  } catch (e) {
+    console.error("Failed to create schedule:", e);
+    showSlashHint("Failed to create schedule");
+  }
 }
 
 // Close popover on outside click
-document.addEventListener('click', (e) => {
-    const pop = document.getElementById('schedule-popover');
-    if (pop && !pop.classList.contains('hidden')) {
-        if (!e.target.closest('.schedule-popover') && !e.target.closest('footer')) {
-            pop.classList.add('hidden');
-        }
+document.addEventListener("click", (e) => {
+  const pop = document.getElementById("schedule-popover");
+  if (pop && !pop.classList.contains("hidden")) {
+    if (!e.target.closest(".schedule-popover") && !e.target.closest("footer")) {
+      pop.classList.add("hidden");
     }
+  }
 });
 
 // Refresh "next: Xm" countdowns every 30s
 setInterval(() => {
-    if (schedulesList.length > 0) renderSchedulesBar();
+  if (schedulesList.length > 0) renderSchedulesBar();
 }, 10000);
 
 // --- Decision card resolve (with fade animation) ---
 async function resolveDecision(msgId, choice) {
-    // Fade out buttons immediately
-    const msgEl = document.querySelector(`.message[data-id="${msgId}"]`);
-    const buttons = msgEl ? msgEl.querySelectorAll('.decision-choice') : [];
-    buttons.forEach(btn => { btn.style.opacity = '0.4'; btn.style.pointerEvents = 'none'; });
-    try {
-        const res = await fetch(`/api/messages/${msgId}/resolve_decision`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': SESSION_TOKEN },
-            body: JSON.stringify({ choice }),
-        });
-        if (!res.ok) {
-            const err = await res.json();
-            console.error('Failed to resolve decision:', err);
-            // Restore buttons on failure
-            buttons.forEach(btn => { btn.style.opacity = ''; btn.style.pointerEvents = ''; });
-        }
-    } catch (e) {
-        console.error('Decision resolve error:', e);
-        buttons.forEach(btn => { btn.style.opacity = ''; btn.style.pointerEvents = ''; });
+  // Fade out buttons immediately
+  const msgEl = document.querySelector(`.message[data-id="${msgId}"]`);
+  const buttons = msgEl ? msgEl.querySelectorAll(".decision-choice") : [];
+  buttons.forEach((btn) => {
+    btn.style.opacity = "0.4";
+    btn.style.pointerEvents = "none";
+  });
+  try {
+    const res = await fetch(`/api/messages/${msgId}/resolve_decision`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ choice }),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      console.error("Failed to resolve decision:", err);
+      // Restore buttons on failure
+      buttons.forEach((btn) => {
+        btn.style.opacity = "";
+        btn.style.pointerEvents = "";
+      });
     }
+  } catch (e) {
+    console.error("Decision resolve error:", e);
+    buttons.forEach((btn) => {
+      btn.style.opacity = "";
+      btn.style.pointerEvents = "";
+    });
+  }
 }
 window.resolveDecision = resolveDecision;
 
@@ -3579,514 +4142,548 @@ var _helpOpen = false;
 var _helpResizeTimer = null;
 
 function toggleHelp() {
-    _helpOpen ? closeHelp() : openHelp();
+  _helpOpen ? closeHelp() : openHelp();
 }
 
 // --- Card content definitions (shared between both modes) ---
 function _helpCardDefs() {
-    return [
-        {
-            id: 'hg-agents',
-            anchor: '#agent-status',
-            row: 'top',
-            html:
-            '<div class="hg-module-title">Agents <span class="hg-loc">header pills</span></div>' +
-            '<p class="hg-module-desc">The status pills in the header show who is here and what they\'re doing.</p>' +
-            '<div class="hg-mock-row">' +
-                '<div class="hg-mock-pill hg-pill-available">' +
-                    '<span class="hg-mock-dot" style="background:#f97316"></span>' +
-                    '<span style="color:#f97316">claude</span>' +
-                '</div>' +
-                '<span class="hg-mock-label">Online</span>' +
-            '</div>' +
-            '<div class="hg-mock-row">' +
-                '<div class="hg-mock-pill hg-pill-working">' +
-                    '<span class="hg-mock-dot" style="background:#4ade80"></span>' +
-                    '<span style="color:#34d399">codex</span>' +
-                '</div>' +
-                '<span class="hg-mock-label">Working &mdash; spinning border</span>' +
-            '</div>' +
-            '<div class="hg-mock-row">' +
-                '<div class="hg-mock-pill hg-pill-offline">' +
-                    '<span class="hg-mock-dot" style="background:#555"></span>' +
-                    '<span style="color:#555">gemini</span>' +
-                '</div>' +
-                '<span class="hg-mock-label">Offline</span>' +
-            '</div>' +
-            '<p class="hg-module-tip">Click any pill to rename it, assign a role, or change its colour.</p>'
-        },
-        {
-            id: 'hg-jobs',
-            anchor: '#jobs-toggle',
-            row: 'top',
-            html:
-            '<div class="hg-module-title">Jobs <span class="hg-loc">hover any message + sidebar</span></div>' +
-            '<p class="hg-module-desc">Jobs turn conversation into tracked work. Any message can become a job.</p>' +
-            '<div class="hg-mock-message">' +
-                '<div class="hg-mock-avatar" style="background:#f97316"></div>' +
-                '<div class="hg-mock-msg-body">' +
-                    '<span class="hg-mock-sender" style="color:#f97316">claude</span>' +
-                    '<span class="hg-mock-text">The auth module needs refactoring before we can add SSO support.</span>' +
-                '</div>' +
-                '<span class="hg-mock-convert-pill">convert to job</span>' +
-            '</div>' +
-            '<p class="hg-module-tip">Hover any message to see <strong>convert to job</strong>. This opens the Jobs sidebar.</p>' +
-            '<div class="hg-mock-panel">' +
-                '<div class="hg-mock-panel-header">' +
-                    '<span>Jobs sidebar</span>' +
-                    '<span class="hg-mock-panel-add">+</span>' +
-                '</div>' +
-                '<div class="hg-mock-job-card">' +
-                    '<span class="hg-mock-job-dot" style="background:#6a6a80"></span>' +
-                    '<span class="hg-mock-job-title">Auth refactor</span>' +
-                    '<div class="hg-mock-job-toggles">' +
-                        '<span class="hg-mock-toggle hg-toggle-open active">TO DO</span>' +
-                        '<span class="hg-mock-toggle hg-toggle-done">ACTIVE</span>' +
-                        '<span class="hg-mock-toggle hg-toggle-archived">CLOSED</span>' +
-                    '</div>' +
-                '</div>' +
-            '</div>' +
-            '<p class="hg-module-tip">Jobs live in the sidebar. Each one opens its own thread, and you can track it from TO DO to ACTIVE to CLOSED.</p>'
-        },
-        {
-            id: 'hg-rules',
-            anchor: '#rules-toggle',
-            row: 'top',
-            html:
-            '<div class="hg-module-title">Rules <span class="hg-loc">top-right panel</span></div>' +
-            '<p class="hg-module-desc">Rules tell agents how to work in this room. Active rules are followed automatically.</p>' +
-            '<div class="hg-mock-panel">' +
-                '<div class="hg-mock-panel-header">' +
-                    '<span>Rules</span>' +
-                    '<span class="hg-mock-panel-counter">2</span>' +
-                    '<span class="hg-mock-panel-add">+</span>' +
-                '</div>' +
-                '<div class="hg-mock-rule-card">' +
-                    '<span class="hg-mock-rule-dot draft"></span>' +
-                    '<span class="hg-mock-rule-text">Run tests before committing</span>' +
-                    '<span class="hg-mock-rule-badge">draft</span>' +
-                '</div>' +
-                '<div class="hg-mock-rule-card">' +
-                    '<span class="hg-mock-rule-dot active"></span>' +
-                    '<span class="hg-mock-rule-text">Always explain your reasoning before making changes</span>' +
-                '</div>' +
-            '</div>' +
-            '<p class="hg-module-tip"><span class="hg-mock-rule-dot active" style="display:inline-block;vertical-align:middle;margin-top:0;margin-right:4px"></span> <strong>Active</strong> = agents follow this. ' +
-            '<span class="hg-mock-rule-dot draft" style="display:inline-block;vertical-align:middle;margin-top:0;margin-left:4px;margin-right:4px"></span> <strong>Draft</strong> = not active yet. ' +
-            'You or agents can add rules.</p>'
-        },
-        {
-            id: 'hg-channels',
-            anchor: '#channel-tabs',
-            row: 'middle',
-            light: true,
-            wide: true,
-            html:
-            '<div class="hg-module-title">Channels <span class="hg-loc">top bar</span></div>' +
-            '<p class="hg-module-desc">Split conversations by topic. Each channel has its own message history.</p>' +
-            '<div class="hg-mock-channels">' +
-                '<span class="hg-mock-ch active"># general</span>' +
-                '<span class="hg-mock-ch"># design</span>' +
-                '<span class="hg-mock-ch"># backend</span>' +
-                '<span class="hg-mock-ch-add">+</span>' +
-            '</div>' +
-            '<p class="hg-module-tip">Click <strong>+</strong> to create a new channel. Agents can be mentioned in any channel.</p>'
-        },
-        {
-            id: 'hg-mentions',
-            anchor: '.mention-toggle',
-            row: 'bottom',
-            light: true,
-            html:
-            '<div class="hg-module-title">Mentions <span class="hg-loc">pills above composer</span></div>' +
-            '<p class="hg-module-desc">Type <strong>@</strong> in the composer to mention an agent. The pills above the input let you pre-select who to address. Selected agents are mentioned automatically when you send.</p>' +
-            '<p class="hg-module-tip">Mentioned agents receive a trigger and will respond in the channel.</p>'
-        },
-        {
-            id: 'hg-sessions',
-            anchor: '#session-launch-btn',
-            row: 'bottom',
-            html:
-            '<div class="hg-module-title">Sessions <span class="hg-loc">play button</span></div>' +
-            '<p class="hg-module-desc">Sessions are structured multi-agent workflows with phases and roles. Launch one to coordinate agents on a shared goal.</p>' +
-            '<div class="hg-mock-sessions">' +
-                '<div class="hg-mock-session-card">' +
-                    '<span class="hg-mock-session-icon">&#9654;</span>' +
-                    '<div class="hg-mock-session-info">' +
-                        '<span class="hg-mock-session-name">Brainstorm</span>' +
-                        '<span class="hg-mock-session-desc">Free-form idea generation with all agents</span>' +
-                    '</div>' +
-                '</div>' +
-                '<div class="hg-mock-session-card">' +
-                    '<span class="hg-mock-session-icon">&#9654;</span>' +
-                    '<div class="hg-mock-session-info">' +
-                        '<span class="hg-mock-session-name">Code Review</span>' +
-                        '<span class="hg-mock-session-desc">Structured review with phases and roles</span>' +
-                    '</div>' +
-                '</div>' +
-                '<div class="hg-mock-session-card">' +
-                    '<span class="hg-mock-session-icon">&#9654;</span>' +
-                    '<div class="hg-mock-session-info">' +
-                        '<span class="hg-mock-session-name">Design Review</span>' +
-                        '<span class="hg-mock-session-desc">Critique and iterate on design decisions</span>' +
-                    '</div>' +
-                '</div>' +
-            '</div>' +
-            '<div class="hg-custom-session">' +
-                '<strong>Custom sessions</strong> &mdash; describe a goal and agents will organise themselves into a structured workflow.' +
-            '</div>' +
-            '<p class="hg-module-tip">Click the <strong>&#9654; play button</strong> next to the composer to start.</p>'
-        },
-        {
-            id: 'hg-scheduling',
-            anchor: '#schedule-btn',
-            row: 'bottom',
-            html:
-            '<div class="hg-module-title">Scheduling <span class="hg-loc">clock button</span></div>' +
-            '<p class="hg-module-desc">Schedule any message for later delivery, or set up recurring prompts on a timer.</p>' +
-            '<div class="hg-mock-sched-entry">' +
-                '<span class="hg-sched-time">3:00 PM</span>' +
-                '<span style="flex:1;color:var(--text)">@codex check deployment status</span>' +
-                '<span class="hg-sched-recur">every 1h</span>' +
-            '</div>' +
-            '<div class="hg-mock-sched-entry">' +
-                '<span class="hg-sched-time">Tomorrow 9 AM</span>' +
-                '<span style="flex:1;color:var(--text)">@claude summarise overnight changes</span>' +
-            '</div>' +
-            '<p class="hg-module-tip">Click the <strong>&#9201; clock button</strong> next to Send to schedule a one-time or recurring message.</p>'
-        }
-    ];
+  return [
+    {
+      id: "hg-agents",
+      anchor: "#agent-status",
+      row: "top",
+      html:
+        '<div class="hg-module-title">Agents <span class="hg-loc">header pills</span></div>' +
+        '<p class="hg-module-desc">The status pills in the header show who is here and what they\'re doing.</p>' +
+        '<div class="hg-mock-row">' +
+        '<div class="hg-mock-pill hg-pill-available">' +
+        '<span class="hg-mock-dot" style="background:#f97316"></span>' +
+        '<span style="color:#f97316">claude</span>' +
+        "</div>" +
+        '<span class="hg-mock-label">Online</span>' +
+        "</div>" +
+        '<div class="hg-mock-row">' +
+        '<div class="hg-mock-pill hg-pill-working">' +
+        '<span class="hg-mock-dot" style="background:#4ade80"></span>' +
+        '<span style="color:#34d399">codex</span>' +
+        "</div>" +
+        '<span class="hg-mock-label">Working &mdash; spinning border</span>' +
+        "</div>" +
+        '<div class="hg-mock-row">' +
+        '<div class="hg-mock-pill hg-pill-offline">' +
+        '<span class="hg-mock-dot" style="background:#555"></span>' +
+        '<span style="color:#555">gemini</span>' +
+        "</div>" +
+        '<span class="hg-mock-label">Offline</span>' +
+        "</div>" +
+        '<p class="hg-module-tip">Click any pill to rename it, assign a role, or change its colour.</p>',
+    },
+    {
+      id: "hg-jobs",
+      anchor: "#jobs-toggle",
+      row: "top",
+      html:
+        '<div class="hg-module-title">Jobs <span class="hg-loc">hover any message + sidebar</span></div>' +
+        '<p class="hg-module-desc">Jobs turn conversation into tracked work. Any message can become a job.</p>' +
+        '<div class="hg-mock-message">' +
+        '<div class="hg-mock-avatar" style="background:#f97316"></div>' +
+        '<div class="hg-mock-msg-body">' +
+        '<span class="hg-mock-sender" style="color:#f97316">claude</span>' +
+        '<span class="hg-mock-text">The auth module needs refactoring before we can add SSO support.</span>' +
+        "</div>" +
+        '<span class="hg-mock-convert-pill">convert to job</span>' +
+        "</div>" +
+        '<p class="hg-module-tip">Hover any message to see <strong>convert to job</strong>. This opens the Jobs sidebar.</p>' +
+        '<div class="hg-mock-panel">' +
+        '<div class="hg-mock-panel-header">' +
+        "<span>Jobs sidebar</span>" +
+        '<span class="hg-mock-panel-add">+</span>' +
+        "</div>" +
+        '<div class="hg-mock-job-card">' +
+        '<span class="hg-mock-job-dot" style="background:#6a6a80"></span>' +
+        '<span class="hg-mock-job-title">Auth refactor</span>' +
+        '<div class="hg-mock-job-toggles">' +
+        '<span class="hg-mock-toggle hg-toggle-open active">TO DO</span>' +
+        '<span class="hg-mock-toggle hg-toggle-done">ACTIVE</span>' +
+        '<span class="hg-mock-toggle hg-toggle-archived">CLOSED</span>' +
+        "</div>" +
+        "</div>" +
+        "</div>" +
+        '<p class="hg-module-tip">Jobs live in the sidebar. Each one opens its own thread, and you can track it from TO DO to ACTIVE to CLOSED.</p>',
+    },
+    {
+      id: "hg-rules",
+      anchor: "#rules-toggle",
+      row: "top",
+      html:
+        '<div class="hg-module-title">Rules <span class="hg-loc">top-right panel</span></div>' +
+        '<p class="hg-module-desc">Rules tell agents how to work in this room. Active rules are followed automatically.</p>' +
+        '<div class="hg-mock-panel">' +
+        '<div class="hg-mock-panel-header">' +
+        "<span>Rules</span>" +
+        '<span class="hg-mock-panel-counter">2</span>' +
+        '<span class="hg-mock-panel-add">+</span>' +
+        "</div>" +
+        '<div class="hg-mock-rule-card">' +
+        '<span class="hg-mock-rule-dot draft"></span>' +
+        '<span class="hg-mock-rule-text">Run tests before committing</span>' +
+        '<span class="hg-mock-rule-badge">draft</span>' +
+        "</div>" +
+        '<div class="hg-mock-rule-card">' +
+        '<span class="hg-mock-rule-dot active"></span>' +
+        '<span class="hg-mock-rule-text">Always explain your reasoning before making changes</span>' +
+        "</div>" +
+        "</div>" +
+        '<p class="hg-module-tip"><span class="hg-mock-rule-dot active" style="display:inline-block;vertical-align:middle;margin-top:0;margin-right:4px"></span> <strong>Active</strong> = agents follow this. ' +
+        '<span class="hg-mock-rule-dot draft" style="display:inline-block;vertical-align:middle;margin-top:0;margin-left:4px;margin-right:4px"></span> <strong>Draft</strong> = not active yet. ' +
+        "You or agents can add rules.</p>",
+    },
+    {
+      id: "hg-channels",
+      anchor: "#channel-tabs",
+      row: "middle",
+      light: true,
+      wide: true,
+      html:
+        '<div class="hg-module-title">Channels <span class="hg-loc">top bar</span></div>' +
+        '<p class="hg-module-desc">Split conversations by topic. Each channel has its own message history.</p>' +
+        '<div class="hg-mock-channels">' +
+        '<span class="hg-mock-ch active"># general</span>' +
+        '<span class="hg-mock-ch"># design</span>' +
+        '<span class="hg-mock-ch"># backend</span>' +
+        '<span class="hg-mock-ch-add">+</span>' +
+        "</div>" +
+        '<p class="hg-module-tip">Click <strong>+</strong> to create a new channel. Agents can be mentioned in any channel.</p>',
+    },
+    {
+      id: "hg-mentions",
+      anchor: ".mention-toggle",
+      row: "bottom",
+      light: true,
+      html:
+        '<div class="hg-module-title">Mentions <span class="hg-loc">pills above composer</span></div>' +
+        '<p class="hg-module-desc">Type <strong>@</strong> in the composer to mention an agent. The pills above the input let you pre-select who to address. Selected agents are mentioned automatically when you send.</p>' +
+        '<p class="hg-module-tip">Mentioned agents receive a trigger and will respond in the channel.</p>',
+    },
+    {
+      id: "hg-sessions",
+      anchor: "#session-launch-btn",
+      row: "bottom",
+      html:
+        '<div class="hg-module-title">Sessions <span class="hg-loc">play button</span></div>' +
+        '<p class="hg-module-desc">Sessions are structured multi-agent workflows with phases and roles. Launch one to coordinate agents on a shared goal.</p>' +
+        '<div class="hg-mock-sessions">' +
+        '<div class="hg-mock-session-card">' +
+        '<span class="hg-mock-session-icon">&#9654;</span>' +
+        '<div class="hg-mock-session-info">' +
+        '<span class="hg-mock-session-name">Brainstorm</span>' +
+        '<span class="hg-mock-session-desc">Free-form idea generation with all agents</span>' +
+        "</div>" +
+        "</div>" +
+        '<div class="hg-mock-session-card">' +
+        '<span class="hg-mock-session-icon">&#9654;</span>' +
+        '<div class="hg-mock-session-info">' +
+        '<span class="hg-mock-session-name">Code Review</span>' +
+        '<span class="hg-mock-session-desc">Structured review with phases and roles</span>' +
+        "</div>" +
+        "</div>" +
+        '<div class="hg-mock-session-card">' +
+        '<span class="hg-mock-session-icon">&#9654;</span>' +
+        '<div class="hg-mock-session-info">' +
+        '<span class="hg-mock-session-name">Design Review</span>' +
+        '<span class="hg-mock-session-desc">Critique and iterate on design decisions</span>' +
+        "</div>" +
+        "</div>" +
+        "</div>" +
+        '<div class="hg-custom-session">' +
+        "<strong>Custom sessions</strong> &mdash; describe a goal and agents will organise themselves into a structured workflow." +
+        "</div>" +
+        '<p class="hg-module-tip">Click the <strong>&#9654; play button</strong> next to the composer to start.</p>',
+    },
+    {
+      id: "hg-scheduling",
+      anchor: "#schedule-btn",
+      row: "bottom",
+      html:
+        '<div class="hg-module-title">Scheduling <span class="hg-loc">clock button</span></div>' +
+        '<p class="hg-module-desc">Schedule any message for later delivery, or set up recurring prompts on a timer.</p>' +
+        '<div class="hg-mock-sched-entry">' +
+        '<span class="hg-sched-time">3:00 PM</span>' +
+        '<span style="flex:1;color:var(--text)">@codex check deployment status</span>' +
+        '<span class="hg-sched-recur">every 1h</span>' +
+        "</div>" +
+        '<div class="hg-mock-sched-entry">' +
+        '<span class="hg-sched-time">Tomorrow 9 AM</span>' +
+        '<span style="flex:1;color:var(--text)">@claude summarise overnight changes</span>' +
+        "</div>" +
+        '<p class="hg-module-tip">Click the <strong>&#9201; clock button</strong> next to Send to schedule a one-time or recurring message.</p>',
+    },
+  ];
 }
 
 // --- Anchored (desktop) mode ---
 function _openHelpAnchored(cardDefs) {
-    var svgNS = 'http://www.w3.org/2000/svg';
+  var svgNS = "http://www.w3.org/2000/svg";
 
-    // Main overlay container (contains everything)
-    var overlay = document.createElement('div');
-    overlay.className = 'help-guide';
-    overlay.id = 'help-guide';
+  // Main overlay container (contains everything)
+  var overlay = document.createElement("div");
+  overlay.className = "help-guide";
+  overlay.id = "help-guide";
 
-    // Backdrop (inside overlay)
-    var backdrop = document.createElement('div');
-    backdrop.className = 'hg-backdrop';
-    backdrop.addEventListener('click', closeHelp);
-    overlay.appendChild(backdrop);
+  // Backdrop (inside overlay)
+  var backdrop = document.createElement("div");
+  backdrop.className = "hg-backdrop";
+  backdrop.addEventListener("click", closeHelp);
+  overlay.appendChild(backdrop);
 
-    // SVG arrow layer (inside overlay)
-    var svg = document.createElementNS(svgNS, 'svg');
-    svg.setAttribute('class', 'hg-svg-layer');
-    svg.id = 'hg-svg-layer';
-    svg.setAttribute('width', '100%');
-    svg.setAttribute('height', '100%');
-    overlay.appendChild(svg);
+  // SVG arrow layer (inside overlay)
+  var svg = document.createElementNS(svgNS, "svg");
+  svg.setAttribute("class", "hg-svg-layer");
+  svg.id = "hg-svg-layer";
+  svg.setAttribute("width", "100%");
+  svg.setAttribute("height", "100%");
+  overlay.appendChild(svg);
 
-    // Group cards by row
-    var topCards = [], middleCards = [], bottomCards = [];
-    var cardMap = {};
-    cardDefs.forEach(function(def) {
-        cardMap[def.id] = def;
-        if (def.row === 'top') topCards.push(def);
-        else if (def.row === 'middle') middleCards.push(def);
-        else if (def.row === 'bottom') bottomCards.push(def);
+  // Group cards by row
+  var topCards = [],
+    middleCards = [],
+    bottomCards = [];
+  var cardMap = {};
+  cardDefs.forEach(function (def) {
+    cardMap[def.id] = def;
+    if (def.row === "top") topCards.push(def);
+    else if (def.row === "middle") middleCards.push(def);
+    else if (def.row === "bottom") bottomCards.push(def);
+  });
+
+  // Create the three rows
+  var topRow = document.createElement("div");
+  topRow.className = "hg-row hg-row--top";
+  topRow.id = "hg-row-top";
+
+  var middleRow = document.createElement("div");
+  middleRow.className = "hg-row hg-row--middle";
+  middleRow.id = "hg-row-middle";
+
+  var bottomRow = document.createElement("div");
+  bottomRow.className = "hg-row hg-row--bottom";
+  bottomRow.id = "hg-row-bottom";
+
+  // Track card elements + their defs for arrow drawing
+  var cardEls = [];
+
+  // Populate top row (Agents, Jobs, Rules)
+  topCards.forEach(function (def) {
+    var card = document.createElement("div");
+    card.className =
+      "hg-card" +
+      (def.light ? " hg-card--light" : "") +
+      (def.wide ? " hg-card--wide" : "");
+    card.id = def.id;
+    card.innerHTML = def.html;
+    card.addEventListener("click", function (e) {
+      e.stopPropagation();
     });
+    topRow.appendChild(card);
+    cardEls.push({ el: card, def: def });
+  });
 
-    // Create the three rows
-    var topRow = document.createElement('div');
-    topRow.className = 'hg-row hg-row--top';
-    topRow.id = 'hg-row-top';
-
-    var middleRow = document.createElement('div');
-    middleRow.className = 'hg-row hg-row--middle';
-    middleRow.id = 'hg-row-middle';
-
-    var bottomRow = document.createElement('div');
-    bottomRow.className = 'hg-row hg-row--bottom';
-    bottomRow.id = 'hg-row-bottom';
-
-    // Track card elements + their defs for arrow drawing
-    var cardEls = [];
-
-    // Populate top row (Agents, Jobs, Rules)
-    topCards.forEach(function(def) {
-        var card = document.createElement('div');
-        card.className = 'hg-card' + (def.light ? ' hg-card--light' : '') + (def.wide ? ' hg-card--wide' : '');
-        card.id = def.id;
-        card.innerHTML = def.html;
-        card.addEventListener('click', function(e) { e.stopPropagation(); });
-        topRow.appendChild(card);
-        cardEls.push({ el: card, def: def });
+  // Populate middle row (Channels)
+  middleCards.forEach(function (def) {
+    var card = document.createElement("div");
+    card.className =
+      "hg-card" +
+      (def.light ? " hg-card--light" : "") +
+      (def.wide ? " hg-card--wide" : "");
+    card.id = def.id;
+    card.innerHTML = def.html;
+    card.addEventListener("click", function (e) {
+      e.stopPropagation();
     });
+    middleRow.appendChild(card);
+    cardEls.push({ el: card, def: def });
+  });
 
-    // Populate middle row (Channels)
-    middleCards.forEach(function(def) {
-        var card = document.createElement('div');
-        card.className = 'hg-card' + (def.light ? ' hg-card--light' : '') + (def.wide ? ' hg-card--wide' : '');
-        card.id = def.id;
-        card.innerHTML = def.html;
-        card.addEventListener('click', function(e) { e.stopPropagation(); });
-        middleRow.appendChild(card);
-        cardEls.push({ el: card, def: def });
+  // Populate bottom row (Sessions, Mentions, Scheduling)
+  bottomCards.forEach(function (def) {
+    var card = document.createElement("div");
+    card.className =
+      "hg-card" +
+      (def.light ? " hg-card--light" : "") +
+      (def.wide ? " hg-card--wide" : "");
+    card.id = def.id;
+    card.innerHTML = def.html;
+    card.addEventListener("click", function (e) {
+      e.stopPropagation();
     });
+    bottomRow.appendChild(card);
+    cardEls.push({ el: card, def: def });
+  });
 
-    // Populate bottom row (Sessions, Mentions, Scheduling)
-    bottomCards.forEach(function(def) {
-        var card = document.createElement('div');
-        card.className = 'hg-card' + (def.light ? ' hg-card--light' : '') + (def.wide ? ' hg-card--wide' : '');
-        card.id = def.id;
-        card.innerHTML = def.html;
-        card.addEventListener('click', function(e) { e.stopPropagation(); });
-        bottomRow.appendChild(card);
-        cardEls.push({ el: card, def: def });
-    });
+  overlay.appendChild(topRow);
+  overlay.appendChild(middleRow);
+  overlay.appendChild(bottomRow);
 
-    overlay.appendChild(topRow);
-    overlay.appendChild(middleRow);
-    overlay.appendChild(bottomRow);
+  // Create spotlight rings on anchor elements
+  cardDefs.forEach(function (def) {
+    var anchorEl = document.querySelector(def.anchor);
+    if (!anchorEl) return;
+    var rect = anchorEl.getBoundingClientRect();
+    var spot = document.createElement("div");
+    spot.className = "hg-spotlight";
+    spot.dataset.anchor = def.anchor;
+    var pad = 4;
+    spot.style.left = rect.left - pad + "px";
+    spot.style.top = rect.top - pad + "px";
+    spot.style.width = rect.width + pad * 2 + "px";
+    spot.style.height = rect.height + pad * 2 + "px";
+    overlay.appendChild(spot);
+  });
 
-    // Create spotlight rings on anchor elements
-    cardDefs.forEach(function(def) {
-        var anchorEl = document.querySelector(def.anchor);
-        if (!anchorEl) return;
-        var rect = anchorEl.getBoundingClientRect();
-        var spot = document.createElement('div');
-        spot.className = 'hg-spotlight';
-        spot.dataset.anchor = def.anchor;
-        var pad = 4;
-        spot.style.left = (rect.left - pad) + 'px';
-        spot.style.top = (rect.top - pad) + 'px';
-        spot.style.width = (rect.width + pad * 2) + 'px';
-        spot.style.height = (rect.height + pad * 2) + 'px';
-        overlay.appendChild(spot);
-    });
+  // Dismiss hint
+  var hint = document.createElement("div");
+  hint.className = "hg-dismiss-hint";
+  hint.textContent = "Press Esc or click outside to close";
+  overlay.appendChild(hint);
 
-    // Dismiss hint
-    var hint = document.createElement('div');
-    hint.className = 'hg-dismiss-hint';
-    hint.textContent = 'Press Esc or click outside to close';
-    overlay.appendChild(hint);
+  document.body.appendChild(overlay);
 
-    document.body.appendChild(overlay);
+  // Store refs for resize handler
+  _helpCardEls = cardEls;
+  _helpMode = "anchored";
 
-    // Store refs for resize handler
-    _helpCardEls = cardEls;
-    _helpMode = 'anchored';
-
-    // Position rows and draw arrows after layout
-    requestAnimationFrame(function() {
-        _positionHelpRows();
-        _drawHelpArrows();
-    });
+  // Position rows and draw arrows after layout
+  requestAnimationFrame(function () {
+    _positionHelpRows();
+    _drawHelpArrows();
+  });
 }
 
 // --- Position rows based on real UI element positions ---
 function _positionHelpRows() {
-    var header = document.querySelector('header');
-    var channelBar = document.getElementById('channel-bar');
-    var footer = document.querySelector('footer');
+  var header = document.querySelector("header");
+  var channelBar = document.getElementById("channel-bar");
+  var footer = document.querySelector("footer");
 
-    var headerBottom = header ? header.getBoundingClientRect().bottom : 48;
-    var channelBarBottom = channelBar ? channelBar.getBoundingClientRect().bottom : headerBottom + 30;
-    var footerTop = footer ? footer.getBoundingClientRect().top : window.innerHeight - 60;
+  var headerBottom = header ? header.getBoundingClientRect().bottom : 48;
+  var channelBarBottom = channelBar
+    ? channelBar.getBoundingClientRect().bottom
+    : headerBottom + 30;
+  var footerTop = footer
+    ? footer.getBoundingClientRect().top
+    : window.innerHeight - 60;
 
-    var topRow = document.getElementById('hg-row-top');
-    var middleRow = document.getElementById('hg-row-middle');
-    var bottomRow = document.getElementById('hg-row-bottom');
+  var topRow = document.getElementById("hg-row-top");
+  var middleRow = document.getElementById("hg-row-middle");
+  var bottomRow = document.getElementById("hg-row-bottom");
 
-    // Channels first (right below channel bar)
-    if (middleRow) middleRow.style.top = (channelBarBottom + 6) + 'px';
+  // Channels first (right below channel bar)
+  if (middleRow) middleRow.style.top = channelBarBottom + 6 + "px";
 
-    // Agents/Jobs/Rules below channels card
-    if (topRow) {
-        if (middleRow) {
-            var middleBottom = middleRow.getBoundingClientRect().bottom;
-            topRow.style.top = (middleBottom + 10) + 'px';
-        } else {
-            topRow.style.top = (channelBarBottom + 6) + 'px';
-        }
+  // Agents/Jobs/Rules below channels card
+  if (topRow) {
+    if (middleRow) {
+      var middleBottom = middleRow.getBoundingClientRect().bottom;
+      topRow.style.top = middleBottom + 10 + "px";
+    } else {
+      topRow.style.top = channelBarBottom + 6 + "px";
     }
+  }
 
-    if (bottomRow) bottomRow.style.bottom = (window.innerHeight - footerTop + 6) + 'px';
+  if (bottomRow)
+    bottomRow.style.bottom = window.innerHeight - footerTop + 6 + "px";
 }
 
 // --- Draw SVG connector lines from cards to their anchors ---
 function _drawHelpArrows() {
-    var svgNS = 'http://www.w3.org/2000/svg';
-    var svg = document.getElementById('hg-svg-layer');
-    if (!svg) return;
+  var svgNS = "http://www.w3.org/2000/svg";
+  var svg = document.getElementById("hg-svg-layer");
+  if (!svg) return;
 
-    // Clear existing lines
-    while (svg.firstChild) svg.removeChild(svg.firstChild);
+  // Clear existing lines
+  while (svg.firstChild) svg.removeChild(svg.firstChild);
 
-    _helpCardEls.forEach(function(item) {
-        var cardEl = item.el;
-        var def = item.def;
-        var anchorEl = document.querySelector(def.anchor);
-        if (!anchorEl) return;
+  _helpCardEls.forEach(function (item) {
+    var cardEl = item.el;
+    var def = item.def;
+    var anchorEl = document.querySelector(def.anchor);
+    if (!anchorEl) return;
 
-        var cardRect = cardEl.getBoundingClientRect();
-        var anchorRect = anchorEl.getBoundingClientRect();
+    var cardRect = cardEl.getBoundingClientRect();
+    var anchorRect = anchorEl.getBoundingClientRect();
 
-        var cardCx = cardRect.left + cardRect.width / 2;
-        var anchorCx = anchorRect.left + anchorRect.width / 2;
+    var cardCx = cardRect.left + cardRect.width / 2;
+    var anchorCx = anchorRect.left + anchorRect.width / 2;
 
-        var lineX1, lineY1, lineX2, lineY2;
+    var lineX1, lineY1, lineX2, lineY2;
 
-        if (def.row === 'top' || def.row === 'middle') {
-            // Line from card top-center UP to anchor bottom-center
-            lineX1 = cardCx;
-            lineY1 = cardRect.top;
-            lineX2 = anchorCx;
-            lineY2 = anchorRect.bottom;
-        } else {
-            // Line from card bottom-center DOWN to anchor top-center
-            lineX1 = cardCx;
-            lineY1 = cardRect.bottom;
-            lineX2 = anchorCx;
-            lineY2 = anchorRect.top;
-        }
+    if (def.row === "top" || def.row === "middle") {
+      // Line from card top-center UP to anchor bottom-center
+      lineX1 = cardCx;
+      lineY1 = cardRect.top;
+      lineX2 = anchorCx;
+      lineY2 = anchorRect.bottom;
+    } else {
+      // Line from card bottom-center DOWN to anchor top-center
+      lineX1 = cardCx;
+      lineY1 = cardRect.bottom;
+      lineX2 = anchorCx;
+      lineY2 = anchorRect.top;
+    }
 
-        var line = document.createElementNS(svgNS, 'line');
-        line.setAttribute('x1', lineX1);
-        line.setAttribute('y1', lineY1);
-        line.setAttribute('x2', lineX2);
-        line.setAttribute('y2', lineY2);
-        svg.appendChild(line);
+    var line = document.createElementNS(svgNS, "line");
+    line.setAttribute("x1", lineX1);
+    line.setAttribute("y1", lineY1);
+    line.setAttribute("x2", lineX2);
+    line.setAttribute("y2", lineY2);
+    svg.appendChild(line);
 
-        // Dot at anchor end
-        var dot = document.createElementNS(svgNS, 'circle');
-        dot.setAttribute('cx', lineX2);
-        dot.setAttribute('cy', lineY2);
-        dot.setAttribute('r', '2.5');
-        dot.setAttribute('class', 'hg-arrow-dot');
-        svg.appendChild(dot);
-    });
+    // Dot at anchor end
+    var dot = document.createElementNS(svgNS, "circle");
+    dot.setAttribute("cx", lineX2);
+    dot.setAttribute("cy", lineY2);
+    dot.setAttribute("r", "2.5");
+    dot.setAttribute("class", "hg-arrow-dot");
+    svg.appendChild(dot);
+  });
 }
 
 // --- Stacked modal (narrow viewport) mode ---
 function _openHelpStacked(cardDefs) {
-    // Main overlay container
-    var overlay = document.createElement('div');
-    overlay.className = 'help-guide';
-    overlay.id = 'help-guide';
+  // Main overlay container
+  var overlay = document.createElement("div");
+  overlay.className = "help-guide";
+  overlay.id = "help-guide";
 
-    // Backdrop (inside overlay)
-    var backdrop = document.createElement('div');
-    backdrop.className = 'hg-backdrop';
-    backdrop.addEventListener('click', closeHelp);
-    overlay.appendChild(backdrop);
+  // Backdrop (inside overlay)
+  var backdrop = document.createElement("div");
+  backdrop.className = "hg-backdrop";
+  backdrop.addEventListener("click", closeHelp);
+  overlay.appendChild(backdrop);
 
-    var modal = document.createElement('div');
-    modal.className = 'hg-modal';
+  var modal = document.createElement("div");
+  modal.className = "hg-modal";
 
-    var content = document.createElement('div');
-    content.className = 'hg-content';
+  var content = document.createElement("div");
+  content.className = "hg-content";
 
-    // Sticky header
-    var header = document.createElement('div');
-    header.className = 'hg-modal-header';
-    header.innerHTML = '<span class="hg-modal-title">Guide</span>';
-    var closeBtn = document.createElement('button');
-    closeBtn.className = 'hg-modal-close';
-    closeBtn.innerHTML = '&times;';
-    closeBtn.addEventListener('click', closeHelp);
-    header.appendChild(closeBtn);
-    content.appendChild(header);
+  // Sticky header
+  var header = document.createElement("div");
+  header.className = "hg-modal-header";
+  header.innerHTML = '<span class="hg-modal-title">Guide</span>';
+  var closeBtn = document.createElement("button");
+  closeBtn.className = "hg-modal-close";
+  closeBtn.innerHTML = "&times;";
+  closeBtn.addEventListener("click", closeHelp);
+  header.appendChild(closeBtn);
+  content.appendChild(header);
 
-    // Card order for stacked: Agents, Jobs, Rules, Channels, Sessions, Scheduling, Mentions
-    var stackedOrder = ['hg-agents', 'hg-jobs', 'hg-rules', 'hg-channels', 'hg-sessions', 'hg-scheduling', 'hg-mentions'];
-    var cardMap = {};
-    cardDefs.forEach(function(def) { cardMap[def.id] = def; });
+  // Card order for stacked: Agents, Jobs, Rules, Channels, Sessions, Scheduling, Mentions
+  var stackedOrder = [
+    "hg-agents",
+    "hg-jobs",
+    "hg-rules",
+    "hg-channels",
+    "hg-sessions",
+    "hg-scheduling",
+    "hg-mentions",
+  ];
+  var cardMap = {};
+  cardDefs.forEach(function (def) {
+    cardMap[def.id] = def;
+  });
 
-    stackedOrder.forEach(function(id) {
-        var def = cardMap[id];
-        if (!def) return;
-        var mod = document.createElement('div');
-        mod.className = 'hg-module';
-        mod.innerHTML = def.html;
-        mod.addEventListener('click', function(e) { e.stopPropagation(); });
-        content.appendChild(mod);
+  stackedOrder.forEach(function (id) {
+    var def = cardMap[id];
+    if (!def) return;
+    var mod = document.createElement("div");
+    mod.className = "hg-module";
+    mod.innerHTML = def.html;
+    mod.addEventListener("click", function (e) {
+      e.stopPropagation();
     });
+    content.appendChild(mod);
+  });
 
-    modal.appendChild(content);
-    overlay.appendChild(modal);
-    document.body.appendChild(overlay);
+  modal.appendChild(content);
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
 
-    _helpCardEls = [];
-    _helpMode = 'stacked';
+  _helpCardEls = [];
+  _helpMode = "stacked";
 }
 
 // --- Reposition rows, spotlights, and redraw arrows on resize ---
 function _helpResizeHandler() {
-    clearTimeout(_helpResizeTimer);
-    _helpResizeTimer = setTimeout(function() {
-        if (!_helpOpen) return;
+  clearTimeout(_helpResizeTimer);
+  _helpResizeTimer = setTimeout(function () {
+    if (!_helpOpen) return;
 
-        // If viewport crossed the threshold, teardown and rebuild in the other mode
-        var shouldBeAnchored = window.innerWidth >= 900;
-        if ((_helpMode === 'anchored') !== shouldBeAnchored) {
-            closeHelp();
-            openHelp();
-            return;
-        }
+    // If viewport crossed the threshold, teardown and rebuild in the other mode
+    var shouldBeAnchored = window.innerWidth >= 900;
+    if ((_helpMode === "anchored") !== shouldBeAnchored) {
+      closeHelp();
+      openHelp();
+      return;
+    }
 
-        if (_helpMode !== 'anchored') return;
+    if (_helpMode !== "anchored") return;
 
-        // Re-measure and update row positions
-        _positionHelpRows();
+    // Re-measure and update row positions
+    _positionHelpRows();
 
-        // Reposition spotlight rings
-        var spots = document.querySelectorAll('.hg-spotlight');
-        spots.forEach(function(spot) {
-            var anchorEl = document.querySelector(spot.dataset.anchor);
-            if (!anchorEl) return;
-            var r = anchorEl.getBoundingClientRect();
-            var pad = 4;
-            spot.style.left = (r.left - pad) + 'px';
-            spot.style.top = (r.top - pad) + 'px';
-            spot.style.width = (r.width + pad * 2) + 'px';
-            spot.style.height = (r.height + pad * 2) + 'px';
-        });
+    // Reposition spotlight rings
+    var spots = document.querySelectorAll(".hg-spotlight");
+    spots.forEach(function (spot) {
+      var anchorEl = document.querySelector(spot.dataset.anchor);
+      if (!anchorEl) return;
+      var r = anchorEl.getBoundingClientRect();
+      var pad = 4;
+      spot.style.left = r.left - pad + "px";
+      spot.style.top = r.top - pad + "px";
+      spot.style.width = r.width + pad * 2 + "px";
+      spot.style.height = r.height + pad * 2 + "px";
+    });
 
-        // Redraw arrows
-        _drawHelpArrows();
-    }, 60);
+    // Redraw arrows
+    _drawHelpArrows();
+  }, 60);
 }
 
 var _helpCardEls = [];
 var _helpMode = null; // 'anchored' or 'stacked'
 
 function openHelp() {
-    closeHelp();
-    _helpOpen = true;
+  closeHelp();
+  _helpOpen = true;
 
-    var cardDefs = _helpCardDefs();
+  var cardDefs = _helpCardDefs();
 
-    if (window.innerWidth >= 900) {
-        _openHelpAnchored(cardDefs);
-    } else {
-        _openHelpStacked(cardDefs);
-    }
+  if (window.innerWidth >= 900) {
+    _openHelpAnchored(cardDefs);
+  } else {
+    _openHelpStacked(cardDefs);
+  }
 
-    document.addEventListener('keydown', _helpKeyHandler);
-    window.addEventListener('resize', _helpResizeHandler);
+  document.addEventListener("keydown", _helpKeyHandler);
+  window.addEventListener("resize", _helpResizeHandler);
 }
 
 function closeHelp() {
-    _helpOpen = false;
-    _helpCardEls = [];
-    _helpMode = null;
-    clearTimeout(_helpResizeTimer);
-    window.removeEventListener('resize', _helpResizeHandler);
-    var el = document.getElementById('help-guide');
-    if (el) el.remove();
-    // Spotlights and SVG layer are inside help-guide, so they get removed too
-    document.removeEventListener('keydown', _helpKeyHandler);
-    localStorage.setItem('help_seen', '1');
+  _helpOpen = false;
+  _helpCardEls = [];
+  _helpMode = null;
+  clearTimeout(_helpResizeTimer);
+  window.removeEventListener("resize", _helpResizeHandler);
+  var el = document.getElementById("help-guide");
+  if (el) el.remove();
+  // Spotlights and SVG layer are inside help-guide, so they get removed too
+  document.removeEventListener("keydown", _helpKeyHandler);
+  localStorage.setItem("help_seen", "1");
 }
 
 function _helpKeyHandler(e) {
-    if (e.key === 'Escape') closeHelp();
+  if (e.key === "Escape") closeHelp();
 }
 
 window.toggleHelp = toggleHelp;
@@ -4094,11 +4691,14 @@ window.closeHelp = closeHelp;
 
 // Auto-show on first visit
 function initHelpTour() {
-    if (!localStorage.getItem('help_seen')) {
-        setTimeout(openHelp, 2500);
-    }
+  if (!localStorage.getItem("help_seen")) {
+    setTimeout(openHelp, 2500);
+  }
 }
 
 // --- Start ---
 
-document.addEventListener('DOMContentLoaded', function() { init(); initHelpTour(); });
+document.addEventListener("DOMContentLoaded", function () {
+  init();
+  initHelpTour();
+});

--- a/static/chat.js
+++ b/static/chat.js
@@ -721,6 +721,12 @@ function connectWebSocket() {
     } else if (event.type === "reload") {
       // Server requests full page reload (e.g. after import)
       location.reload();
+    } else if (event.type === "agent_processes") {
+      Hub.emit("agent_processes", event);
+    } else if (event.type === "agent_log") {
+      Hub.emit("agent_log", event);
+    } else if (event.type === "session_restore") {
+      Hub.emit("session_restore", event);
     }
   };
 

--- a/static/index.html
+++ b/static/index.html
@@ -1,321 +1,732 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>agentchattr</title>
-    <link rel="stylesheet" href="/static/style.css?v=249">
-    <link rel="stylesheet" href="/static/sessions.css?v=223">
-    <link rel="stylesheet" href="/static/jobs.css?v=223">
-    <link rel="icon" href="/static/favicon.ico">
-</head>
-<body>
+    <link rel="stylesheet" href="/static/style.css?v=249" />
+    <link rel="stylesheet" href="/static/sessions.css?v=223" />
+    <link rel="stylesheet" href="/static/jobs.css?v=223" />
+    <link rel="icon" href="/static/favicon.ico" />
+    <link rel="stylesheet" href="/static/launcher.css?v=100" />
+  </head>
+  <body>
     <div id="app">
-        <header>
-            <div class="header-left">
-                <img src="/static/logo.png" alt="agentchattr" class="header-logo">
-                <h1 id="room-title">agentchattr</h1>
-                <a class="discord-pill" href="https://discord.gg/qzfn5YTT9a" target="_blank" rel="noopener" title="Join the Discord">
-                    <svg width="14" height="14" viewBox="0 0 71 55" fill="currentColor"><path d="M60.1 4.9A58.5 58.5 0 0045.4.2a.2.2 0 00-.2.1 40.8 40.8 0 00-1.8 3.7 54 54 0 00-16.2 0A37.4 37.4 0 0025.4.3a.2.2 0 00-.2-.1A58.4 58.4 0 0010.5 4.9a.2.2 0 00-.1.1C1.5 18.7-.9 32.2.3 45.5v.2a58.9 58.9 0 0017.7 9a.2.2 0 00.3-.1 42.1 42.1 0 003.6-5.9.2.2 0 00-.1-.3 38.8 38.8 0 01-5.5-2.6.2.2 0 01 0-.4l1.1-.9a.2.2 0 01.2 0 42 42 0 0035.6 0 .2.2 0 01.2 0l1.1.9a.2.2 0 010 .4 36.4 36.4 0 01-5.5 2.6.2.2 0 00-.1.3 47.2 47.2 0 003.6 5.9.2.2 0 00.3.1A58.7 58.7 0 0070.4 45.7v-.2C72 30.1 68 16.7 60.2 5a.2.2 0 00-.1-.1zM23.7 37.3c-3.5 0-6.4-3.2-6.4-7.2s2.8-7.2 6.4-7.2 6.5 3.2 6.4 7.2c0 4-2.8 7.2-6.4 7.2zm23.6 0c-3.5 0-6.4-3.2-6.4-7.2s2.8-7.2 6.4-7.2 6.5 3.2 6.4 7.2c0 4-2.9 7.2-6.4 7.2z"/></svg>
-                    Discord
-                </a>
-                <span class="subtitle" id="room-subtitle"></span>
-            </div>
-            <div class="header-right">
-                <div id="agent-status"></div>
-                <button class="settings-btn" id="jobs-toggle" onclick="toggleJobsPanel()" title="Jobs">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <rect x="3" y="2" width="10" height="12" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
-                        <path d="M6 5h4M6 8h4M6 11h2" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
-                    </svg>
-                    <span class="jobs-badge hidden" id="jobs-badge">0</span>
-                </button>
-                <button class="settings-btn" id="rules-toggle" onclick="toggleRulesPanel()" title="Rules">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" stroke-width="1.2"/>
-                        <path d="M5 8L7 10L11 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-                    </svg>
-                    <span class="rules-badge hidden" id="rules-badge">0</span>
-                </button>
-                <button class="settings-btn" id="pins-toggle" onclick="togglePinsPanel()" title="Pinned messages">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <path d="M6 2.5h4l.5 4.5H9.5L8 14L6.5 7H5.5Z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
-                        <line x1="4.5" y1="7" x2="11.5" y2="7" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
-                    </svg>
-                </button>
-                <button class="settings-btn" id="settings-toggle" onclick="toggleSettings()" title="Settings">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <path d="M6.5 1L7.1 3.1C7.4 3.2 7.7 3.4 8 3.6L10 2.8L11.5 5.4L9.8 6.7C9.8 7 9.8 7.3 9.8 7.6L11.5 8.9L10 11.5L8 10.7C7.7 10.9 7.4 11 7.1 11.2L6.5 13.3H3.5L2.9 11.2C2.6 11 2.3 10.9 2 10.7L0 11.5L-1.5 8.9L0.2 7.6C0.2 7.3 0.2 7 0.2 6.7L-1.5 5.4L0 2.8L2 3.6C2.3 3.4 2.6 3.2 2.9 3.1L3.5 1H6.5Z" transform="translate(3 1)" stroke="currentColor" stroke-width="1.2" fill="none"/>
-                        <circle cx="8" cy="8" r="2" stroke="currentColor" stroke-width="1.2" fill="none"/>
-                    </svg>
-                </button>
-                <button class="settings-btn" id="help-btn" onclick="toggleHelp()" title="Help">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.2"/>
-                        <text x="8" y="11" text-anchor="middle" fill="currentColor" font-size="9" font-weight="700">?</text>
-                    </svg>
-                </button>
-            </div>
-        </header>
+      <header>
+        <div class="header-left">
+          <img src="/static/logo.png" alt="agentchattr" class="header-logo" />
+          <h1 id="room-title">agentchattr</h1>
+          <a
+            class="discord-pill"
+            href="https://discord.gg/qzfn5YTT9a"
+            target="_blank"
+            rel="noopener"
+            title="Join the Discord"
+          >
+            <svg width="14" height="14" viewBox="0 0 71 55" fill="currentColor">
+              <path
+                d="M60.1 4.9A58.5 58.5 0 0045.4.2a.2.2 0 00-.2.1 40.8 40.8 0 00-1.8 3.7 54 54 0 00-16.2 0A37.4 37.4 0 0025.4.3a.2.2 0 00-.2-.1A58.4 58.4 0 0010.5 4.9a.2.2 0 00-.1.1C1.5 18.7-.9 32.2.3 45.5v.2a58.9 58.9 0 0017.7 9a.2.2 0 00.3-.1 42.1 42.1 0 003.6-5.9.2.2 0 00-.1-.3 38.8 38.8 0 01-5.5-2.6.2.2 0 01 0-.4l1.1-.9a.2.2 0 01.2 0 42 42 0 0035.6 0 .2.2 0 01.2 0l1.1.9a.2.2 0 010 .4 36.4 36.4 0 01-5.5 2.6.2.2 0 00-.1.3 47.2 47.2 0 003.6 5.9.2.2 0 00.3.1A58.7 58.7 0 0070.4 45.7v-.2C72 30.1 68 16.7 60.2 5a.2.2 0 00-.1-.1zM23.7 37.3c-3.5 0-6.4-3.2-6.4-7.2s2.8-7.2 6.4-7.2 6.5 3.2 6.4 7.2c0 4-2.8 7.2-6.4 7.2zm23.6 0c-3.5 0-6.4-3.2-6.4-7.2s2.8-7.2 6.4-7.2 6.5 3.2 6.4 7.2c0 4-2.9 7.2-6.4 7.2z"
+              />
+            </svg>
+            Discord
+          </a>
+          <span class="subtitle" id="room-subtitle"></span>
+        </div>
+        <div class="header-right">
+          <div id="agent-status"></div>
+          <button
+            class="settings-btn"
+            id="launcher-toggle"
+            onclick="toggleLauncherPanel()"
+            title="Agent Launcher"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <rect
+                x="2"
+                y="3"
+                width="12"
+                height="10"
+                rx="1.5"
+                stroke="currentColor"
+                stroke-width="1.2"
+              />
+              <path
+                d="M5 7l2 2-2 2"
+                stroke="currentColor"
+                stroke-width="1.2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <line
+                x1="9"
+                y1="11"
+                x2="11"
+                y2="11"
+                stroke="currentColor"
+                stroke-width="1.2"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
+          <button
+            class="settings-btn"
+            id="jobs-toggle"
+            onclick="toggleJobsPanel()"
+            title="Jobs"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <rect
+                x="3"
+                y="2"
+                width="10"
+                height="12"
+                rx="1.5"
+                stroke="currentColor"
+                stroke-width="1.2"
+              />
+              <path
+                d="M6 5h4M6 8h4M6 11h2"
+                stroke="currentColor"
+                stroke-width="1.2"
+                stroke-linecap="round"
+              />
+            </svg>
+            <span class="jobs-badge hidden" id="jobs-badge">0</span>
+          </button>
+          <button
+            class="settings-btn"
+            id="rules-toggle"
+            onclick="toggleRulesPanel()"
+            title="Rules"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <rect
+                x="2"
+                y="2"
+                width="12"
+                height="12"
+                rx="2"
+                stroke="currentColor"
+                stroke-width="1.2"
+              />
+              <path
+                d="M5 8L7 10L11 6"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                fill="none"
+              />
+            </svg>
+            <span class="rules-badge hidden" id="rules-badge">0</span>
+          </button>
+          <button
+            class="settings-btn"
+            id="pins-toggle"
+            onclick="togglePinsPanel()"
+            title="Pinned messages"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M6 2.5h4l.5 4.5H9.5L8 14L6.5 7H5.5Z"
+                stroke="currentColor"
+                stroke-width="1.2"
+                stroke-linejoin="round"
+              />
+              <line
+                x1="4.5"
+                y1="7"
+                x2="11.5"
+                y2="7"
+                stroke="currentColor"
+                stroke-width="1.2"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
+          <button
+            class="settings-btn"
+            id="settings-toggle"
+            onclick="toggleSettings()"
+            title="Settings"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M6.5 1L7.1 3.1C7.4 3.2 7.7 3.4 8 3.6L10 2.8L11.5 5.4L9.8 6.7C9.8 7 9.8 7.3 9.8 7.6L11.5 8.9L10 11.5L8 10.7C7.7 10.9 7.4 11 7.1 11.2L6.5 13.3H3.5L2.9 11.2C2.6 11 2.3 10.9 2 10.7L0 11.5L-1.5 8.9L0.2 7.6C0.2 7.3 0.2 7 0.2 6.7L-1.5 5.4L0 2.8L2 3.6C2.3 3.4 2.6 3.2 2.9 3.1L3.5 1H6.5Z"
+                transform="translate(3 1)"
+                stroke="currentColor"
+                stroke-width="1.2"
+                fill="none"
+              />
+              <circle
+                cx="8"
+                cy="8"
+                r="2"
+                stroke="currentColor"
+                stroke-width="1.2"
+                fill="none"
+              />
+            </svg>
+          </button>
+          <button
+            class="settings-btn"
+            id="help-btn"
+            onclick="toggleHelp()"
+            title="Help"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <circle
+                cx="8"
+                cy="8"
+                r="6.5"
+                stroke="currentColor"
+                stroke-width="1.2"
+              />
+              <text
+                x="8"
+                y="11"
+                text-anchor="middle"
+                fill="currentColor"
+                font-size="9"
+                font-weight="700"
+              >
+                ?
+              </text>
+            </svg>
+          </button>
+        </div>
+      </header>
 
-        <div id="settings-bar" class="hidden">
-            <div class="settings-field">
-                <label for="setting-username">Name</label>
-                <input type="text" id="setting-username" placeholder="your name" maxlength="20">
+      <div id="settings-bar" class="hidden">
+        <div class="settings-field">
+          <label for="setting-username">Name</label>
+          <input
+            type="text"
+            id="setting-username"
+            placeholder="your name"
+            maxlength="20"
+          />
+        </div>
+        <div class="settings-field">
+          <label for="setting-font">Font</label>
+          <select id="setting-font">
+            <option value="mono">Monospace</option>
+            <option value="sans">Sans</option>
+          </select>
+        </div>
+        <div class="settings-field">
+          <label for="setting-hops">Loop guard</label>
+          <div class="sched-num-wrap">
+            <input
+              type="number"
+              id="setting-hops"
+              class="sched-pop-num"
+              min="1"
+              max="50"
+              value="4"
+              title="Max agent-to-agent hops before pausing"
+            />
+            <div class="sched-num-btns">
+              <button
+                type="button"
+                onclick="stepNumInput('setting-hops', 1)"
+                tabindex="-1"
+              >
+                &#9650;
+              </button>
+              <button
+                type="button"
+                onclick="stepNumInput('setting-hops', -1)"
+                tabindex="-1"
+              >
+                &#9660;
+              </button>
             </div>
-            <div class="settings-field">
-                <label for="setting-font">Font</label>
-                <select id="setting-font">
-                    <option value="mono">Monospace</option>
-                    <option value="sans">Sans</option>
-                </select>
+          </div>
+        </div>
+        <div class="settings-field">
+          <label for="setting-history">History</label>
+          <select id="setting-history">
+            <option value="all">All</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+            <option value="200">200</option>
+            <option value="500">500</option>
+          </select>
+        </div>
+        <div class="settings-field">
+          <label for="setting-contrast">Contrast</label>
+          <select id="setting-contrast">
+            <option value="normal">Normal</option>
+            <option value="high">High</option>
+          </select>
+        </div>
+        <div class="settings-field">
+          <label for="setting-rules-refresh">Rule refresh</label>
+          <select
+            id="setting-rules-refresh"
+            title="How often to re-send active rules to agents"
+          >
+            <option value="0">On rule changes</option>
+            <option value="5">Every 5 triggers</option>
+            <option value="10" selected>Every 10 triggers</option>
+            <option value="20">Every 20 triggers</option>
+            <option value="50">Every 50 triggers</option>
+          </select>
+        </div>
+        <div class="settings-divider"></div>
+        <div class="settings-field">
+          <div id="sound-settings"></div>
+        </div>
+        <div class="settings-divider"></div>
+        <div class="settings-field">
+          <label>Project History</label>
+          <div class="settings-history-btns">
+            <button class="settings-btn" onclick="exportHistory()">
+              Export History
+            </button>
+            <button
+              class="settings-btn"
+              id="import-history-btn"
+              onclick="document.getElementById('import-file').click()"
+            >
+              Import History
+            </button>
+            <input
+              type="file"
+              id="import-file"
+              accept=".zip"
+              style="display: none"
+              onchange="importHistory(this)"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div id="pins-panel" class="hidden">
+        <div class="pins-header">
+          <span>Pinned</span>
+        </div>
+        <div id="pins-list"></div>
+      </div>
+
+      <div id="channel-bar">
+        <div class="channel-bar-left-spacer" aria-hidden="true"></div>
+        <div class="channel-main">
+          <div id="channel-tabs"></div>
+          <button
+            id="channel-add-btn"
+            class="channel-add"
+            onclick="showChannelCreateDialog()"
+            title="Add channel"
+          >
+            +
+          </button>
+        </div>
+        <div class="channel-bar-right">
+          <a
+            id="update-pill"
+            class="update-pill hidden"
+            href=""
+            target="_blank"
+            rel="noopener"
+          ></a>
+          <a
+            class="channel-support"
+            href="https://buymeacoffee.com/bcurts"
+            target="_blank"
+            rel="noopener"
+            title="Support development"
+            >&#9829;<span class="support-label"> Support development</span></a
+          >
+        </div>
+      </div>
+
+      <div id="session-bar" class="hidden">
+        <div class="session-info">
+          <span class="session-template"></span>
+          <span class="session-phase"></span>
+          <span class="session-waiting"></span>
+        </div>
+        <div id="session-end-controls" class="session-end-controls">
+          <button
+            id="session-jump-btn"
+            class="session-jump-btn hidden"
+            onclick="jumpToSessionChannel()"
+          >
+            Go to channel
+          </button>
+          <button
+            id="session-end-btn"
+            class="session-end-btn"
+            onclick="toggleEndSessionConfirm(event)"
+          >
+            End Session
+          </button>
+        </div>
+      </div>
+
+      <div id="content-area">
+        <main id="timeline">
+          <div id="loading-indicator">
+            <div class="loading-spinner"></div>
+            <span>Loading messages...</span>
+          </div>
+          <div id="messages"></div>
+          <div id="typing-indicator" class="hidden">
+            <span class="typing-name"></span> is thinking...
+          </div>
+        </main>
+        <aside id="jobs-panel" class="hidden">
+          <div class="jobs-grip" id="jobs-grip"></div>
+          <div id="jobs-list-view">
+            <div class="jobs-header">
+              <span>Jobs</span>
+              <button
+                class="jobs-create-btn"
+                onclick="showCreateJob()"
+                title="Create Job"
+              >
+                +
+              </button>
             </div>
-            <div class="settings-field">
-                <label for="setting-hops">Loop guard</label>
+            <div id="jobs-list"></div>
+          </div>
+          <div id="jobs-conversation-view" class="hidden">
+            <div class="jobs-conv-header">
+              <button class="jobs-back-btn" onclick="jobsBack()" title="Back">
+                &larr;
+              </button>
+              <span class="jobs-conv-title" id="jobs-conv-title"></span>
+              <div class="jobs-status-toggles" id="jobs-status-toggles">
+                <button
+                  class="job-toggle open"
+                  data-status="open"
+                  onclick="toggleJobStatus('open')"
+                  title="To Do"
+                >
+                  TO DO
+                </button>
+                <button
+                  class="job-toggle done"
+                  data-status="done"
+                  onclick="toggleJobStatus('done')"
+                  title="Active"
+                >
+                  ACTIVE
+                </button>
+                <button
+                  class="job-toggle archived"
+                  data-status="archived"
+                  onclick="toggleJobStatus('archived')"
+                  title="Closed"
+                >
+                  CLOSED
+                </button>
+              </div>
+            </div>
+            <div class="jobs-conv-messages" id="jobs-conv-messages"></div>
+            <div class="jobs-conv-input">
+              <div id="job-mention-menu" class="mention-menu hidden"></div>
+              <div id="job-attachments" class="job-attachments"></div>
+              <div
+                class="job-reply-target-row hidden"
+                id="job-reply-target-row"
+              >
+                <button
+                  class="job-reply-target-btn"
+                  id="job-reply-target-btn"
+                  type="button"
+                  onclick="cycleJobReplyTarget()"
+                  title="Reply target"
+                >
+                  <span class="job-reply-target-prefix">To</span>
+                  <span
+                    class="job-reply-target-dot"
+                    id="job-reply-target-dot"
+                  ></span>
+                  <span
+                    class="job-reply-target-name"
+                    id="job-reply-target-name"
+                  ></span>
+                </button>
+                <button
+                  class="job-reply-target-clear hidden"
+                  id="job-reply-target-clear"
+                  type="button"
+                  onclick="clearJobReplyTarget(event)"
+                  title="Clear reply target"
+                  aria-label="Clear reply target"
+                >
+                  &times;
+                </button>
+              </div>
+              <div class="job-input-row">
+                <textarea
+                  id="jobs-conv-input-text"
+                  placeholder="Message..."
+                  rows="1"
+                ></textarea>
+                <button onclick="sendJobMessage()">Send</button>
+              </div>
+            </div>
+          </div>
+        </aside>
+        <aside id="rules-panel" class="hidden">
+          <div class="rules-grip" id="rules-grip"></div>
+          <div class="rules-header">
+            <span>Rules</span>
+            <span class="rules-counter" id="rules-counter"></span>
+            <button class="rules-remind-btn" onclick="remindAgents()">
+              Remind agents
+            </button>
+            <button
+              class="jobs-create-btn"
+              onclick="showCreateRule()"
+              title="Add Rule"
+            >
+              +
+            </button>
+          </div>
+          <div id="rules-list"></div>
+        </aside>
+        <aside id="launcher-panel" class="hidden">
+          <div class="launcher-header">
+            <span>Agents</span>
+            <button class="add-agent-btn" onclick="toggleAddAgentForm()">
+              + Add Agent
+            </button>
+          </div>
+          <div id="launcher-list"></div>
+          <div id="add-agent-form" class="hidden"></div>
+        </aside>
+      </div>
+
+      <div id="scroll-anchor" class="hidden" onclick="scrollToBottom()">
+        <span class="unread-badge">0</span
+        ><svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M8 3v10M3 8l5 5 5-5"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </div>
+
+      <footer>
+        <div id="schedules-bar" class="hidden">
+          <div class="schedules-bar-summary">
+            <svg
+              class="schedules-icon"
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="6.5"
+                stroke="currentColor"
+                stroke-width="1.2"
+              />
+              <path
+                d="M8 4v4.5l3 1.5"
+                stroke="currentColor"
+                stroke-width="1.2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <span class="schedules-count" id="schedules-count"></span>
+            <span class="schedules-next" id="schedules-next"></span>
+            <a class="schedules-see-all" onclick="toggleSchedulesExpand()"
+              >See all</a
+            >
+          </div>
+          <div class="schedules-bar-list hidden" id="schedules-list"></div>
+        </div>
+        <div id="mention-toggles"></div>
+        <div id="slash-menu" class="hidden"></div>
+        <div id="mention-menu" class="hidden"></div>
+        <div id="attachments"></div>
+        <div id="input-row">
+          <span id="sender-label" class="sender-label">user</span>
+          <button
+            id="session-launch-btn"
+            onclick="showSessionLauncher()"
+            title="Start a session"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polygon points="5 3 19 12 5 21 5 3" />
+            </svg>
+          </button>
+          <textarea
+            id="input"
+            placeholder="Type a message... (use @name to mention agents)"
+            rows="1"
+            autofocus
+          ></textarea>
+          <button
+            id="mic"
+            type="button"
+            onmousedown="event.preventDefault()"
+            onclick="toggleVoice()"
+            title="Voice typing (local speech-to-text)"
+            aria-label="Voice typing"
+            aria-pressed="false"
+          >
+            <svg
+              id="mic-icon"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+              <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+              <line x1="12" y1="19" x2="12" y2="23" />
+              <line x1="8" y1="23" x2="16" y2="23" />
+            </svg>
+          </button>
+          <div class="send-group">
+            <button id="send" onclick="sendMessage()">Send</button>
+            <button
+              id="schedule-btn"
+              class="send-clock"
+              onclick="toggleSchedulePopover(event)"
+              title="Schedule message"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 6v6.5l4 2" />
+              </svg>
+            </button>
+          </div>
+          <div id="schedule-popover" class="schedule-popover hidden">
+            <div class="sched-pop-header">
+              <span>Schedule message</span>
+              <button class="sched-pop-close" onclick="closeSchedulePopover()">
+                &times;
+              </button>
+            </div>
+            <div class="sched-pop-body">
+              <div class="sched-pop-row">
+                <label class="sched-pop-label">When</label>
+                <select id="sched-date" class="sched-pop-select"></select>
+              </div>
+              <div class="sched-pop-row sched-time-row">
+                <label class="sched-pop-label">At</label>
+                <select
+                  id="sched-hour"
+                  class="sched-pop-select sched-pop-select-sm"
+                ></select>
+                <span class="sched-time-colon">:</span>
+                <select
+                  id="sched-minute"
+                  class="sched-pop-select sched-pop-select-sm"
+                ></select>
+                <select
+                  id="sched-ampm"
+                  class="sched-pop-select sched-pop-select-sm"
+                ></select>
+              </div>
+              <div class="sched-pop-row">
+                <label class="sched-pop-check">
+                  <input
+                    type="checkbox"
+                    id="sched-recurring"
+                    onchange="toggleRecurringFields()"
+                  />
+                  <span>Recurring</span>
+                </label>
+              </div>
+              <div
+                class="sched-pop-row sched-recurring-fields hidden"
+                id="sched-recurring-fields"
+              >
+                <label class="sched-pop-label">Every</label>
                 <div class="sched-num-wrap">
-                    <input type="number" id="setting-hops" class="sched-pop-num" min="1" max="50" value="4" title="Max agent-to-agent hops before pausing">
-                    <div class="sched-num-btns">
-                        <button type="button" onclick="stepNumInput('setting-hops',1)" tabindex="-1">&#9650;</button>
-                        <button type="button" onclick="stepNumInput('setting-hops',-1)" tabindex="-1">&#9660;</button>
-                    </div>
-                </div>
-            </div>
-            <div class="settings-field">
-                <label for="setting-history">History</label>
-                <select id="setting-history">
-                    <option value="all">All</option>
-                    <option value="25">25</option>
-                    <option value="50">50</option>
-                    <option value="100">100</option>
-                    <option value="200">200</option>
-                    <option value="500">500</option>
-                </select>
-            </div>
-            <div class="settings-field">
-                <label for="setting-contrast">Contrast</label>
-                <select id="setting-contrast">
-                    <option value="normal">Normal</option>
-                    <option value="high">High</option>
-                </select>
-            </div>
-            <div class="settings-field">
-                <label for="setting-rules-refresh">Rule refresh</label>
-                <select id="setting-rules-refresh" title="How often to re-send active rules to agents">
-                    <option value="0">On rule changes</option>
-                    <option value="5">Every 5 triggers</option>
-                    <option value="10" selected>Every 10 triggers</option>
-                    <option value="20">Every 20 triggers</option>
-                    <option value="50">Every 50 triggers</option>
-                </select>
-            </div>
-            <div class="settings-divider"></div>
-            <div class="settings-field">
-                <div id="sound-settings"></div>
-            </div>
-            <div class="settings-divider"></div>
-            <div class="settings-field">
-                <label>Project History</label>
-                <div class="settings-history-btns">
-                    <button class="settings-btn" onclick="exportHistory()">Export History</button>
-                    <button class="settings-btn" id="import-history-btn" onclick="document.getElementById('import-file').click()">Import History</button>
-                    <input type="file" id="import-file" accept=".zip" style="display:none" onchange="importHistory(this)">
-                </div>
-            </div>
-        </div>
-
-        <div id="pins-panel" class="hidden">
-            <div class="pins-header">
-                <span>Pinned</span>
-            </div>
-            <div id="pins-list"></div>
-        </div>
-
-        <div id="channel-bar">
-            <div class="channel-bar-left-spacer" aria-hidden="true"></div>
-            <div class="channel-main">
-                <div id="channel-tabs"></div>
-                <button id="channel-add-btn" class="channel-add" onclick="showChannelCreateDialog()" title="Add channel">+</button>
-            </div>
-            <div class="channel-bar-right">
-                <a id="update-pill" class="update-pill hidden" href="" target="_blank" rel="noopener"></a>
-                <a class="channel-support" href="https://buymeacoffee.com/bcurts" target="_blank" rel="noopener" title="Support development">&#9829;<span class="support-label"> Support development</span></a>
-            </div>
-        </div>
-
-        <div id="session-bar" class="hidden">
-            <div class="session-info">
-                <span class="session-template"></span>
-                <span class="session-phase"></span>
-                <span class="session-waiting"></span>
-            </div>
-            <div id="session-end-controls" class="session-end-controls">
-                <button id="session-jump-btn" class="session-jump-btn hidden" onclick="jumpToSessionChannel()">Go to channel</button>
-                <button id="session-end-btn" class="session-end-btn" onclick="toggleEndSessionConfirm(event)">End Session</button>
-            </div>
-        </div>
-
-        <div id="content-area">
-            <main id="timeline">
-                <div id="loading-indicator">
-                    <div class="loading-spinner"></div>
-                    <span>Loading messages...</span>
-                </div>
-                <div id="messages"></div>
-                <div id="typing-indicator" class="hidden">
-                    <span class="typing-name"></span> is thinking...
-                </div>
-            </main>
-            <aside id="jobs-panel" class="hidden">
-                <div class="jobs-grip" id="jobs-grip"></div>
-                <div id="jobs-list-view">
-                    <div class="jobs-header">
-                        <span>Jobs</span>
-                        <button class="jobs-create-btn" onclick="showCreateJob()" title="Create Job">+</button>
-                    </div>
-                    <div id="jobs-list"></div>
-                </div>
-                <div id="jobs-conversation-view" class="hidden">
-                    <div class="jobs-conv-header">
-                        <button class="jobs-back-btn" onclick="jobsBack()" title="Back">&larr;</button>
-                        <span class="jobs-conv-title" id="jobs-conv-title"></span>
-                        <div class="jobs-status-toggles" id="jobs-status-toggles">
-                            <button class="job-toggle open" data-status="open" onclick="toggleJobStatus('open')" title="To Do">TO DO</button>
-                            <button class="job-toggle done" data-status="done" onclick="toggleJobStatus('done')" title="Active">ACTIVE</button>
-                            <button class="job-toggle archived" data-status="archived" onclick="toggleJobStatus('archived')" title="Closed">CLOSED</button>
-                        </div>
-                    </div>
-                    <div class="jobs-conv-messages" id="jobs-conv-messages"></div>
-                    <div class="jobs-conv-input">
-                        <div id="job-mention-menu" class="mention-menu hidden"></div>
-                        <div id="job-attachments" class="job-attachments"></div>
-                        <div class="job-reply-target-row hidden" id="job-reply-target-row">
-                            <button class="job-reply-target-btn" id="job-reply-target-btn" type="button" onclick="cycleJobReplyTarget()" title="Reply target">
-                                <span class="job-reply-target-prefix">To</span>
-                                <span class="job-reply-target-dot" id="job-reply-target-dot"></span>
-                                <span class="job-reply-target-name" id="job-reply-target-name"></span>
-                            </button>
-                            <button class="job-reply-target-clear hidden" id="job-reply-target-clear" type="button" onclick="clearJobReplyTarget(event)" title="Clear reply target" aria-label="Clear reply target">&times;</button>
-                        </div>
-                        <div class="job-input-row">
-                            <textarea id="jobs-conv-input-text" placeholder="Message..." rows="1"></textarea>
-                            <button onclick="sendJobMessage()">Send</button>
-                        </div>
-                    </div>
-                </div>
-            </aside>
-            <aside id="rules-panel" class="hidden">
-                <div class="rules-grip" id="rules-grip"></div>
-                <div class="rules-header">
-                    <span>Rules</span>
-                    <span class="rules-counter" id="rules-counter"></span>
-                    <button class="rules-remind-btn" onclick="remindAgents()">Remind agents</button>
-                    <button class="jobs-create-btn" onclick="showCreateRule()" title="Add Rule">+</button>
-                </div>
-                <div id="rules-list"></div>
-            </aside>
-        </div>
-
-        <div id="scroll-anchor" class="hidden" onclick="scrollToBottom()"><span class="unread-badge">0</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M8 3v10M3 8l5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></div>
-
-        <footer>
-            <div id="schedules-bar" class="hidden">
-                <div class="schedules-bar-summary">
-                    <svg class="schedules-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
-                        <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.2"/>
-                        <path d="M8 4v4.5l3 1.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                    <span class="schedules-count" id="schedules-count"></span>
-                    <span class="schedules-next" id="schedules-next"></span>
-                    <a class="schedules-see-all" onclick="toggleSchedulesExpand()">See all</a>
-                </div>
-                <div class="schedules-bar-list hidden" id="schedules-list"></div>
-            </div>
-            <div id="mention-toggles"></div>
-            <div id="slash-menu" class="hidden"></div>
-            <div id="mention-menu" class="hidden"></div>
-            <div id="attachments"></div>
-            <div id="input-row">
-                <span id="sender-label" class="sender-label">user</span>
-                <button id="session-launch-btn" onclick="showSessionLauncher()" title="Start a session">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <polygon points="5 3 19 12 5 21 5 3"/>
-                    </svg>
-                </button>
-                <textarea id="input"
-                    placeholder="Type a message... (use @name to mention agents)"
-                    rows="1"
-                    autofocus></textarea>
-                <button id="mic" type="button" onmousedown="event.preventDefault()" onclick="toggleVoice()" title="Voice typing (local speech-to-text)" aria-label="Voice typing" aria-pressed="false">
-                    <svg id="mic-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/>
-                        <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
-                        <line x1="12" y1="19" x2="12" y2="23"/>
-                        <line x1="8" y1="23" x2="16" y2="23"/>
-                    </svg>
-                </button>
-                <div class="send-group">
-                    <button id="send" onclick="sendMessage()">Send</button>
-                    <button id="schedule-btn" class="send-clock" onclick="toggleSchedulePopover(event)" title="Schedule message">
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
-                            <circle cx="12" cy="12" r="10"/>
-                            <path d="M12 6v6.5l4 2"/>
-                        </svg>
+                  <input
+                    type="number"
+                    id="sched-interval-val"
+                    class="sched-pop-num"
+                    value="1"
+                    min="1"
+                    max="99"
+                  />
+                  <div class="sched-num-btns">
+                    <button
+                      type="button"
+                      onclick="stepSchedNum(1)"
+                      tabindex="-1"
+                    >
+                      &#9650;
                     </button>
+                    <button
+                      type="button"
+                      onclick="stepSchedNum(-1)"
+                      tabindex="-1"
+                    >
+                      &#9660;
+                    </button>
+                  </div>
                 </div>
-                <div id="schedule-popover" class="schedule-popover hidden">
-                    <div class="sched-pop-header">
-                        <span>Schedule message</span>
-                        <button class="sched-pop-close" onclick="closeSchedulePopover()">&times;</button>
-                    </div>
-                    <div class="sched-pop-body">
-                        <div class="sched-pop-row">
-                            <label class="sched-pop-label">When</label>
-                            <select id="sched-date" class="sched-pop-select"></select>
-                        </div>
-                        <div class="sched-pop-row sched-time-row">
-                            <label class="sched-pop-label">At</label>
-                            <select id="sched-hour" class="sched-pop-select sched-pop-select-sm"></select>
-                            <span class="sched-time-colon">:</span>
-                            <select id="sched-minute" class="sched-pop-select sched-pop-select-sm"></select>
-                            <select id="sched-ampm" class="sched-pop-select sched-pop-select-sm"></select>
-                        </div>
-                        <div class="sched-pop-row">
-                            <label class="sched-pop-check">
-                                <input type="checkbox" id="sched-recurring" onchange="toggleRecurringFields()">
-                                <span>Recurring</span>
-                            </label>
-                        </div>
-                        <div class="sched-pop-row sched-recurring-fields hidden" id="sched-recurring-fields">
-                            <label class="sched-pop-label">Every</label>
-                            <div class="sched-num-wrap">
-                                <input type="number" id="sched-interval-val" class="sched-pop-num" value="1" min="1" max="99">
-                                <div class="sched-num-btns">
-                                    <button type="button" onclick="stepSchedNum(1)" tabindex="-1">&#9650;</button>
-                                    <button type="button" onclick="stepSchedNum(-1)" tabindex="-1">&#9660;</button>
-                                </div>
-                            </div>
-                            <select id="sched-interval-unit" class="sched-pop-select">
-                                <option value="minutes">minutes</option>
-                                <option value="hours" selected>hours</option>
-                                <option value="days">days</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="sched-pop-error hidden" id="sched-pop-error"></div>
-                    <div class="sched-pop-footer">
-                        <button class="sched-pop-cancel" onclick="closeSchedulePopover()">Cancel</button>
-                        <button class="sched-pop-submit" onclick="submitSchedulePopover()">Schedule</button>
-                    </div>
-                </div>
+                <select id="sched-interval-unit" class="sched-pop-select">
+                  <option value="minutes">minutes</option>
+                  <option value="hours" selected>hours</option>
+                  <option value="days">days</option>
+                </select>
+              </div>
             </div>
-            <div class="input-hint">
-                Enter to send &middot; Shift+Enter for newline &middot; Paste/drop images &middot; Mic for voice &middot; Type / or @ for autocomplete
+            <div class="sched-pop-error hidden" id="sched-pop-error"></div>
+            <div class="sched-pop-footer">
+              <button class="sched-pop-cancel" onclick="closeSchedulePopover()">
+                Cancel
+              </button>
+              <button
+                class="sched-pop-submit"
+                onclick="submitSchedulePopover()"
+              >
+                Schedule
+              </button>
             </div>
-        </footer>
+          </div>
+        </div>
+        <div class="input-hint">
+          Enter to send &middot; Shift+Enter for newline &middot; Paste/drop
+          images &middot; Mic for voice &middot; Type / or @ for autocomplete
+        </div>
+      </footer>
     </div>
 
     <div id="dropzone" class="hidden">
-        <div class="dropzone-inner">Drop image here</div>
+      <div class="dropzone-inner">Drop image here</div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -325,6 +736,7 @@
     <script src="/static/jobs.js?v=224"></script>
     <script src="/static/channels.js?v=224"></script>
     <script src="/static/rules-panel.js?v=223"></script>
+    <script src="/static/launcher.js?v=100"></script>
     <script src="/static/chat.js?v=266"></script>
-</body>
+  </body>
 </html>

--- a/static/jobs.js
+++ b/static/jobs.js
@@ -7,7 +7,7 @@
  * Owns all job state, rendering, and interaction logic.
  * Subscribes to Hub for WS events.
  *
- * Reads from window: activeChannel, username, SESSION_TOKEN, ws,
+ * Reads from window: activeChannel, username, ws,
  *                    agentConfig, escapeHtml, getColor, renderMarkdown,
  *                    getMentionCandidates, openImageModal,
  *                    _lastMentionedAgent, _preserveScroll, startReply,
@@ -35,7 +35,7 @@ let _draggedJobId = null;
 let _draggedJobStatus = null;
 let _pendingJobReflowTops = null;
 let _pendingJobReflowTimer = null;
-const _expandedGroups = new Set(['open']); // track which collapsible groups are open across re-renders
+const _expandedGroups = new Set(["open"]); // track which collapsible groups are open across re-renders
 
 // ---------------------------------------------------------------------------
 // Message Renderers
@@ -45,20 +45,20 @@ const _expandedGroups = new Set(['open']); // track which collapsible groups are
 
 if (!window._messageRenderers) window._messageRenderers = {};
 
-window._messageRenderers['job_created'] = function (el, msg) {
-    el.classList.add('system-msg', 'job-breadcrumb');
-    const actId = msg.metadata?.job_id;
-    if (actId && !jobsData.some(a => a.id === actId)) {
-        el.style.display = 'none';
-        el.dataset.hiddenReason = 'no-job-data';
-    }
-    if (actId) {
-        el.innerHTML = `<span class="job-breadcrumb-link" onclick="openJobFromBreadcrumb(${actId})" title="Open job">
+window._messageRenderers["job_created"] = function (el, msg) {
+  el.classList.add("system-msg", "job-breadcrumb");
+  const actId = msg.metadata?.job_id;
+  if (actId && !jobsData.some((a) => a.id === actId)) {
+    el.style.display = "none";
+    el.dataset.hiddenReason = "no-job-data";
+  }
+  if (actId) {
+    el.innerHTML = `<span class="job-breadcrumb-link" onclick="openJobFromBreadcrumb(${actId})" title="Open job">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:-2px;margin-right:4px;opacity:0.6"><rect x="2" y="1" width="5" height="7" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/><rect x="9" y="8" width="5" height="7" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
-            New job: <em>${window.escapeHtml(msg.text.replace('Job created: ', ''))}</em></span>`;
-    } else {
-        el.innerHTML = `<span class="msg-text">${window.escapeHtml(msg.text)}</span>`;
-    }
+            New job: <em>${window.escapeHtml(msg.text.replace("Job created: ", ""))}</em></span>`;
+  } else {
+    el.innerHTML = `<span class="msg-text">${window.escapeHtml(msg.text)}</span>`;
+  }
 };
 
 // ---------------------------------------------------------------------------
@@ -66,89 +66,94 @@ window._messageRenderers['job_created'] = function (el, msg) {
 // ---------------------------------------------------------------------------
 
 function _unhideResolvedBreadcrumbs() {
-    // After jobsData is populated (e.g. from WS 'jobs' event), unhide any
-    // breadcrumbs that were hidden during history replay because jobsData
-    // was still empty when the job_created message was rendered.
-    // Only targets elements with data-hidden-reason="no-job-data" to avoid
-    // unhiding off-channel breadcrumbs hidden by the channel filter.
-    const validIds = new Set(jobsData.map(a => a.id));
-    document.querySelectorAll('.job-breadcrumb[data-hidden-reason="no-job-data"]').forEach(el => {
-        const link = el.querySelector('.job-breadcrumb-link');
-        if (!link) return;
-        const onclick = link.getAttribute('onclick') || '';
-        const m = onclick.match(/openJobFromBreadcrumb\((\d+)\)/);
-        if (m && validIds.has(Number(m[1]))) {
-            el.style.display = '';
-            delete el.dataset.hiddenReason;
-        }
+  // After jobsData is populated (e.g. from WS 'jobs' event), unhide any
+  // breadcrumbs that were hidden during history replay because jobsData
+  // was still empty when the job_created message was rendered.
+  // Only targets elements with data-hidden-reason="no-job-data" to avoid
+  // unhiding off-channel breadcrumbs hidden by the channel filter.
+  const validIds = new Set(jobsData.map((a) => a.id));
+  document
+    .querySelectorAll('.job-breadcrumb[data-hidden-reason="no-job-data"]')
+    .forEach((el) => {
+      const link = el.querySelector(".job-breadcrumb-link");
+      if (!link) return;
+      const onclick = link.getAttribute("onclick") || "";
+      const m = onclick.match(/openJobFromBreadcrumb\((\d+)\)/);
+      if (m && validIds.has(Number(m[1]))) {
+        el.style.display = "";
+        delete el.dataset.hiddenReason;
+      }
     });
 }
 
 function _collapseJobBreadcrumbs(container, newEl) {
-    // Collect consecutive job-breadcrumb elements ending with newEl
-    const crumbs = [newEl];
-    let prev = newEl.previousElementSibling;
-    let existingGroup = null;
-    while (prev) {
-        if (prev.classList.contains('job-breadcrumb')) {
-            crumbs.unshift(prev);
-            prev = prev.previousElementSibling;
-        } else if (prev.classList.contains('job-group')) {
-            // Already a collapsed group — absorb its children
-            existingGroup = prev;
-            const inner = [...prev.querySelectorAll('.job-breadcrumb')];
-            inner.forEach(c => crumbs.unshift(c));
-            prev = prev.previousElementSibling;
-            existingGroup.remove();
-            break;
-        } else {
-            break;
-        }
+  // Collect consecutive job-breadcrumb elements ending with newEl
+  const crumbs = [newEl];
+  let prev = newEl.previousElementSibling;
+  let existingGroup = null;
+  while (prev) {
+    if (prev.classList.contains("job-breadcrumb")) {
+      crumbs.unshift(prev);
+      prev = prev.previousElementSibling;
+    } else if (prev.classList.contains("job-group")) {
+      // Already a collapsed group — absorb its children
+      existingGroup = prev;
+      const inner = [...prev.querySelectorAll(".job-breadcrumb")];
+      inner.forEach((c) => crumbs.unshift(c));
+      prev = prev.previousElementSibling;
+      existingGroup.remove();
+      break;
+    } else {
+      break;
     }
+  }
 
-    if (crumbs.length < 2) return; // nothing to collapse
+  if (crumbs.length < 2) return; // nothing to collapse
 
-    // Remember insertion point (the element after the last crumb = newEl)
-    const insertBefore = newEl.nextSibling;
+  // Remember insertion point (the element after the last crumb = newEl)
+  const insertBefore = newEl.nextSibling;
 
-    // Build the group wrapper
-    const group = document.createElement('div');
-    group.className = 'job-group';
-    const summary = document.createElement('div');
-    summary.className = 'job-group-summary';
-    summary.innerHTML = `<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:-2px;margin-right:4px;opacity:0.6"><rect x="2" y="1" width="5" height="7" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/><rect x="9" y="8" width="5" height="7" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>${crumbs.length} jobs were started`;
-    summary.onclick = () => {
-        group.classList.toggle('expanded');
-    };
-    group.appendChild(summary);
+  // Build the group wrapper
+  const group = document.createElement("div");
+  group.className = "job-group";
+  const summary = document.createElement("div");
+  summary.className = "job-group-summary";
+  summary.innerHTML = `<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:-2px;margin-right:4px;opacity:0.6"><rect x="2" y="1" width="5" height="7" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/><rect x="9" y="8" width="5" height="7" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>${crumbs.length} jobs were started`;
+  summary.onclick = () => {
+    group.classList.toggle("expanded");
+  };
+  group.appendChild(summary);
 
-    const list = document.createElement('div');
-    list.className = 'job-group-list';
-    for (const c of crumbs) {
-        list.appendChild(c); // moves from container into list
-    }
-    group.appendChild(list);
+  const list = document.createElement("div");
+  list.className = "job-group-list";
+  for (const c of crumbs) {
+    list.appendChild(c); // moves from container into list
+  }
+  group.appendChild(list);
 
-    // Insert group at the position where the crumbs were
-    container.insertBefore(group, insertBefore);
+  // Insert group at the position where the crumbs were
+  container.insertBefore(group, insertBefore);
 }
 
 function _repairJobGroup(group) {
-    if (!group || !group.classList.contains('job-group')) return;
-    const listEl = group.querySelector('.job-group-list');
-    const remaining = listEl ? listEl.querySelectorAll('.job-breadcrumb') : [];
-    if (remaining.length === 0) {
-        group.remove();
-    } else if (remaining.length === 1) {
-        // Unwrap single breadcrumb out of the group
-        group.replaceWith(remaining[0]);
-    } else {
-        // Update the count text
-        const summary = group.querySelector('.job-group-summary');
-        if (summary) {
-            summary.innerHTML = summary.innerHTML.replace(/\d+ jobs were started/, `${remaining.length} jobs were started`);
-        }
+  if (!group || !group.classList.contains("job-group")) return;
+  const listEl = group.querySelector(".job-group-list");
+  const remaining = listEl ? listEl.querySelectorAll(".job-breadcrumb") : [];
+  if (remaining.length === 0) {
+    group.remove();
+  } else if (remaining.length === 1) {
+    // Unwrap single breadcrumb out of the group
+    group.replaceWith(remaining[0]);
+  } else {
+    // Update the count text
+    const summary = group.querySelector(".job-group-summary");
+    if (summary) {
+      summary.innerHTML = summary.innerHTML.replace(
+        /\d+ jobs were started/,
+        `${remaining.length} jobs were started`,
+      );
     }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -156,42 +161,45 @@ function _repairJobGroup(group) {
 // ---------------------------------------------------------------------------
 
 function setupJobsGrip() {
-    const grip = document.getElementById('jobs-grip');
-    const panel = document.getElementById('jobs-panel');
-    if (!grip || !panel) return;
+  const grip = document.getElementById("jobs-grip");
+  const panel = document.getElementById("jobs-panel");
+  if (!grip || !panel) return;
 
-    let dragging = false;
-    let startX = 0;
-    let startWidth = 0;
+  let dragging = false;
+  let startX = 0;
+  let startWidth = 0;
 
-    grip.addEventListener('mousedown', (e) => {
-        e.preventDefault();
-        dragging = true;
-        startX = e.clientX;
-        startWidth = panel.offsetWidth;
-        grip.classList.add('dragging');
-        panel.style.transition = 'none';
-        document.body.style.cursor = 'col-resize';
-        document.body.style.userSelect = 'none';
-    });
+  grip.addEventListener("mousedown", (e) => {
+    e.preventDefault();
+    dragging = true;
+    startX = e.clientX;
+    startWidth = panel.offsetWidth;
+    grip.classList.add("dragging");
+    panel.style.transition = "none";
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  });
 
-    document.addEventListener('mousemove', (e) => {
-        if (!dragging) return;
-        const delta = startX - e.clientX;
-        const newWidth = Math.min(Math.max(startWidth + delta, 260), window.innerWidth * 0.5);
-        panel.style.setProperty('--panel-w', newWidth + 'px');
-        panel.style.width = newWidth + 'px';
-        panel.style.minWidth = newWidth + 'px';
-    });
+  document.addEventListener("mousemove", (e) => {
+    if (!dragging) return;
+    const delta = startX - e.clientX;
+    const newWidth = Math.min(
+      Math.max(startWidth + delta, 260),
+      window.innerWidth * 0.5,
+    );
+    panel.style.setProperty("--panel-w", newWidth + "px");
+    panel.style.width = newWidth + "px";
+    panel.style.minWidth = newWidth + "px";
+  });
 
-    document.addEventListener('mouseup', () => {
-        if (!dragging) return;
-        dragging = false;
-        grip.classList.remove('dragging');
-        panel.style.transition = '';
-        document.body.style.cursor = '';
-        document.body.style.userSelect = '';
-    });
+  document.addEventListener("mouseup", () => {
+    if (!dragging) return;
+    dragging = false;
+    grip.classList.remove("dragging");
+    panel.style.transition = "";
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -199,24 +207,24 @@ function setupJobsGrip() {
 // ---------------------------------------------------------------------------
 
 function setupJobsInput() {
-    const input = document.getElementById('jobs-conv-input-text');
-    if (!input) return;
-    input.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' && !e.shiftKey && !jobMentionVisible) {
-            e.preventDefault();
-            sendJobMessage();
-            return;
-        }
-        if (e.key === 'Tab' && !jobMentionVisible && activeJobId) {
-            e.preventDefault();
-            cycleJobReplyTarget(e.shiftKey ? -1 : 1);
-        }
-    });
-    // Auto-grow
-    input.addEventListener('input', () => {
-        input.style.height = 'auto';
-        input.style.height = Math.min(input.scrollHeight, 120) + 'px';
-    });
+  const input = document.getElementById("jobs-conv-input-text");
+  if (!input) return;
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey && !jobMentionVisible) {
+      e.preventDefault();
+      sendJobMessage();
+      return;
+    }
+    if (e.key === "Tab" && !jobMentionVisible && activeJobId) {
+      e.preventDefault();
+      cycleJobReplyTarget(e.shiftKey ? -1 : 1);
+    }
+  });
+  // Auto-grow
+  input.addEventListener("input", () => {
+    input.style.height = "auto";
+    input.style.height = Math.min(input.scrollHeight, 120) + "px";
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -224,135 +232,140 @@ function setupJobsInput() {
 // ---------------------------------------------------------------------------
 
 function getJobRecipientOptions() {
-    const opts = [];
-    for (const [name, cfg] of Object.entries(window.agentConfig)) {
-        if (cfg.state === 'pending') continue;
-        opts.push({
-            name,
-            label: cfg.label || name,
-            color: cfg.color || 'var(--accent)',
-        });
-    }
-    return opts;
+  const opts = [];
+  for (const [name, cfg] of Object.entries(window.agentConfig)) {
+    if (cfg.state === "pending") continue;
+    opts.push({
+      name,
+      label: cfg.label || name,
+      color: cfg.color || "var(--accent)",
+    });
+  }
+  return opts;
 }
 
 function _normalizeJobRecipient(name, options = null) {
-    if (!name) return '';
-    const opts = options || getJobRecipientOptions();
-    const wanted = String(name).toLowerCase();
-    const hit = opts.find(o => o.name.toLowerCase() === wanted);
-    return hit ? hit.name : '';
+  if (!name) return "";
+  const opts = options || getJobRecipientOptions();
+  const wanted = String(name).toLowerCase();
+  const hit = opts.find((o) => o.name.toLowerCase() === wanted);
+  return hit ? hit.name : "";
 }
 
 function _extractJobMentionTargets(text) {
-    if (!text) return [];
-    const opts = getJobRecipientOptions();
-    if (opts.length === 0) return [];
-    const byLower = {};
-    for (const o of opts) byLower[o.name.toLowerCase()] = o.name;
-    const hits = [];
-    const re = /@([a-zA-Z][\w-]*)/g;
-    let m;
-    while ((m = re.exec(text)) !== null) {
-        const key = m[1].toLowerCase();
-        const canonical = byLower[key];
-        if (canonical && !hits.includes(canonical)) hits.push(canonical);
-    }
-    return hits;
+  if (!text) return [];
+  const opts = getJobRecipientOptions();
+  if (opts.length === 0) return [];
+  const byLower = {};
+  for (const o of opts) byLower[o.name.toLowerCase()] = o.name;
+  const hits = [];
+  const re = /@([a-zA-Z][\w-]*)/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const key = m[1].toLowerCase();
+    const canonical = byLower[key];
+    if (canonical && !hits.includes(canonical)) hits.push(canonical);
+  }
+  return hits;
 }
 
 function resolveJobDefaultRecipient(job, messages = []) {
-    const opts = getJobRecipientOptions();
-    if (opts.length === 0) return '';
-    const hasStored = job && Object.prototype.hasOwnProperty.call(jobReplyTargets, job.id);
-    if (hasStored) {
-        const stored = jobReplyTargets[job.id];
-        if (stored === null) return '';
-        const normalized = _normalizeJobRecipient(stored, opts);
-        if (normalized) return normalized;
-    }
+  const opts = getJobRecipientOptions();
+  if (opts.length === 0) return "";
+  const hasStored =
+    job && Object.prototype.hasOwnProperty.call(jobReplyTargets, job.id);
+  if (hasStored) {
+    const stored = jobReplyTargets[job.id];
+    if (stored === null) return "";
+    const normalized = _normalizeJobRecipient(stored, opts);
+    if (normalized) return normalized;
+  }
 
-    // New/empty jobs should start un-targeted.
-    if (!messages || messages.length === 0) return '';
+  // New/empty jobs should start un-targeted.
+  if (!messages || messages.length === 0) return "";
 
-    // For active threads with history, infer from last non-self agent sender.
-    for (let i = messages.length - 1; i >= 0; i--) {
-        const sender = String(messages[i]?.sender || '');
-        if (!sender || sender.toLowerCase() === window.username.toLowerCase()) continue;
-        const normalized = _normalizeJobRecipient(sender, opts);
-        if (normalized) return normalized;
-    }
+  // For active threads with history, infer from last non-self agent sender.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const sender = String(messages[i]?.sender || "");
+    if (!sender || sender.toLowerCase() === window.username.toLowerCase())
+      continue;
+    const normalized = _normalizeJobRecipient(sender, opts);
+    if (normalized) return normalized;
+  }
 
-    // Fallback to assignee if present and valid.
-    const assignee = _normalizeJobRecipient(job?.assignee || '', opts);
-    if (assignee) return assignee;
-    return '';
+  // Fallback to assignee if present and valid.
+  const assignee = _normalizeJobRecipient(job?.assignee || "", opts);
+  if (assignee) return assignee;
+  return "";
 }
 
 function updateJobReplyTargetUI() {
-    const row = document.getElementById('job-reply-target-row');
-    const btn = document.getElementById('job-reply-target-btn');
-    const dot = document.getElementById('job-reply-target-dot');
-    const nameEl = document.getElementById('job-reply-target-name');
-    const clearBtn = document.getElementById('job-reply-target-clear');
-    if (!row || !btn || !dot || !nameEl || !clearBtn) return;
-    if (!activeJobId) {
-        row.classList.add('hidden');
-        return;
+  const row = document.getElementById("job-reply-target-row");
+  const btn = document.getElementById("job-reply-target-btn");
+  const dot = document.getElementById("job-reply-target-dot");
+  const nameEl = document.getElementById("job-reply-target-name");
+  const clearBtn = document.getElementById("job-reply-target-clear");
+  if (!row || !btn || !dot || !nameEl || !clearBtn) return;
+  if (!activeJobId) {
+    row.classList.add("hidden");
+    return;
+  }
+  const opts = getJobRecipientOptions();
+  if (opts.length === 0) {
+    row.classList.add("hidden");
+    return;
+  }
+  const hasStored = Object.prototype.hasOwnProperty.call(
+    jobReplyTargets,
+    activeJobId,
+  );
+  let selected = null;
+  if (hasStored) {
+    const stored = jobReplyTargets[activeJobId];
+    if (stored !== null) {
+      const normalized = _normalizeJobRecipient(stored, opts);
+      selected = opts.find((o) => o.name === normalized) || null;
     }
-    const opts = getJobRecipientOptions();
-    if (opts.length === 0) {
-        row.classList.add('hidden');
-        return;
-    }
-    const hasStored = Object.prototype.hasOwnProperty.call(jobReplyTargets, activeJobId);
-    let selected = null;
-    if (hasStored) {
-        const stored = jobReplyTargets[activeJobId];
-        if (stored !== null) {
-            const normalized = _normalizeJobRecipient(stored, opts);
-            selected = opts.find(o => o.name === normalized) || null;
-        }
-    }
-    if (!selected && hasStored && jobReplyTargets[activeJobId] !== null) {
-        jobReplyTargets[activeJobId] = null;
-    }
-    if (selected) {
-        dot.style.background = selected.color || 'var(--accent)';
-        nameEl.textContent = selected.label || selected.name;
-        btn.title = `Reply target: ${selected.label || selected.name} (Tab to cycle)`;
-    } else {
-        nameEl.textContent = 'none';
-        btn.title = 'Reply target: none (Tab to choose)';
-    }
-    btn.classList.toggle('no-target', !selected);
-    clearBtn.classList.toggle('hidden', !selected);
-    row.classList.remove('hidden');
+  }
+  if (!selected && hasStored && jobReplyTargets[activeJobId] !== null) {
+    jobReplyTargets[activeJobId] = null;
+  }
+  if (selected) {
+    dot.style.background = selected.color || "var(--accent)";
+    nameEl.textContent = selected.label || selected.name;
+    btn.title = `Reply target: ${selected.label || selected.name} (Tab to cycle)`;
+  } else {
+    nameEl.textContent = "none";
+    btn.title = "Reply target: none (Tab to choose)";
+  }
+  btn.classList.toggle("no-target", !selected);
+  clearBtn.classList.toggle("hidden", !selected);
+  row.classList.remove("hidden");
 }
 
 function cycleJobReplyTarget(step = 1) {
-    if (!activeJobId) return;
-    const opts = getJobRecipientOptions();
-    if (opts.length === 0) return;
-    const current = _normalizeJobRecipient(jobReplyTargets[activeJobId], opts);
-    let idx = opts.findIndex(o => o.name === current);
-    if (idx < 0) {
-        idx = step < 0 ? opts.length - 1 : 0;
-    } else {
-        idx = (idx + step + opts.length) % opts.length;
-    }
-    jobReplyTargets[activeJobId] = opts[idx].name;
-    updateJobReplyTargetUI();
-    document.getElementById('jobs-conv-input-text')?.focus();
+  if (!activeJobId) return;
+  const opts = getJobRecipientOptions();
+  if (opts.length === 0) return;
+  const current = _normalizeJobRecipient(jobReplyTargets[activeJobId], opts);
+  let idx = opts.findIndex((o) => o.name === current);
+  if (idx < 0) {
+    idx = step < 0 ? opts.length - 1 : 0;
+  } else {
+    idx = (idx + step + opts.length) % opts.length;
+  }
+  jobReplyTargets[activeJobId] = opts[idx].name;
+  updateJobReplyTargetUI();
+  document.getElementById("jobs-conv-input-text")?.focus();
 }
 
 function clearJobReplyTarget(event) {
-    event?.preventDefault?.();
-    event?.stopPropagation?.();
-    if (!activeJobId) return;
-    jobReplyTargets[activeJobId] = null;
-    updateJobReplyTargetUI();
-    document.getElementById('jobs-conv-input-text')?.focus();
+  event?.preventDefault?.();
+  event?.stopPropagation?.();
+  if (!activeJobId) return;
+  jobReplyTargets[activeJobId] = null;
+  updateJobReplyTargetUI();
+  document.getElementById("jobs-conv-input-text")?.focus();
 }
 
 // ---------------------------------------------------------------------------
@@ -360,38 +373,40 @@ function clearJobReplyTarget(event) {
 // ---------------------------------------------------------------------------
 
 function toggleJobsPanel() {
-    window._preserveScroll(() => {
-        const panel = document.getElementById('jobs-panel');
-        panel.classList.toggle('hidden');
-        document.getElementById('jobs-toggle').classList.toggle('active', !panel.classList.contains('hidden'));
-        if (!panel.classList.contains('hidden')) {
-            // Return to list view if we were in conversation view
-            showJobsListView();
-            renderJobsList();
-        }
-    });
+  window._preserveScroll(() => {
+    const panel = document.getElementById("jobs-panel");
+    panel.classList.toggle("hidden");
+    document
+      .getElementById("jobs-toggle")
+      .classList.toggle("active", !panel.classList.contains("hidden"));
+    if (!panel.classList.contains("hidden")) {
+      // Return to list view if we were in conversation view
+      showJobsListView();
+      renderJobsList();
+    }
+  });
 }
 
 function _animateJobViewSwitch(exitView, enterView, direction, onDone) {
-    // No animation — instant swap
-    if (exitView) exitView.classList.add('hidden');
-    if (enterView) enterView.classList.remove('hidden');
-    if (onDone) onDone();
+  // No animation — instant swap
+  if (exitView) exitView.classList.add("hidden");
+  if (enterView) enterView.classList.remove("hidden");
+  if (onDone) onDone();
 }
 
 function showJobsListView(onDone) {
-    const listView = document.getElementById('jobs-list-view');
-    const convView = document.getElementById('jobs-conversation-view');
-    activeJobId = null;
-    updateJobReplyTargetUI();
-    if (!convView.classList.contains('hidden')) {
-        _animateJobViewSwitch(convView, listView, 'back', onDone);
-    } else {
-        listView.classList.remove('hidden');
-        convView.classList.add('hidden');
-        _jobViewSwitching = false;
-        if (onDone) onDone();
-    }
+  const listView = document.getElementById("jobs-list-view");
+  const convView = document.getElementById("jobs-conversation-view");
+  activeJobId = null;
+  updateJobReplyTargetUI();
+  if (!convView.classList.contains("hidden")) {
+    _animateJobViewSwitch(convView, listView, "back", onDone);
+  } else {
+    listView.classList.remove("hidden");
+    convView.classList.add("hidden");
+    _jobViewSwitching = false;
+    if (onDone) onDone();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -399,130 +414,138 @@ function showJobsListView(onDone) {
 // ---------------------------------------------------------------------------
 
 function _jobSortValue(a) {
-    const raw = Number(a?.sort_order);
-    return Number.isFinite(raw) ? raw : 0;
+  const raw = Number(a?.sort_order);
+  return Number.isFinite(raw) ? raw : 0;
 }
 
 function _compareJobsForList(a, b) {
-    const byOrder = _jobSortValue(b) - _jobSortValue(a);
-    if (byOrder !== 0) return byOrder;
-    return (b.updated_at || 0) - (a.updated_at || 0);
+  const byOrder = _jobSortValue(b) - _jobSortValue(a);
+  if (byOrder !== 0) return byOrder;
+  return (b.updated_at || 0) - (a.updated_at || 0);
 }
 
 function _clearJobReorderTargets(container) {
-    if (!container) return;
-    container.querySelectorAll('.reorder-target-before, .reorder-target-after').forEach((el) => {
-        el.classList.remove('reorder-target-before', 'reorder-target-after');
+  if (!container) return;
+  container
+    .querySelectorAll(".reorder-target-before, .reorder-target-after")
+    .forEach((el) => {
+      el.classList.remove("reorder-target-before", "reorder-target-after");
     });
 }
 
 function _orderedIdsForJobGroup(status) {
-    return jobsData
-        .filter(a => a.status === status)
-        .sort(_compareJobsForList)
-        .map(a => Number(a.id));
+  return jobsData
+    .filter((a) => a.status === status)
+    .sort(_compareJobsForList)
+    .map((a) => Number(a.id));
 }
 
 function _applyLocalJobOrder(status, orderedIds) {
-    const n = orderedIds.length;
-    const byId = new Map();
-    orderedIds.forEach((id, idx) => byId.set(Number(id), n - idx));
-    for (const a of jobsData) {
-        if (a.status !== status) continue;
-        const nextOrder = byId.get(Number(a.id));
-        if (nextOrder != null) a.sort_order = nextOrder;
-    }
+  const n = orderedIds.length;
+  const byId = new Map();
+  orderedIds.forEach((id, idx) => byId.set(Number(id), n - idx));
+  for (const a of jobsData) {
+    if (a.status !== status) continue;
+    const nextOrder = byId.get(Number(a.id));
+    if (nextOrder != null) a.sort_order = nextOrder;
+  }
 }
 
 function _isJobsListVisible() {
-    const panel = document.getElementById('jobs-panel');
-    return Boolean(panel && !panel.classList.contains('hidden') && !activeJobId);
+  const panel = document.getElementById("jobs-panel");
+  return Boolean(panel && !panel.classList.contains("hidden") && !activeJobId);
 }
 
-function _beginJobReorderMute({ ids = [], channel = window.activeChannel, status = null, durationMs = 650 } = {}) {
-    const muteIds = new Set(
-        (ids || []).map(id => Number(id)).filter(id => Number.isFinite(id))
-    );
-    if (muteIds.size === 0) return;
-    const ttl = Math.max(180, Number(durationMs) || 0);
-    if (jobReorderMuteTimer) clearTimeout(jobReorderMuteTimer);
-    jobReorderMute = {
-        ids: muteIds,
-        channel,
-        status,
-        until: Date.now() + ttl,
-        suppressed: false,
-    };
-    jobReorderMuteTimer = setTimeout(() => {
-        const muted = jobReorderMute;
-        jobReorderMute = null;
-        jobReorderMuteTimer = null;
-        if (muted && muted.suppressed && _isJobsListVisible()) {
-            renderJobsList();
-        }
-    }, ttl);
+function _beginJobReorderMute({
+  ids = [],
+  channel = window.activeChannel,
+  status = null,
+  durationMs = 650,
+} = {}) {
+  const muteIds = new Set(
+    (ids || []).map((id) => Number(id)).filter((id) => Number.isFinite(id)),
+  );
+  if (muteIds.size === 0) return;
+  const ttl = Math.max(180, Number(durationMs) || 0);
+  if (jobReorderMuteTimer) clearTimeout(jobReorderMuteTimer);
+  jobReorderMute = {
+    ids: muteIds,
+    channel,
+    status,
+    until: Date.now() + ttl,
+    suppressed: false,
+  };
+  jobReorderMuteTimer = setTimeout(() => {
+    const muted = jobReorderMute;
+    jobReorderMute = null;
+    jobReorderMuteTimer = null;
+    if (muted && muted.suppressed && _isJobsListVisible()) {
+      renderJobsList();
+    }
+  }, ttl);
 }
 
 function _shouldSuppressJobUpdateRender(data) {
-    if (!jobReorderMute || !data) return false;
-    if (Date.now() > jobReorderMute.until) {
-        if (jobReorderMuteTimer) {
-            clearTimeout(jobReorderMuteTimer);
-            jobReorderMuteTimer = null;
-        }
-        jobReorderMute = null;
-        return false;
+  if (!jobReorderMute || !data) return false;
+  if (Date.now() > jobReorderMute.until) {
+    if (jobReorderMuteTimer) {
+      clearTimeout(jobReorderMuteTimer);
+      jobReorderMuteTimer = null;
     }
-    const id = Number(data.id);
-    if (!Number.isFinite(id) || !jobReorderMute.ids.has(id)) return false;
-    if (jobReorderMute.status && data.status !== jobReorderMute.status) return false;
-    jobReorderMute.suppressed = true;
-    return true;
+    jobReorderMute = null;
+    return false;
+  }
+  const id = Number(data.id);
+  if (!Number.isFinite(id) || !jobReorderMute.ids.has(id)) return false;
+  if (jobReorderMute.status && data.status !== jobReorderMute.status)
+    return false;
+  jobReorderMute.suppressed = true;
+  return true;
 }
 
 async function _persistJobOrder(status, orderedIds) {
-    const resp = await fetch('/api/jobs/reorder', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-        body: JSON.stringify({ status, ordered_ids: orderedIds }),
-    });
-    if (!resp.ok) {
-        throw new Error(`Failed to persist order: ${resp.status}`);
-    }
+  const resp = await fetch("/api/jobs/reorder", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ status, ordered_ids: orderedIds }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Failed to persist order: ${resp.status}`);
+  }
 }
 
 async function reorderJobWithinGroup(status, draggedId, targetId, insertAfter) {
-    const ordered = _orderedIdsForJobGroup(status);
-    const from = ordered.indexOf(Number(draggedId));
-    const to = ordered.indexOf(Number(targetId));
-    if (from < 0 || to < 0 || from === to) return;
+  const ordered = _orderedIdsForJobGroup(status);
+  const from = ordered.indexOf(Number(draggedId));
+  const to = ordered.indexOf(Number(targetId));
+  if (from < 0 || to < 0 || from === to) return;
 
-    const [moved] = ordered.splice(from, 1);
-    let insertAt = to + (insertAfter ? 1 : 0);
-    if (from < insertAt) insertAt -= 1;
-    ordered.splice(insertAt, 0, moved);
+  const [moved] = ordered.splice(from, 1);
+  let insertAt = to + (insertAfter ? 1 : 0);
+  if (from < insertAt) insertAt -= 1;
+  ordered.splice(insertAt, 0, moved);
 
-    _beginJobReorderMute({ ids: ordered, status });
-    _applyLocalJobOrder(status, ordered);
-    _flipRenderJobs();
+  _beginJobReorderMute({ ids: ordered, status });
+  _applyLocalJobOrder(status, ordered);
+  _flipRenderJobs();
+  try {
+    await _persistJobOrder(status, ordered);
+  } catch (err) {
+    console.error(err);
+    // Reload canonical state from server on failure.
     try {
-        await _persistJobOrder(status, ordered);
-    } catch (err) {
-        console.error(err);
-        // Reload canonical state from server on failure.
-        try {
-            const resp = await fetch('/api/jobs', {
-                headers: { 'X-Session-Token': window.SESSION_TOKEN },
-            });
-            if (resp.ok) {
-                jobsData = await resp.json();
-                syncJobUnreadCache();
-                renderJobsList();
-            }
-        } catch (reloadErr) {
-            console.error('Failed to reload jobs after reorder failure:', reloadErr);
-        }
+      const resp = await fetch("/api/jobs", {});
+      if (resp.ok) {
+        jobsData = await resp.json();
+        syncJobUnreadCache();
+        renderJobsList();
+      }
+    } catch (reloadErr) {
+      console.error("Failed to reload jobs after reorder failure:", reloadErr);
     }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -530,34 +553,34 @@ async function reorderJobWithinGroup(status, draggedId, targetId, insertAfter) {
 // ---------------------------------------------------------------------------
 
 function _flushPendingJobReflow() {
-    if (!_pendingJobReflowTops) return;
-    const tops = _pendingJobReflowTops;
-    _pendingJobReflowTops = null;
-    animateJobListReflow(tops);
+  if (!_pendingJobReflowTops) return;
+  const tops = _pendingJobReflowTops;
+  _pendingJobReflowTops = null;
+  animateJobListReflow(tops);
 }
 
 function _flipRenderJobs() {
-    const prevTops = captureJobCardTops();
-    const scrollContainer = document.getElementById('jobs-list-view');
-    const scrollY = scrollContainer ? scrollContainer.scrollTop : 0;
+  const prevTops = captureJobCardTops();
+  const scrollContainer = document.getElementById("jobs-list-view");
+  const scrollY = scrollContainer ? scrollContainer.scrollTop : 0;
 
-    renderJobsList();
+  renderJobsList();
 
-    if (scrollContainer) scrollContainer.scrollTop = scrollY;
+  if (scrollContainer) scrollContainer.scrollTop = scrollY;
 
-    // During HTML5 drag lifecycle, some browsers suppress paint/transition work.
-    // Queue reflow animation until dragend for reliable visual playback.
-    if (_draggedJobId) {
-        if (!_pendingJobReflowTops) _pendingJobReflowTops = prevTops;
-        if (_pendingJobReflowTimer) clearTimeout(_pendingJobReflowTimer);
-        // Fallback in case dragend does not fire (e.g. source node replaced).
-        _pendingJobReflowTimer = setTimeout(() => {
-            _pendingJobReflowTimer = null;
-            _flushPendingJobReflow();
-        }, 120);
-        return;
-    }
-    animateJobListReflow(prevTops);
+  // During HTML5 drag lifecycle, some browsers suppress paint/transition work.
+  // Queue reflow animation until dragend for reliable visual playback.
+  if (_draggedJobId) {
+    if (!_pendingJobReflowTops) _pendingJobReflowTops = prevTops;
+    if (_pendingJobReflowTimer) clearTimeout(_pendingJobReflowTimer);
+    // Fallback in case dragend does not fire (e.g. source node replaced).
+    _pendingJobReflowTimer = setTimeout(() => {
+      _pendingJobReflowTimer = null;
+      _flushPendingJobReflow();
+    }, 120);
+    return;
+  }
+  animateJobListReflow(prevTops);
 }
 
 // ---------------------------------------------------------------------------
@@ -565,310 +588,385 @@ function _flipRenderJobs() {
 // ---------------------------------------------------------------------------
 
 function renderJobsList() {
-    const list = document.getElementById('jobs-list');
-    if (!list) return;
-    // Preserve in-progress create form across re-renders (save focus state)
-    const activeForm = list.querySelector('.job-create-form');
-    let savedForm = null, savedFocusSelector = null, savedSelStart = 0, savedSelEnd = 0;
-    if (activeForm) {
-        const focused = document.activeElement;
-        if (focused && activeForm.contains(focused)) {
-            savedFocusSelector = focused.tagName.toLowerCase() + (focused.className ? '.' + focused.className.split(' ')[0] : '');
-            savedSelStart = focused.selectionStart || 0;
-            savedSelEnd = focused.selectionEnd || 0;
-        }
-        savedForm = activeForm.parentNode.removeChild(activeForm);
+  const list = document.getElementById("jobs-list");
+  if (!list) return;
+  // Preserve in-progress create form across re-renders (save focus state)
+  const activeForm = list.querySelector(".job-create-form");
+  let savedForm = null,
+    savedFocusSelector = null,
+    savedSelStart = 0,
+    savedSelEnd = 0;
+  if (activeForm) {
+    const focused = document.activeElement;
+    if (focused && activeForm.contains(focused)) {
+      savedFocusSelector =
+        focused.tagName.toLowerCase() +
+        (focused.className ? "." + focused.className.split(" ")[0] : "");
+      savedSelStart = focused.selectionStart || 0;
+      savedSelEnd = focused.selectionEnd || 0;
     }
-    list.innerHTML = '';
+    savedForm = activeForm.parentNode.removeChild(activeForm);
+  }
+  list.innerHTML = "";
 
-    // Jobs are global — show all regardless of channel
-    const channelJobs = jobsData;
+  // Jobs are global — show all regardless of channel
+  const channelJobs = jobsData;
 
-    // Group by status: open first, then done, then archived
-    const groups = [
-        { key: 'open', label: 'TO DO', items: [] },
-        { key: 'done', label: 'ACTIVE', items: [] },
-        { key: 'archived', label: 'CLOSED', items: [] },
-    ];
-    for (const a of channelJobs) {
-        const g = groups.find(g => g.key === a.status);
-        if (g) g.items.push(a);
-    }
+  // Group by status: open first, then done, then archived
+  const groups = [
+    { key: "open", label: "TO DO", items: [] },
+    { key: "done", label: "ACTIVE", items: [] },
+    { key: "archived", label: "CLOSED", items: [] },
+  ];
+  for (const a of channelJobs) {
+    const g = groups.find((g) => g.key === a.status);
+    if (g) g.items.push(a);
+  }
 
-    // Ghost card only when there are zero jobs total
-    if (channelJobs.length === 0) {
-        const ghost = document.createElement('div');
-        ghost.className = 'sb-ghost-card';
-        ghost.innerHTML = `
+  // Ghost card only when there are zero jobs total
+  if (channelJobs.length === 0) {
+    const ghost = document.createElement("div");
+    ghost.className = "sb-ghost-card";
+    ghost.innerHTML = `
             <div class="sb-ghost-title">Create your first job</div>
             <div class="sb-ghost-meta">Track work items with threaded conversations. Use @mentions to loop in agents.</div>
         `;
-        ghost.onclick = () => {
-            const btn = document.querySelector('.jobs-create-btn');
-            if (btn) btn.click();
-        };
-        list.appendChild(ghost);
+    ghost.onclick = () => {
+      const btn = document.querySelector(".jobs-create-btn");
+      if (btn) btn.click();
+    };
+    list.appendChild(ghost);
+  }
+
+  for (const group of groups) {
+    // Sort by explicit manual order first; fallback to recency.
+    group.items.sort(_compareJobsForList);
+
+    const isCollapsible = group.key === "open" || group.key === "archived";
+    const isExpanded = _expandedGroups.has(group.key);
+    const isCollapsed = isCollapsible && !isExpanded;
+    const header = document.createElement("div");
+    header.className =
+      "jobs-group-header " +
+      group.key +
+      (isCollapsible ? " collapsible" : "") +
+      (isCollapsed ? " collapsed" : "");
+    header.dataset.status = group.key;
+    const isEmpty = group.items.length === 0;
+    header.textContent = isEmpty
+      ? group.label
+      : `${group.label} (${group.items.length})`;
+    if (isEmpty) header.classList.add("empty-group");
+    if (isCollapsible) {
+      header.onclick = () => {
+        header.classList.toggle("collapsed");
+        const container = header.nextElementSibling;
+        if (container) container.classList.toggle("collapsed");
+        if (header.classList.contains("collapsed")) {
+          _expandedGroups.delete(group.key);
+        } else {
+          _expandedGroups.add(group.key);
+        }
+      };
     }
 
-    for (const group of groups) {
-        // Sort by explicit manual order first; fallback to recency.
-        group.items.sort(_compareJobsForList);
-
-        const isCollapsible = group.key === 'open' || group.key === 'archived';
-        const isExpanded = _expandedGroups.has(group.key);
-        const isCollapsed = isCollapsible && !isExpanded;
-        const header = document.createElement('div');
-        header.className = 'jobs-group-header ' + group.key + (isCollapsible ? ' collapsible' : '') + (isCollapsed ? ' collapsed' : '');
-        header.dataset.status = group.key;
-        const isEmpty = group.items.length === 0;
-        header.textContent = isEmpty ? group.label : `${group.label} (${group.items.length})`;
-        if (isEmpty) header.classList.add('empty-group');
-        if (isCollapsible) {
-            header.onclick = () => {
-                header.classList.toggle('collapsed');
-                const container = header.nextElementSibling;
-                if (container) container.classList.toggle('collapsed');
-                if (header.classList.contains('collapsed')) {
-                    _expandedGroups.delete(group.key);
-                } else {
-                    _expandedGroups.add(group.key);
-                }
-            };
-        }
-
-        // Drop target: drag a card from another group onto this header to change its status
-        header.addEventListener('dragover', (e) => {
-            if (!_draggedJobId || _draggedJobStatus === group.key) return;
-            e.preventDefault();
-            header.classList.add('drop-target');
+    // Drop target: drag a card from another group onto this header to change its status
+    header.addEventListener("dragover", (e) => {
+      if (!_draggedJobId || _draggedJobStatus === group.key) return;
+      e.preventDefault();
+      header.classList.add("drop-target");
+    });
+    header.addEventListener("dragleave", () => {
+      header.classList.remove("drop-target");
+    });
+    header.addEventListener("drop", async (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      header.classList.remove("drop-target");
+      const draggedId = _draggedJobId;
+      if (!draggedId || _draggedJobStatus === group.key) return;
+      const oldStatus = _draggedJobStatus;
+      try {
+        await fetch(`/api/jobs/${draggedId}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ status: group.key }),
         });
-        header.addEventListener('dragleave', () => {
-            header.classList.remove('drop-target');
+        const act = jobsData.find((a) => String(a.id) === String(draggedId));
+        _beginJobReorderMute({
+          ids: [draggedId],
+          channel: window.activeChannel,
+          status: group.key,
         });
-        header.addEventListener('drop', async (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            header.classList.remove('drop-target');
-            const draggedId = _draggedJobId;
-            if (!draggedId || _draggedJobStatus === group.key) return;
-            const oldStatus = _draggedJobStatus;
-            try {
-                await fetch(`/api/jobs/${draggedId}`, {
-                    method: 'PATCH',
-                    headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-                    body: JSON.stringify({ status: group.key }),
-                });
-                const act = jobsData.find(a => String(a.id) === String(draggedId));
-                _beginJobReorderMute({ ids: [draggedId], channel: window.activeChannel, status: group.key });
-                if (act) act.status = group.key;
-                _flipRenderJobs();
+        if (act) act.status = group.key;
+        _flipRenderJobs();
+      } catch (err) {
+        console.error("Failed to change status:", err);
+      }
+    });
 
-            } catch (err) { console.error('Failed to change status:', err); }
-        });
+    list.appendChild(header);
 
-        list.appendChild(header);
+    // Wrap group items in a container for collapsing (CSS grid animation)
+    const itemsContainer = document.createElement("div");
+    itemsContainer.className =
+      "jobs-group-items" + (isCollapsed ? " collapsed" : "");
+    const itemsInner = document.createElement("div");
+    itemsInner.className = "jobs-group-items-inner";
 
-        // Wrap group items in a container for collapsing (CSS grid animation)
-        const itemsContainer = document.createElement('div');
-        itemsContainer.className = 'jobs-group-items' + (isCollapsed ? ' collapsed' : '');
-        const itemsInner = document.createElement('div');
-        itemsInner.className = 'jobs-group-items-inner';
+    for (const a of group.items) {
+      const card = document.createElement("div");
+      card.className = "job-card";
+      card.dataset.id = a.id;
+      card.onclick = () => openJobConversation(a.id);
+      card.addEventListener("selectstart", (e) => e.preventDefault());
 
-        for (const a of group.items) {
-            const card = document.createElement('div');
-            card.className = 'job-card';
-            card.dataset.id = a.id;
-            card.onclick = () => openJobConversation(a.id);
-            card.addEventListener('selectstart', (e) => e.preventDefault());
+      const msgCount = (a.messages || []).filter((m) => !m?.deleted).length;
+      const unread = jobUnread[a.id] || 0;
 
-            const msgCount = (a.messages || []).filter(m => !m?.deleted).length;
-            const unread = jobUnread[a.id] || 0;
+      const unreadHtml =
+        unread > 0
+          ? `<span class="job-unread-dot" title="Unread messages">${unread > 99 ? "99+" : unread}</span>`
+          : "";
 
-            const unreadHtml = unread > 0
-                ? `<span class="job-unread-dot" title="Unread messages">${unread > 99 ? '99+' : unread}</span>`
-                : '';
-
-            card.innerHTML = `
+      card.innerHTML = `
                 <div class="job-card-header">
                     <span class="job-status-dot ${a.status}"></span>
                     <span class="job-title">${window.escapeHtml(a.title)}</span>
-                    <span class="job-msg-count">${msgCount > 0 ? msgCount : ''}</span>
+                    <span class="job-msg-count">${msgCount > 0 ? msgCount : ""}</span>
                     ${unreadHtml}
                 </div>
             `;
 
-
-            card.draggable = true;
-            card.addEventListener('dragstart', (e) => {
-                let ids = [card.dataset.id];
-                if (group.key === 'archived') {
-                    const selected = [...itemsContainer.querySelectorAll('.archive-selected')].map(c => c.dataset.id);
-                    // If dragging one of the selected cards, drag the whole selection.
-                    if (selected.length > 0 && selected.includes(card.dataset.id)) {
-                        ids = selected;
-                    }
-                }
-
-                _draggedJobId = card.dataset.id;
-                _draggedJobStatus = group.key;
-
-                e.dataTransfer.setData('application/x-job-id', String(card.dataset.id));
-                e.dataTransfer.setData('application/x-job-status', group.key);
-                e.dataTransfer.setData('application/x-job-multi', ids.length > 1 ? '1' : '0');
-                e.dataTransfer.setData('application/x-archive-ids', JSON.stringify(ids));
-                e.dataTransfer.effectAllowed = 'move';
-
-                card.classList.add('reorder-dragging');
-                if (group.key === 'archived') {
-                    card.classList.remove('archive-holding');
-                    document.body.classList.add('archive-no-select');
-                    ids.forEach(id => {
-                        const el = itemsContainer.querySelector(`.job-card[data-id="${id}"]`);
-                        if (el) el.classList.add('archive-dragging');
-                    });
-                    itemsContainer.classList.add('archive-drag-active');
-
-                    const trash = itemsContainer.querySelector('.archive-trash-zone');
-                    if (trash) {
-                        trash.classList.add('drop-ready');
-                        const hint = trash.querySelector('.archive-trash-hint');
-                        if (hint) hint.textContent = ids.length > 1 ? `Drop to delete ${ids.length} jobs` : 'Drop to delete job';
-                    }
-                } else {
-                    itemsContainer.classList.add('job-reorder-active');
-                }
-            });
-            card.addEventListener('dragover', (e) => {
-                if (_draggedJobStatus !== group.key || !_draggedJobId || _draggedJobId === card.dataset.id) return;
-                e.preventDefault();
-                // Clear all other indicators first, then set this one
-                _clearJobReorderTargets(itemsContainer);
-                const rect = card.getBoundingClientRect();
-                const before = e.clientY < rect.top + rect.height / 2;
-                card.classList.toggle('reorder-target-before', before);
-                card.classList.toggle('reorder-target-after', !before);
-            });
-            card.addEventListener('drop', async (e) => {
-                const draggedId = _draggedJobId;
-                const draggedStatus = _draggedJobStatus;
-                _clearJobReorderTargets(itemsContainer);
-                if (!draggedStatus || draggedStatus !== group.key || !draggedId) return;
-                if (draggedId === card.dataset.id) return;
-                e.preventDefault();
-                e.stopPropagation();
-                const rect = card.getBoundingClientRect();
-                const insertAfter = e.clientY >= rect.top + rect.height / 2;
-                await reorderJobWithinGroup(group.key, draggedId, card.dataset.id, insertAfter);
-            });
-            card.addEventListener('dragend', () => {
-                _draggedJobId = null;
-                _draggedJobStatus = null;
-                document.body.classList.remove('archive-no-select');
-                card.classList.remove('reorder-dragging');
-                itemsContainer.classList.remove('job-reorder-active', 'archive-drag-active');
-                itemsContainer.querySelectorAll('.archive-dragging').forEach(c => c.classList.remove('archive-dragging'));
-                _clearJobReorderTargets(itemsContainer);
-                const trash = itemsContainer.querySelector('.archive-trash-zone');
-                if (trash) {
-                    trash.classList.remove('drop-ready', 'hover');
-                    updateArchiveTrashHint(itemsContainer);
-                }
-                if (_pendingJobReflowTimer) {
-                    clearTimeout(_pendingJobReflowTimer);
-                    _pendingJobReflowTimer = null;
-                }
-                _flushPendingJobReflow();
-            });
-
-            // Archived cards: shift+click for multi-select
-            if (group.key === 'archived') {
-                card.classList.add('archive-selectable');
-                const clearHoldState = () => card.classList.remove('archive-holding');
-                card.addEventListener('pointerdown', (e) => {
-                    if (e.button !== 0) return;
-                    card.classList.add('archive-holding');
-                });
-                card.addEventListener('pointerup', clearHoldState);
-                card.addEventListener('pointercancel', clearHoldState);
-                card.addEventListener('mouseleave', clearHoldState);
-                const origOnclick = card.onclick;
-                card.onclick = (e) => {
-                    if (e.shiftKey) {
-                        e.stopPropagation();
-                        card.classList.toggle('archive-selected');
-                        updateArchiveTrashHint(itemsContainer);
-                        return;
-                    }
-                    origOnclick(e);
-                };
-            }
-
-            itemsInner.appendChild(card);
+      card.draggable = true;
+      card.addEventListener("dragstart", (e) => {
+        let ids = [card.dataset.id];
+        if (group.key === "archived") {
+          const selected = [
+            ...itemsContainer.querySelectorAll(".archive-selected"),
+          ].map((c) => c.dataset.id);
+          // If dragging one of the selected cards, drag the whole selection.
+          if (selected.length > 0 && selected.includes(card.dataset.id)) {
+            ids = selected;
+          }
         }
 
-        itemsContainer.addEventListener('dragover', (e) => {
-            if (_draggedJobStatus !== group.key || !_draggedJobId) return;
-            e.preventDefault();
-        });
-        itemsContainer.addEventListener('drop', async (e) => {
-            if (e.target.closest('.job-card') || e.target.closest('.archive-trash-zone')) return;
-            const draggedStatus = _draggedJobStatus;
-            const draggedId = _draggedJobId;
-            _clearJobReorderTargets(itemsContainer);
-            if (!draggedStatus || draggedStatus !== group.key || !draggedId) return;
-            e.preventDefault();
-            const cards = [...itemsContainer.querySelectorAll('.job-card')];
-            const lastCard = cards[cards.length - 1];
-            if (!lastCard) return;
-            if (String(lastCard.dataset.id) === String(draggedId)) return;
-            await reorderJobWithinGroup(group.key, draggedId, lastCard.dataset.id, true);
-        });
+        _draggedJobId = card.dataset.id;
+        _draggedJobStatus = group.key;
 
-        // Add trash zone at the bottom of archived group — always visible
-        if (group.key === 'archived' && group.items.length > 0) {
-            const trashZone = document.createElement('div');
-            trashZone.className = 'archive-trash-zone visible';
-            trashZone.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M6 4V3h4v1M5 4v8.5h6V4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="archive-trash-hint">Drag here to delete</span>`;
+        e.dataTransfer.setData("application/x-job-id", String(card.dataset.id));
+        e.dataTransfer.setData("application/x-job-status", group.key);
+        e.dataTransfer.setData(
+          "application/x-job-multi",
+          ids.length > 1 ? "1" : "0",
+        );
+        e.dataTransfer.setData(
+          "application/x-archive-ids",
+          JSON.stringify(ids),
+        );
+        e.dataTransfer.effectAllowed = "move";
 
-            // Click to delete selected items
-            trashZone.addEventListener('click', async () => {
-                const selected = [...itemsContainer.querySelectorAll('.archive-selected')];
-                if (selected.length === 0) return;
-                await deleteArchiveIds(selected.map(c => c.dataset.id), trashZone);
-            });
+        card.classList.add("reorder-dragging");
+        if (group.key === "archived") {
+          card.classList.remove("archive-holding");
+          document.body.classList.add("archive-no-select");
+          ids.forEach((id) => {
+            const el = itemsContainer.querySelector(
+              `.job-card[data-id="${id}"]`,
+            );
+            if (el) el.classList.add("archive-dragging");
+          });
+          itemsContainer.classList.add("archive-drag-active");
 
-            // Drag-and-drop support
-            trashZone.addEventListener('dragover', (e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; trashZone.classList.add('hover'); _clearJobReorderTargets(itemsInner); });
-            trashZone.addEventListener('dragleave', () => { trashZone.classList.remove('hover'); });
-            trashZone.addEventListener('drop', async (e) => {
-                e.preventDefault();
-                trashZone.classList.remove('hover');
-                itemsContainer.classList.remove('archive-drag-active');
-                document.body.classList.remove('archive-no-select');
-                let ids;
-                try { ids = JSON.parse(e.dataTransfer.getData('application/x-archive-ids')); } catch { return; }
-                if (!ids || ids.length === 0) return;
-                await deleteArchiveIds(ids, trashZone);
-            });
-
-            itemsInner.appendChild(trashZone);
+          const trash = itemsContainer.querySelector(".archive-trash-zone");
+          if (trash) {
+            trash.classList.add("drop-ready");
+            const hint = trash.querySelector(".archive-trash-hint");
+            if (hint)
+              hint.textContent =
+                ids.length > 1
+                  ? `Drop to delete ${ids.length} jobs`
+                  : "Drop to delete job";
+          }
+        } else {
+          itemsContainer.classList.add("job-reorder-active");
         }
+      });
+      card.addEventListener("dragover", (e) => {
+        if (
+          _draggedJobStatus !== group.key ||
+          !_draggedJobId ||
+          _draggedJobId === card.dataset.id
+        )
+          return;
+        e.preventDefault();
+        // Clear all other indicators first, then set this one
+        _clearJobReorderTargets(itemsContainer);
+        const rect = card.getBoundingClientRect();
+        const before = e.clientY < rect.top + rect.height / 2;
+        card.classList.toggle("reorder-target-before", before);
+        card.classList.toggle("reorder-target-after", !before);
+      });
+      card.addEventListener("drop", async (e) => {
+        const draggedId = _draggedJobId;
+        const draggedStatus = _draggedJobStatus;
+        _clearJobReorderTargets(itemsContainer);
+        if (!draggedStatus || draggedStatus !== group.key || !draggedId) return;
+        if (draggedId === card.dataset.id) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const rect = card.getBoundingClientRect();
+        const insertAfter = e.clientY >= rect.top + rect.height / 2;
+        await reorderJobWithinGroup(
+          group.key,
+          draggedId,
+          card.dataset.id,
+          insertAfter,
+        );
+      });
+      card.addEventListener("dragend", () => {
+        _draggedJobId = null;
+        _draggedJobStatus = null;
+        document.body.classList.remove("archive-no-select");
+        card.classList.remove("reorder-dragging");
+        itemsContainer.classList.remove(
+          "job-reorder-active",
+          "archive-drag-active",
+        );
+        itemsContainer
+          .querySelectorAll(".archive-dragging")
+          .forEach((c) => c.classList.remove("archive-dragging"));
+        _clearJobReorderTargets(itemsContainer);
+        const trash = itemsContainer.querySelector(".archive-trash-zone");
+        if (trash) {
+          trash.classList.remove("drop-ready", "hover");
+          updateArchiveTrashHint(itemsContainer);
+        }
+        if (_pendingJobReflowTimer) {
+          clearTimeout(_pendingJobReflowTimer);
+          _pendingJobReflowTimer = null;
+        }
+        _flushPendingJobReflow();
+      });
 
-        itemsContainer.appendChild(itemsInner);
-        list.appendChild(itemsContainer);
+      // Archived cards: shift+click for multi-select
+      if (group.key === "archived") {
+        card.classList.add("archive-selectable");
+        const clearHoldState = () => card.classList.remove("archive-holding");
+        card.addEventListener("pointerdown", (e) => {
+          if (e.button !== 0) return;
+          card.classList.add("archive-holding");
+        });
+        card.addEventListener("pointerup", clearHoldState);
+        card.addEventListener("pointercancel", clearHoldState);
+        card.addEventListener("mouseleave", clearHoldState);
+        const origOnclick = card.onclick;
+        card.onclick = (e) => {
+          if (e.shiftKey) {
+            e.stopPropagation();
+            card.classList.toggle("archive-selected");
+            updateArchiveTrashHint(itemsContainer);
+            return;
+          }
+          origOnclick(e);
+        };
+      }
+
+      itemsInner.appendChild(card);
     }
 
-    // Re-insert preserved create form at top and restore focus
-    if (savedForm) {
-        list.prepend(savedForm);
-        if (savedFocusSelector) {
-            const el = savedForm.querySelector(savedFocusSelector);
-            if (el) {
-                el.focus();
-                try { el.setSelectionRange(savedSelStart, savedSelEnd); } catch {}
-            }
+    itemsContainer.addEventListener("dragover", (e) => {
+      if (_draggedJobStatus !== group.key || !_draggedJobId) return;
+      e.preventDefault();
+    });
+    itemsContainer.addEventListener("drop", async (e) => {
+      if (
+        e.target.closest(".job-card") ||
+        e.target.closest(".archive-trash-zone")
+      )
+        return;
+      const draggedStatus = _draggedJobStatus;
+      const draggedId = _draggedJobId;
+      _clearJobReorderTargets(itemsContainer);
+      if (!draggedStatus || draggedStatus !== group.key || !draggedId) return;
+      e.preventDefault();
+      const cards = [...itemsContainer.querySelectorAll(".job-card")];
+      const lastCard = cards[cards.length - 1];
+      if (!lastCard) return;
+      if (String(lastCard.dataset.id) === String(draggedId)) return;
+      await reorderJobWithinGroup(
+        group.key,
+        draggedId,
+        lastCard.dataset.id,
+        true,
+      );
+    });
+
+    // Add trash zone at the bottom of archived group — always visible
+    if (group.key === "archived" && group.items.length > 0) {
+      const trashZone = document.createElement("div");
+      trashZone.className = "archive-trash-zone visible";
+      trashZone.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M6 4V3h4v1M5 4v8.5h6V4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="archive-trash-hint">Drag here to delete</span>`;
+
+      // Click to delete selected items
+      trashZone.addEventListener("click", async () => {
+        const selected = [
+          ...itemsContainer.querySelectorAll(".archive-selected"),
+        ];
+        if (selected.length === 0) return;
+        await deleteArchiveIds(
+          selected.map((c) => c.dataset.id),
+          trashZone,
+        );
+      });
+
+      // Drag-and-drop support
+      trashZone.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        trashZone.classList.add("hover");
+        _clearJobReorderTargets(itemsInner);
+      });
+      trashZone.addEventListener("dragleave", () => {
+        trashZone.classList.remove("hover");
+      });
+      trashZone.addEventListener("drop", async (e) => {
+        e.preventDefault();
+        trashZone.classList.remove("hover");
+        itemsContainer.classList.remove("archive-drag-active");
+        document.body.classList.remove("archive-no-select");
+        let ids;
+        try {
+          ids = JSON.parse(e.dataTransfer.getData("application/x-archive-ids"));
+        } catch {
+          return;
         }
+        if (!ids || ids.length === 0) return;
+        await deleteArchiveIds(ids, trashZone);
+      });
+
+      itemsInner.appendChild(trashZone);
     }
+
+    itemsContainer.appendChild(itemsInner);
+    list.appendChild(itemsContainer);
+  }
+
+  // Re-insert preserved create form at top and restore focus
+  if (savedForm) {
+    list.prepend(savedForm);
+    if (savedFocusSelector) {
+      const el = savedForm.querySelector(savedFocusSelector);
+      if (el) {
+        el.focus();
+        try {
+          el.setSelectionRange(savedSelStart, savedSelEnd);
+        } catch {}
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -876,106 +974,106 @@ function renderJobsList() {
 // ---------------------------------------------------------------------------
 
 async function openJobConversation(jobId) {
-    const job = jobsData.find(a => a.id === jobId);
-    if (!job) return;
-    activeJobId = jobId;
-    markJobRead(jobId);
+  const job = jobsData.find((a) => a.id === jobId);
+  if (!job) return;
+  activeJobId = jobId;
+  markJobRead(jobId);
 
-    const listView = document.getElementById('jobs-list-view');
-    const convView = document.getElementById('jobs-conversation-view');
+  const listView = document.getElementById("jobs-list-view");
+  const convView = document.getElementById("jobs-conversation-view");
 
-    // Prepare content while conv view is still hidden
-    // Set header — click to edit title inline
-    const titleEl = document.getElementById('jobs-conv-title');
-    titleEl.textContent = job.title;
-    titleEl.onclick = () => startEditJobTitle(job, titleEl);
-    updateJobToggles(job.status);
+  // Prepare content while conv view is still hidden
+  // Set header — click to edit title inline
+  const titleEl = document.getElementById("jobs-conv-title");
+  titleEl.textContent = job.title;
+  titleEl.onclick = () => startEditJobTitle(job, titleEl);
+  updateJobToggles(job.status);
 
-    // Render unified brief card header
-    let briefEl = convView.querySelector('.job-brief-card');
-    if (briefEl) briefEl.remove();
-    let legacyBody = convView.querySelector('.job-body-brief');
-    if (legacyBody) legacyBody.remove();
-    let legacyPinned = convView.querySelector('.job-pinned-msg');
-    if (legacyPinned) legacyPinned.remove();
+  // Render unified brief card header
+  let briefEl = convView.querySelector(".job-brief-card");
+  if (briefEl) briefEl.remove();
+  let legacyBody = convView.querySelector(".job-body-brief");
+  if (legacyBody) legacyBody.remove();
+  let legacyPinned = convView.querySelector(".job-pinned-msg");
+  if (legacyPinned) legacyPinned.remove();
 
-    if (job.body) {
-        briefEl = document.createElement('div');
-        briefEl.className = 'job-brief-card';
-        briefEl.innerHTML = `<div class="job-brief-text">${window.renderMarkdown(job.body)}</div>`;
-        const messagesContainer = document.getElementById('jobs-conv-messages');
-        messagesContainer.parentNode.insertBefore(briefEl, messagesContainer);
-    }
+  if (job.body) {
+    briefEl = document.createElement("div");
+    briefEl.className = "job-brief-card";
+    briefEl.innerHTML = `<div class="job-brief-text">${window.renderMarkdown(job.body)}</div>`;
+    const messagesContainer = document.getElementById("jobs-conv-messages");
+    messagesContainer.parentNode.insertBefore(briefEl, messagesContainer);
+  }
 
-    // Load messages before showing the view
-    const messages = await loadJobMessages(jobId);
-    const target = resolveJobDefaultRecipient(job, messages);
-    if (target) jobReplyTargets[jobId] = target;
-    updateJobReplyTargetUI();
+  // Load messages before showing the view
+  const messages = await loadJobMessages(jobId);
+  const target = resolveJobDefaultRecipient(job, messages);
+  if (target) jobReplyTargets[jobId] = target;
+  updateJobReplyTargetUI();
 
-    // Switch views — instant swap (animation deferred to future Motion Guard impl)
-    listView.classList.add('hidden');
-    convView.classList.remove('hidden');
+  // Switch views — instant swap (animation deferred to future Motion Guard impl)
+  listView.classList.add("hidden");
+  convView.classList.remove("hidden");
 
-    // Pre-fill starter text for empty jobs
-    const jobInput = document.getElementById('jobs-conv-input-text');
-    const msgCount = (job.messages || []).filter(m => !m?.deleted).length;
-    if (msgCount === 0 && target) {
-        const starterText = `@${target} start this job`;
-        jobInput.value = starterText;
-        jobInput.placeholder = 'Send to assign · click to edit';
-        jobInput.classList.add('job-starter-prefill');
-        const clearStarter = () => {
-            if (jobInput.classList.contains('job-starter-prefill')) {
-                jobInput.value = '';
-                jobInput.placeholder = 'Message...';
-                jobInput.classList.remove('job-starter-prefill');
-            }
-            jobInput.removeEventListener('focus', clearStarter);
-            jobInput.removeEventListener('click', clearStarter);
-        };
-        jobInput.addEventListener('focus', clearStarter);
-        jobInput.addEventListener('click', clearStarter);
-    } else {
-        jobInput.placeholder = 'Message...';
-        jobInput.classList.remove('job-starter-prefill');
-        jobInput.focus();
-    }
+  // Pre-fill starter text for empty jobs
+  const jobInput = document.getElementById("jobs-conv-input-text");
+  const msgCount = (job.messages || []).filter((m) => !m?.deleted).length;
+  if (msgCount === 0 && target) {
+    const starterText = `@${target} start this job`;
+    jobInput.value = starterText;
+    jobInput.placeholder = "Send to assign · click to edit";
+    jobInput.classList.add("job-starter-prefill");
+    const clearStarter = () => {
+      if (jobInput.classList.contains("job-starter-prefill")) {
+        jobInput.value = "";
+        jobInput.placeholder = "Message...";
+        jobInput.classList.remove("job-starter-prefill");
+      }
+      jobInput.removeEventListener("focus", clearStarter);
+      jobInput.removeEventListener("click", clearStarter);
+    };
+    jobInput.addEventListener("focus", clearStarter);
+    jobInput.addEventListener("click", clearStarter);
+  } else {
+    jobInput.placeholder = "Message...";
+    jobInput.classList.remove("job-starter-prefill");
+    jobInput.focus();
+  }
 }
 
 async function loadJobMessages(jobId) {
-    const container = document.getElementById('jobs-conv-messages');
-    container.innerHTML = '';
+  const container = document.getElementById("jobs-conv-messages");
+  container.innerHTML = "";
 
-    try {
-        const resp = await fetch(`/api/jobs/${jobId}/messages`, {
-            headers: { 'X-Session-Token': window.SESSION_TOKEN }
-        });
-        if (!resp.ok) return [];
-        const msgs = await resp.json();
-        const visibleMsgs = msgs.filter(msg => !msg?.deleted);
+  try {
+    const resp = await fetch(`/api/jobs/${jobId}/messages`, {});
+    if (!resp.ok) return [];
+    const msgs = await resp.json();
+    const visibleMsgs = msgs.filter((msg) => !msg?.deleted);
 
-        if (visibleMsgs.length === 0) {
-            // Only show empty state if there's no brief card either
-            const convView = document.getElementById('jobs-conversation-view');
-            const hasBrief = !!convView.querySelector('.job-brief-card');
-            if (!hasBrief) {
-                container.innerHTML = '<div class="jobs-empty" style="font-size:12px; padding:16px">No messages yet. Start the conversation!</div>';
-            }
-            return msgs;
-        }
-
-        // Render all messages in the scrollable area
-        for (const msg of visibleMsgs) {
-            appendJobMessage(msg);
-        }
-
-        container.scrollTop = container.scrollHeight;
-        return msgs;
-    } catch (e) {
-        container.innerHTML = '<div class="jobs-empty">Failed to load messages.</div>';
-        return [];
+    if (visibleMsgs.length === 0) {
+      // Only show empty state if there's no brief card either
+      const convView = document.getElementById("jobs-conversation-view");
+      const hasBrief = !!convView.querySelector(".job-brief-card");
+      if (!hasBrief) {
+        container.innerHTML =
+          '<div class="jobs-empty" style="font-size:12px; padding:16px">No messages yet. Start the conversation!</div>';
+      }
+      return msgs;
     }
+
+    // Render all messages in the scrollable area
+    for (const msg of visibleMsgs) {
+      appendJobMessage(msg);
+    }
+
+    container.scrollTop = container.scrollHeight;
+    return msgs;
+  } catch (e) {
+    container.innerHTML =
+      '<div class="jobs-empty">Failed to load messages.</div>';
+    return [];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -984,98 +1082,100 @@ async function loadJobMessages(jobId) {
 
 const _jobMsgDeleteTimers = new Map();
 function _clearJobMsgDeleteTimer(jobId, msgId) {
-    const key = `${jobId}:${msgId}`;
-    const timer = _jobMsgDeleteTimers.get(key);
-    if (timer) clearTimeout(timer);
-    _jobMsgDeleteTimers.delete(key);
+  const key = `${jobId}:${msgId}`;
+  const timer = _jobMsgDeleteTimers.get(key);
+  if (timer) clearTimeout(timer);
+  _jobMsgDeleteTimers.delete(key);
 }
 
 function _animateRemoveJobMessage(msgEl) {
-    if (!msgEl || msgEl.dataset.removing === '1') {
-        if (msgEl) msgEl?.remove?.();
-        return;
-    }
-    msgEl.dataset.removing = '1';
-    const h = msgEl.offsetHeight || 0;
-    msgEl.style.maxHeight = `${h}px`;
-    msgEl.style.overflow = 'hidden';
-    msgEl.style.willChange = 'max-height, opacity, transform, margin, padding';
-    requestAnimationFrame(() => {
-        msgEl.classList.add('job-msg-removing');
-        msgEl.style.maxHeight = '0px';
-    });
-    const cleanup = () => {
-        msgEl.removeEventListener('transitionend', cleanup);
-        msgEl.remove();
-    };
-    msgEl.addEventListener('transitionend', cleanup);
-    setTimeout(cleanup, 240);
+  if (!msgEl || msgEl.dataset.removing === "1") {
+    if (msgEl) msgEl?.remove?.();
+    return;
+  }
+  msgEl.dataset.removing = "1";
+  const h = msgEl.offsetHeight || 0;
+  msgEl.style.maxHeight = `${h}px`;
+  msgEl.style.overflow = "hidden";
+  msgEl.style.willChange = "max-height, opacity, transform, margin, padding";
+  requestAnimationFrame(() => {
+    msgEl.classList.add("job-msg-removing");
+    msgEl.style.maxHeight = "0px";
+  });
+  const cleanup = () => {
+    msgEl.removeEventListener("transitionend", cleanup);
+    msgEl.remove();
+  };
+  msgEl.addEventListener("transitionend", cleanup);
+  setTimeout(cleanup, 240);
 }
 
 function _renderJobMsgDeleteDefault(actions, jobId, msgId) {
-    if (!actions) return;
-    actions.classList.remove('confirming');
-    actions.innerHTML = `<button class="job-msg-del-btn" onclick="startDeleteJobMessage(${jobId}, ${msgId})">DEL</button>`;
+  if (!actions) return;
+  actions.classList.remove("confirming");
+  actions.innerHTML = `<button class="job-msg-del-btn" onclick="startDeleteJobMessage(${jobId}, ${msgId})">DEL</button>`;
 }
 
 function startDeleteJobMessage(jobId, msgId, event) {
-    event?.preventDefault?.();
-    event?.stopPropagation?.();
-    const selector = `.job-msg[data-msg-id="${msgId}"]`;
-    const msgEl = document.querySelector(selector);
-    const actions = msgEl?.querySelector('.job-msg-actions');
-    if (!actions) return;
+  event?.preventDefault?.();
+  event?.stopPropagation?.();
+  const selector = `.job-msg[data-msg-id="${msgId}"]`;
+  const msgEl = document.querySelector(selector);
+  const actions = msgEl?.querySelector(".job-msg-actions");
+  if (!actions) return;
 
-    document.querySelectorAll('.job-msg-actions.confirming').forEach((el) => {
-        const parent = el.closest('.job-msg');
-        const priorId = Number(parent?.dataset.msgId || NaN);
-        if (Number.isFinite(priorId) && priorId !== Number(msgId)) {
-            _clearJobMsgDeleteTimer(jobId, priorId);
-            _renderJobMsgDeleteDefault(el, jobId, priorId);
-        }
-    });
+  document.querySelectorAll(".job-msg-actions.confirming").forEach((el) => {
+    const parent = el.closest(".job-msg");
+    const priorId = Number(parent?.dataset.msgId || NaN);
+    if (Number.isFinite(priorId) && priorId !== Number(msgId)) {
+      _clearJobMsgDeleteTimer(jobId, priorId);
+      _renderJobMsgDeleteDefault(el, jobId, priorId);
+    }
+  });
 
-    actions.classList.add('confirming');
-    actions.innerHTML = `
+  actions.classList.add("confirming");
+  actions.innerHTML = `
         <span class="job-msg-delete-label">Delete?</span>
         <button class="job-msg-confirm-yes" onclick="confirmDeleteJobMessage(${jobId}, ${msgId})">Yes</button>
         <button class="job-msg-confirm-no" onclick="cancelDeleteJobMessage(${jobId}, ${msgId})">No</button>
     `;
-    _clearJobMsgDeleteTimer(jobId, msgId);
-    const key = `${jobId}:${msgId}`;
-    _jobMsgDeleteTimers.set(key, setTimeout(() => {
-        cancelDeleteJobMessage(jobId, msgId);
-    }, 4000));
+  _clearJobMsgDeleteTimer(jobId, msgId);
+  const key = `${jobId}:${msgId}`;
+  _jobMsgDeleteTimers.set(
+    key,
+    setTimeout(() => {
+      cancelDeleteJobMessage(jobId, msgId);
+    }, 4000),
+  );
 }
 
 async function confirmDeleteJobMessage(jobId, msgId, event) {
-    event?.preventDefault?.();
-    event?.stopPropagation?.();
-    _clearJobMsgDeleteTimer(jobId, msgId);
-    try {
-        const resp = await fetch(`/api/jobs/${jobId}/messages/${msgId}`, {
-            method: 'DELETE',
-            headers: { 'X-Session-Token': window.SESSION_TOKEN },
-        });
-        if (!resp.ok) {
-            cancelDeleteJobMessage(jobId, msgId);
-            return;
-        }
-        const msgEl = document.querySelector(`.job-msg[data-msg-id="${msgId}"]`);
-        _animateRemoveJobMessage(msgEl);
-    } catch (err) {
-        console.error('Failed to delete job message:', err);
-        cancelDeleteJobMessage(jobId, msgId);
+  event?.preventDefault?.();
+  event?.stopPropagation?.();
+  _clearJobMsgDeleteTimer(jobId, msgId);
+  try {
+    const resp = await fetch(`/api/jobs/${jobId}/messages/${msgId}`, {
+      method: "DELETE",
+    });
+    if (!resp.ok) {
+      cancelDeleteJobMessage(jobId, msgId);
+      return;
     }
+    const msgEl = document.querySelector(`.job-msg[data-msg-id="${msgId}"]`);
+    _animateRemoveJobMessage(msgEl);
+  } catch (err) {
+    console.error("Failed to delete job message:", err);
+    cancelDeleteJobMessage(jobId, msgId);
+  }
 }
 
 function cancelDeleteJobMessage(jobId, msgId, event) {
-    event?.preventDefault?.();
-    event?.stopPropagation?.();
-    _clearJobMsgDeleteTimer(jobId, msgId);
-    const msgEl = document.querySelector(`.job-msg[data-msg-id="${msgId}"]`);
-    const actions = msgEl?.querySelector('.job-msg-actions');
-    _renderJobMsgDeleteDefault(actions, jobId, msgId);
+  event?.preventDefault?.();
+  event?.stopPropagation?.();
+  _clearJobMsgDeleteTimer(jobId, msgId);
+  const msgEl = document.querySelector(`.job-msg[data-msg-id="${msgId}"]`);
+  const actions = msgEl?.querySelector(".job-msg-actions");
+  _renderJobMsgDeleteDefault(actions, jobId, msgId);
 }
 
 // ---------------------------------------------------------------------------
@@ -1083,54 +1183,56 @@ function cancelDeleteJobMessage(jobId, msgId, event) {
 // ---------------------------------------------------------------------------
 
 function appendJobMessage(msg) {
-    const container = document.getElementById('jobs-conv-messages');
-    if (!container || msg?.deleted) return;
+  const container = document.getElementById("jobs-conv-messages");
+  if (!container || msg?.deleted) return;
 
-    const div = document.createElement('div');
-    div.className = 'job-msg' + (msg.type === 'suggestion' ? ' job-suggestion' : '');
-    div.dataset.msgId = String(msg.id ?? '');
-    const senderColor = window.getColor(msg.sender);
-    const msgId = Number(msg.id);
-    const canDelete = Number.isFinite(msgId);
-    const deleteActionHtml = canDelete
-        ? `<div class="job-msg-actions"><button class="job-msg-del-btn" onclick="startDeleteJobMessage(${activeJobId}, ${msgId})">DEL</button></div>`
-        : '';
+  const div = document.createElement("div");
+  div.className =
+    "job-msg" + (msg.type === "suggestion" ? " job-suggestion" : "");
+  div.dataset.msgId = String(msg.id ?? "");
+  const senderColor = window.getColor(msg.sender);
+  const msgId = Number(msg.id);
+  const canDelete = Number.isFinite(msgId);
+  const deleteActionHtml = canDelete
+    ? `<div class="job-msg-actions"><button class="job-msg-del-btn" onclick="startDeleteJobMessage(${activeJobId}, ${msgId})">DEL</button></div>`
+    : "";
 
-    if (msg.type === 'suggestion') {
-        const resolved = msg.resolved;
-        div.innerHTML = `
+  if (msg.type === "suggestion") {
+    const resolved = msg.resolved;
+    div.innerHTML = `
             <div class="job-msg-header">
                 <span class="suggestion-pill">Suggestion</span>
                 <span class="job-msg-sender" style="color: ${senderColor}">${window.escapeHtml(msg.sender)}</span>
-                <span class="job-msg-time">${msg.time || ''}</span>
+                <span class="job-msg-time">${msg.time || ""}</span>
                 ${deleteActionHtml}
             </div>
             <div class="job-msg-text">${window.renderMarkdown(msg.text)}</div>
-            <div class="suggestion-actions">${resolved
+            <div class="suggestion-actions">${
+              resolved
                 ? `<span class="suggestion-resolved">${window.escapeHtml(resolved)}</span>`
                 : `<button class="suggestion-accept" onclick="acceptSuggestion(${activeJobId}, ${msg.id})">Accept</button><button class="suggestion-dismiss" onclick="dismissSuggestion(${activeJobId}, ${msg.id})">Dismiss</button>`
             }</div>
         `;
-    } else {
-        let attHtml = '';
-        if (msg.attachments && msg.attachments.length > 0) {
-            attHtml = '<div class="job-msg-attachments">';
-            for (const att of msg.attachments) {
-                attHtml += `<img src="${window.escapeHtml(att.url)}" alt="${window.escapeHtml(att.name || '')}" onclick="openImageModal('${window.escapeHtml(att.url)}')">`;
-            }
-            attHtml += '</div>';
-        }
-        div.innerHTML = `
+  } else {
+    let attHtml = "";
+    if (msg.attachments && msg.attachments.length > 0) {
+      attHtml = '<div class="job-msg-attachments">';
+      for (const att of msg.attachments) {
+        attHtml += `<img src="${window.escapeHtml(att.url)}" alt="${window.escapeHtml(att.name || "")}" onclick="openImageModal('${window.escapeHtml(att.url)}')">`;
+      }
+      attHtml += "</div>";
+    }
+    div.innerHTML = `
             <div class="job-msg-header">
                 <span class="job-msg-sender" style="color: ${senderColor}">${window.escapeHtml(msg.sender)}</span>
-                <span class="job-msg-time">${msg.time || ''}</span>
+                <span class="job-msg-time">${msg.time || ""}</span>
                 ${deleteActionHtml}
             </div>
-            ${msg.text ? `<div class="job-msg-text">${window.renderMarkdown(msg.text)}</div>` : ''}
+            ${msg.text ? `<div class="job-msg-text">${window.renderMarkdown(msg.text)}</div>` : ""}
             ${attHtml}
         `;
-    }
-    container.appendChild(div);
+  }
+  container.appendChild(div);
 }
 
 // ---------------------------------------------------------------------------
@@ -1138,79 +1240,91 @@ function appendJobMessage(msg) {
 // ---------------------------------------------------------------------------
 
 async function sendJobMessage() {
-    if (!activeJobId) return;
-    const input = document.getElementById('jobs-conv-input-text');
-    const text = input.value.trim();
-    if (!text && jobPendingAttachments.length === 0) return;
-    const explicitTargets = _extractJobMentionTargets(text);
-    const hasBroadcastMention = /@(?:all|both)\b/i.test(text);
-    let outboundText = text;
-    if (explicitTargets.length > 0) {
-        jobReplyTargets[activeJobId] = explicitTargets[0];
-    } else if (!hasBroadcastMention) {
-        const target = _normalizeJobRecipient(jobReplyTargets[activeJobId]);
-        if (target) {
-            outboundText = text ? `@${target} ${text}` : `@${target}`;
-        }
+  if (!activeJobId) return;
+  const input = document.getElementById("jobs-conv-input-text");
+  const text = input.value.trim();
+  if (!text && jobPendingAttachments.length === 0) return;
+  const explicitTargets = _extractJobMentionTargets(text);
+  const hasBroadcastMention = /@(?:all|both)\b/i.test(text);
+  let outboundText = text;
+  if (explicitTargets.length > 0) {
+    jobReplyTargets[activeJobId] = explicitTargets[0];
+  } else if (!hasBroadcastMention) {
+    const target = _normalizeJobRecipient(jobReplyTargets[activeJobId]);
+    if (target) {
+      outboundText = text ? `@${target} ${text}` : `@${target}`;
     }
+  }
 
-    try {
-        const resp = await fetch(`/api/jobs/${activeJobId}/messages`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({
-                text: outboundText,
-                sender: window.username,
-                attachments: jobPendingAttachments.map(a => ({
-                    path: a.path, name: a.name, url: a.url,
-                })),
-            }),
-        });
-        if (resp.ok) {
-            input.value = '';
-            input.style.height = 'auto';
-            clearJobAttachments();
-            updateJobReplyTargetUI();
-        }
-    } catch (e) {
-        console.error('Failed to send job message:', e);
+  try {
+    const resp = await fetch(`/api/jobs/${activeJobId}/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        text: outboundText,
+        sender: window.username,
+        attachments: jobPendingAttachments.map((a) => ({
+          path: a.path,
+          name: a.name,
+          url: a.url,
+        })),
+      }),
+    });
+    if (resp.ok) {
+      input.value = "";
+      input.style.height = "auto";
+      clearJobAttachments();
+      updateJobReplyTargetUI();
     }
+  } catch (e) {
+    console.error("Failed to send job message:", e);
+  }
 }
 
 async function uploadJobImage(file) {
-    const form = new FormData();
-    form.append('file', file);
-    try {
-        const resp = await fetch('/api/upload', { method: 'POST', headers: { 'X-Session-Token': window.SESSION_TOKEN }, body: form });
-        const data = await resp.json();
-        jobPendingAttachments.push({ path: data.path, name: data.name, url: data.url });
-        renderJobAttachments();
-    } catch (err) {
-        console.error('Job upload failed:', err);
-    }
+  const form = new FormData();
+  form.append("file", file);
+  try {
+    const resp = await fetch("/api/upload", {
+      method: "POST",
+
+      body: form,
+    });
+    const data = await resp.json();
+    jobPendingAttachments.push({
+      path: data.path,
+      name: data.name,
+      url: data.url,
+    });
+    renderJobAttachments();
+  } catch (err) {
+    console.error("Job upload failed:", err);
+  }
 }
 
 function renderJobAttachments() {
-    const container = document.getElementById('job-attachments');
-    if (!container) return;
-    container.innerHTML = '';
-    jobPendingAttachments.forEach((att, i) => {
-        const wrap = document.createElement('div');
-        wrap.className = 'attachment-preview';
-        wrap.innerHTML = `<img src="${att.url}" alt="${window.escapeHtml(att.name)}"><button class="remove-btn" onclick="removeJobAttachment(${i})">x</button>`;
-        container.appendChild(wrap);
-    });
+  const container = document.getElementById("job-attachments");
+  if (!container) return;
+  container.innerHTML = "";
+  jobPendingAttachments.forEach((att, i) => {
+    const wrap = document.createElement("div");
+    wrap.className = "attachment-preview";
+    wrap.innerHTML = `<img src="${att.url}" alt="${window.escapeHtml(att.name)}"><button class="remove-btn" onclick="removeJobAttachment(${i})">x</button>`;
+    container.appendChild(wrap);
+  });
 }
 
 function removeJobAttachment(index) {
-    jobPendingAttachments.splice(index, 1);
-    renderJobAttachments();
+  jobPendingAttachments.splice(index, 1);
+  renderJobAttachments();
 }
 
 function clearJobAttachments() {
-    jobPendingAttachments = [];
-    const container = document.getElementById('job-attachments');
-    if (container) container.innerHTML = '';
+  jobPendingAttachments = [];
+  const container = document.getElementById("job-attachments");
+  if (container) container.innerHTML = "";
 }
 
 // ---------------------------------------------------------------------------
@@ -1218,71 +1332,83 @@ function clearJobAttachments() {
 // ---------------------------------------------------------------------------
 
 function startEditJobTitle(job, titleEl) {
-    if (titleEl.querySelector('input')) return; // already editing
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.className = 'job-title-input';
-    input.value = job.title;
-    input.maxLength = 120;
-    titleEl.textContent = '';
-    titleEl.appendChild(input);
-    input.focus();
-    input.select();
+  if (titleEl.querySelector("input")) return; // already editing
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = "job-title-input";
+  input.value = job.title;
+  input.maxLength = 120;
+  titleEl.textContent = "";
+  titleEl.appendChild(input);
+  input.focus();
+  input.select();
 
-    const commit = async () => {
-        const newTitle = input.value.trim();
-        if (newTitle && newTitle !== job.title) {
-            try {
-                await fetch(`/api/jobs/${job.id}`, {
-                    method: 'PATCH',
-                    headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-                    body: JSON.stringify({ title: newTitle }),
-                });
-                job.title = newTitle;
-            } catch (e) { console.error('Failed to update title:', e); }
-        }
-        titleEl.textContent = job.title;
-        titleEl.onclick = () => startEditJobTitle(job, titleEl);
-    };
+  const commit = async () => {
+    const newTitle = input.value.trim();
+    if (newTitle && newTitle !== job.title) {
+      try {
+        await fetch(`/api/jobs/${job.id}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ title: newTitle }),
+        });
+        job.title = newTitle;
+      } catch (e) {
+        console.error("Failed to update title:", e);
+      }
+    }
+    titleEl.textContent = job.title;
+    titleEl.onclick = () => startEditJobTitle(job, titleEl);
+  };
 
-    input.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
-        if (e.key === 'Escape') { input.value = job.title; input.blur(); }
-    });
-    input.addEventListener('blur', commit, { once: true });
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      input.blur();
+    }
+    if (e.key === "Escape") {
+      input.value = job.title;
+      input.blur();
+    }
+  });
+  input.addEventListener("blur", commit, { once: true });
 }
 
 async function toggleJobStatus(status) {
-    if (!activeJobId) return;
-    const job = jobsData.find(a => a.id === activeJobId);
-    if (!job) return;
-    const oldStatus = job.status;
-    const statusLabels = { 'open': 'TO DO', 'done': 'ACTIVE', 'archived': 'CLOSED' };
+  if (!activeJobId) return;
+  const job = jobsData.find((a) => a.id === activeJobId);
+  if (!job) return;
+  const oldStatus = job.status;
+  const statusLabels = { open: "TO DO", done: "ACTIVE", archived: "CLOSED" };
 
-    try {
-        await fetch(`/api/jobs/${activeJobId}`, {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({ status }),
-        });
-        // Update local data
-        job.status = status;
-        if (status === 'archived') {
-            jobsBack();
-        } else {
-            updateJobToggles(status);
-        }
-        renderJobsList();
-    } catch (e) {
-        console.error('Failed to update job status:', e);
+  try {
+    await fetch(`/api/jobs/${activeJobId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ status }),
+    });
+    // Update local data
+    job.status = status;
+    if (status === "archived") {
+      jobsBack();
+    } else {
+      updateJobToggles(status);
     }
+    renderJobsList();
+  } catch (e) {
+    console.error("Failed to update job status:", e);
+  }
 }
 
 function updateJobToggles(activeStatus) {
-    const toggles = document.querySelectorAll('#jobs-status-toggles .job-toggle');
-    toggles.forEach(t => {
-        t.classList.toggle('active', t.dataset.status === activeStatus);
-    });
+  const toggles = document.querySelectorAll("#jobs-status-toggles .job-toggle");
+  toggles.forEach((t) => {
+    t.classList.toggle("active", t.dataset.status === activeStatus);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1290,15 +1416,18 @@ function updateJobToggles(activeStatus) {
 // ---------------------------------------------------------------------------
 
 function showCreateJob() {
-    const list = document.getElementById('jobs-list');
-    if (!list) return;
-    // Remove existing form if any
-    const existing = list.querySelector('.job-create-form');
-    if (existing) { existing.remove(); return; }
+  const list = document.getElementById("jobs-list");
+  if (!list) return;
+  // Remove existing form if any
+  const existing = list.querySelector(".job-create-form");
+  if (existing) {
+    existing.remove();
+    return;
+  }
 
-    const form = document.createElement('div');
-    form.className = 'job-create-form';
-    form.innerHTML = `
+  const form = document.createElement("div");
+  form.className = "job-create-form";
+  form.innerHTML = `
         <input type="text" placeholder="Job title" class="job-create-title" maxlength="120" autofocus>
         <textarea placeholder="Description (optional)" class="job-create-body" maxlength="1000" rows="2"></textarea>
         <div class="job-create-actions">
@@ -1306,53 +1435,58 @@ function showCreateJob() {
             <button class="create-btn" onclick="submitCreateJob(this)">Create</button>
         </div>
     `;
-    list.prepend(form);
-    const titleInput = form.querySelector('.job-create-title');
-    titleInput.focus();
-    // Enter on title moves to body, Enter on empty body submits
-    titleInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            form.querySelector('.job-create-body').focus();
-        } else if (e.key === 'Escape') {
-            form.remove();
-        }
-    });
-    const bodyTA = form.querySelector('.job-create-body');
-    bodyTA.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape') form.remove();
-    });
-    bodyTA.addEventListener('input', () => {
-        bodyTA.style.height = 'auto';
-        bodyTA.style.height = bodyTA.scrollHeight + 'px';
-    });
+  list.prepend(form);
+  const titleInput = form.querySelector(".job-create-title");
+  titleInput.focus();
+  // Enter on title moves to body, Enter on empty body submits
+  titleInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      form.querySelector(".job-create-body").focus();
+    } else if (e.key === "Escape") {
+      form.remove();
+    }
+  });
+  const bodyTA = form.querySelector(".job-create-body");
+  bodyTA.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") form.remove();
+  });
+  bodyTA.addEventListener("input", () => {
+    bodyTA.style.height = "auto";
+    bodyTA.style.height = bodyTA.scrollHeight + "px";
+  });
 }
 
 async function submitCreateJob(btn) {
-    const form = btn.closest('.job-create-form');
-    const titleInput = form.querySelector('.job-create-title');
-    const title = titleInput.value.trim();
-    if (!title) { titleInput.focus(); return; }
-    const bodyInput = form.querySelector('.job-create-body');
-    const jobBody = bodyInput ? bodyInput.value.trim() : '';
+  const form = btn.closest(".job-create-form");
+  const titleInput = form.querySelector(".job-create-title");
+  const title = titleInput.value.trim();
+  if (!title) {
+    titleInput.focus();
+    return;
+  }
+  const bodyInput = form.querySelector(".job-create-body");
+  const jobBody = bodyInput ? bodyInput.value.trim() : "";
 
-    try {
-        await fetch('/api/jobs', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({
-                title,
-                body: jobBody,
-                type: 'job',
-                channel: window.activeChannel,
-                created_by: window.username,
-                assignee: window._lastMentionedAgent || '',
-            }),
-        });
-        form.remove();
-    } catch (e) {
-        console.error('Failed to create job:', e);
-    }
+  try {
+    await fetch("/api/jobs", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title,
+        body: jobBody,
+        type: "job",
+        channel: window.activeChannel,
+        created_by: window.username,
+        assignee: window._lastMentionedAgent || "",
+      }),
+    });
+    form.remove();
+  } catch (e) {
+    console.error("Failed to create job:", e);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1360,9 +1494,9 @@ async function submitCreateJob(btn) {
 // ---------------------------------------------------------------------------
 
 function jobsBack() {
-    showJobsListView(() => {
-        renderJobsList();
-    });
+  showJobsListView(() => {
+    renderJobsList();
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1370,120 +1504,148 @@ function jobsBack() {
 // ---------------------------------------------------------------------------
 
 function handleJobEvent(action, data) {
-    let suppressListRender = false;
-    if (action === 'create') {
-        if (!jobsData.some(a => a.id === data.id)) jobsData.push(data);
-        if (!Object.prototype.hasOwnProperty.call(jobUnread, data.id)) {
-            jobUnread[data.id] = 0;
-        }
-    } else if (action === 'update') {
-        const idx = jobsData.findIndex(a => a.id === data.id);
-        if (idx >= 0) jobsData[idx] = data;
-        if (!Object.prototype.hasOwnProperty.call(jobUnread, data.id)) {
-            jobUnread[data.id] = 0;
-        }
-        suppressListRender = _shouldSuppressJobUpdateRender(data);
-    } else if (action === 'message') {
-        // data = { job_id, message }
-        const job = jobsData.find(a => a.id === data.job_id);
-        if (job) {
-            if (!job.messages) job.messages = [];
-            job.messages.push(data.message);
-        }
-        const panel = document.getElementById('jobs-panel');
-        const convView = document.getElementById('jobs-conversation-view');
-        const isViewingThis = Boolean(
-            panel &&
-            !panel.classList.contains('hidden') &&
-            convView &&
-            !convView.classList.contains('hidden') &&
-            activeJobId === data.job_id
-        );
-        const sender = (data.message && data.message.sender) ? String(data.message.sender) : '';
-        const isSelfMessage = sender.toLowerCase() === window.username.toLowerCase();
-        const msgType = data.message.type || 'chat';
-        if (!isSelfMessage) {
-            const normalized = _normalizeJobRecipient(sender);
-            const hasStoredTarget = Object.prototype.hasOwnProperty.call(jobReplyTargets, data.job_id);
-            if (normalized && hasStoredTarget && jobReplyTargets[data.job_id] !== null) {
-                jobReplyTargets[data.job_id] = normalized;
-                if (isViewingThis) updateJobReplyTargetUI();
-            }
-        }
-
-        // Play notification sound for new job messages from others (matching channel behavior)
-        if (window.soundEnabled && !document.hasFocus() && msgType === 'chat' && !isSelfMessage && sender) {
-            window.playNotificationSound(sender);
-        }
-
-        // If we're viewing this job, append the message. Otherwise count unread.
-        if (isViewingThis) {
-            appendJobMessage(data.message);
-            const container = document.getElementById('jobs-conv-messages');
-            if (container) container.scrollTop = container.scrollHeight;
-            markJobRead(data.job_id);
-        } else if (!isSelfMessage) {
-            jobUnread[data.job_id] = (jobUnread[data.job_id] || 0) + 1;
-            // Play soft pluck for chat messages in other job threads
-            if (window.soundEnabled && document.hasFocus() && msgType === 'chat' && window.playCrossChannelSound) {
-                window.playCrossChannelSound();
-            }
-        }
-    } else if (action === 'message_delete') {
-        // data = { job_id, message_id }
-        const job = jobsData.find(a => a.id === data.job_id);
-        if (job && Array.isArray(job.messages)) {
-            const hit = job.messages.find(m => Number(m.id) === Number(data.message_id));
-            if (hit) {
-                hit.deleted = true;
-                hit.text = '';
-                hit.attachments = [];
-            }
-        }
-        const panel = document.getElementById('jobs-panel');
-        const convView = document.getElementById('jobs-conversation-view');
-        const isViewingThis = Boolean(
-            panel &&
-            !panel.classList.contains('hidden') &&
-            convView &&
-            !convView.classList.contains('hidden') &&
-            activeJobId === data.job_id
-        );
-        if (isViewingThis) {
-            const msgEl = document.querySelector(`.job-msg[data-msg-id="${data.message_id}"]`);
-            _animateRemoveJobMessage(msgEl);
-            markJobRead(data.job_id);
-        }
-    } else if (action === 'delete') {
-        jobsData = jobsData.filter(a => a.id !== data.id);
-        delete jobUnread[data.id];
-        // Remove breadcrumb from timeline and fix stale group wrappers
-        document.querySelectorAll('.job-breadcrumb').forEach(el => {
-            const link = el.querySelector('.job-breadcrumb-link');
-            if (link) {
-                const onclick = link.getAttribute('onclick') || '';
-                if (onclick.includes(`openJobFromBreadcrumb(${data.id})`)) {
-                    const group = el.closest('.job-group');
-                    el.remove();
-                    if (group) _repairJobGroup(group);
-                }
-            }
-        });
-        if (activeJobId === data.id) {
-            showJobsListView();
-        }
+  let suppressListRender = false;
+  if (action === "create") {
+    if (!jobsData.some((a) => a.id === data.id)) jobsData.push(data);
+    if (!Object.prototype.hasOwnProperty.call(jobUnread, data.id)) {
+      jobUnread[data.id] = 0;
     }
-    updateJobsBadge();
-    // Re-render list if visible
-    const panel = document.getElementById('jobs-panel');
-    if (panel && !panel.classList.contains('hidden') && !activeJobId) {
-        if (_jobViewSwitching) return;
-        if (action === 'delete' && archiveDeleteBatchIds && archiveDeleteBatchIds.has(Number(data.id))) {
-            return;
-        }
-        if (suppressListRender) return;
-        renderJobsList();
+  } else if (action === "update") {
+    const idx = jobsData.findIndex((a) => a.id === data.id);
+    if (idx >= 0) jobsData[idx] = data;
+    if (!Object.prototype.hasOwnProperty.call(jobUnread, data.id)) {
+      jobUnread[data.id] = 0;
     }
+    suppressListRender = _shouldSuppressJobUpdateRender(data);
+  } else if (action === "message") {
+    // data = { job_id, message }
+    const job = jobsData.find((a) => a.id === data.job_id);
+    if (job) {
+      if (!job.messages) job.messages = [];
+      job.messages.push(data.message);
+    }
+    const panel = document.getElementById("jobs-panel");
+    const convView = document.getElementById("jobs-conversation-view");
+    const isViewingThis = Boolean(
+      panel &&
+      !panel.classList.contains("hidden") &&
+      convView &&
+      !convView.classList.contains("hidden") &&
+      activeJobId === data.job_id,
+    );
+    const sender =
+      data.message && data.message.sender ? String(data.message.sender) : "";
+    const isSelfMessage =
+      sender.toLowerCase() === window.username.toLowerCase();
+    const msgType = data.message.type || "chat";
+    if (!isSelfMessage) {
+      const normalized = _normalizeJobRecipient(sender);
+      const hasStoredTarget = Object.prototype.hasOwnProperty.call(
+        jobReplyTargets,
+        data.job_id,
+      );
+      if (
+        normalized &&
+        hasStoredTarget &&
+        jobReplyTargets[data.job_id] !== null
+      ) {
+        jobReplyTargets[data.job_id] = normalized;
+        if (isViewingThis) updateJobReplyTargetUI();
+      }
+    }
+
+    // Play notification sound for new job messages from others (matching channel behavior)
+    if (
+      window.soundEnabled &&
+      !document.hasFocus() &&
+      msgType === "chat" &&
+      !isSelfMessage &&
+      sender
+    ) {
+      window.playNotificationSound(sender);
+    }
+
+    // If we're viewing this job, append the message. Otherwise count unread.
+    if (isViewingThis) {
+      appendJobMessage(data.message);
+      const container = document.getElementById("jobs-conv-messages");
+      if (container) container.scrollTop = container.scrollHeight;
+      markJobRead(data.job_id);
+    } else if (!isSelfMessage) {
+      jobUnread[data.job_id] = (jobUnread[data.job_id] || 0) + 1;
+      // Play soft pluck for chat messages in other job threads
+      if (
+        window.soundEnabled &&
+        document.hasFocus() &&
+        msgType === "chat" &&
+        window.playCrossChannelSound
+      ) {
+        window.playCrossChannelSound();
+      }
+    }
+  } else if (action === "message_delete") {
+    // data = { job_id, message_id }
+    const job = jobsData.find((a) => a.id === data.job_id);
+    if (job && Array.isArray(job.messages)) {
+      const hit = job.messages.find(
+        (m) => Number(m.id) === Number(data.message_id),
+      );
+      if (hit) {
+        hit.deleted = true;
+        hit.text = "";
+        hit.attachments = [];
+      }
+    }
+    const panel = document.getElementById("jobs-panel");
+    const convView = document.getElementById("jobs-conversation-view");
+    const isViewingThis = Boolean(
+      panel &&
+      !panel.classList.contains("hidden") &&
+      convView &&
+      !convView.classList.contains("hidden") &&
+      activeJobId === data.job_id,
+    );
+    if (isViewingThis) {
+      const msgEl = document.querySelector(
+        `.job-msg[data-msg-id="${data.message_id}"]`,
+      );
+      _animateRemoveJobMessage(msgEl);
+      markJobRead(data.job_id);
+    }
+  } else if (action === "delete") {
+    jobsData = jobsData.filter((a) => a.id !== data.id);
+    delete jobUnread[data.id];
+    // Remove breadcrumb from timeline and fix stale group wrappers
+    document.querySelectorAll(".job-breadcrumb").forEach((el) => {
+      const link = el.querySelector(".job-breadcrumb-link");
+      if (link) {
+        const onclick = link.getAttribute("onclick") || "";
+        if (onclick.includes(`openJobFromBreadcrumb(${data.id})`)) {
+          const group = el.closest(".job-group");
+          el.remove();
+          if (group) _repairJobGroup(group);
+        }
+      }
+    });
+    if (activeJobId === data.id) {
+      showJobsListView();
+    }
+  }
+  updateJobsBadge();
+  // Re-render list if visible
+  const panel = document.getElementById("jobs-panel");
+  if (panel && !panel.classList.contains("hidden") && !activeJobId) {
+    if (_jobViewSwitching) return;
+    if (
+      action === "delete" &&
+      archiveDeleteBatchIds &&
+      archiveDeleteBatchIds.has(Number(data.id))
+    ) {
+      return;
+    }
+    if (suppressListRender) return;
+    renderJobsList();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1491,17 +1653,18 @@ function handleJobEvent(action, data) {
 // ---------------------------------------------------------------------------
 
 function showConvertToJobModal(msgId) {
-    const msgEl = document.querySelector(`.message[data-id="${msgId}"]`);
-    if (!msgEl) return;
-    const rawText = msgEl.dataset.rawText || '';
-    const msgSender = msgEl.querySelector('.msg-sender')?.textContent || window.username;
+  const msgEl = document.querySelector(`.message[data-id="${msgId}"]`);
+  if (!msgEl) return;
+  const rawText = msgEl.dataset.rawText || "";
+  const msgSender =
+    msgEl.querySelector(".msg-sender")?.textContent || window.username;
 
-    let modal = document.getElementById('convert-job-modal');
-    if (!modal) {
-        modal = document.createElement('div');
-        modal.id = 'convert-job-modal';
-        modal.className = 'convert-job-modal hidden';
-        modal.innerHTML = `
+  let modal = document.getElementById("convert-job-modal");
+  if (!modal) {
+    modal = document.createElement("div");
+    modal.id = "convert-job-modal";
+    modal.className = "convert-job-modal hidden";
+    modal.innerHTML = `
             <div class="convert-job-dialog">
                 <h3 class="convert-job-title">Convert to Job</h3>
                 <p class="convert-job-subtitle">An agent will write a job proposal for you to accept</p>
@@ -1513,91 +1676,97 @@ function showConvertToJobModal(msgId) {
                     <button class="convert-job-confirm">Convert</button>
                 </div>
             </div>`;
-        modal.addEventListener('click', (e) => {
-            if (e.target === modal) closeConvertJobModal();
-        });
-        document.body.appendChild(modal);
-    }
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) closeConvertJobModal();
+    });
+    document.body.appendChild(modal);
+  }
 
-    // Store raw text on modal for the confirm handler
-    modal.dataset.rawText = rawText;
-    modal.dataset.sourceMsgId = String(msgId);
+  // Store raw text on modal for the confirm handler
+  modal.dataset.rawText = rawText;
+  modal.dataset.sourceMsgId = String(msgId);
 
-    // Populate message preview
-    const previewEl = modal.querySelector('.convert-job-preview');
-    previewEl.innerHTML = window.renderMarkdown(rawText.substring(0, 500));
+  // Populate message preview
+  const previewEl = modal.querySelector(".convert-job-preview");
+  previewEl.innerHTML = window.renderMarkdown(rawText.substring(0, 500));
 
-    // Populate agent picker — only agents, not humans
-    const selectEl = modal.querySelector('.convert-job-agent');
-    selectEl.innerHTML = '';
-    const agents = Object.keys(window.agentConfig);
-    const defaultAgent = agents.includes(msgSender) ? msgSender : agents[0];
-    for (const name of agents) {
-        const opt = document.createElement('option');
-        opt.value = name;
-        const cfg = window.agentConfig[name];
-        opt.textContent = cfg?.label || name;
-        if (name === defaultAgent) opt.selected = true;
-        selectEl.appendChild(opt);
-    }
+  // Populate agent picker — only agents, not humans
+  const selectEl = modal.querySelector(".convert-job-agent");
+  selectEl.innerHTML = "";
+  const agents = Object.keys(window.agentConfig);
+  const defaultAgent = agents.includes(msgSender) ? msgSender : agents[0];
+  for (const name of agents) {
+    const opt = document.createElement("option");
+    opt.value = name;
+    const cfg = window.agentConfig[name];
+    opt.textContent = cfg?.label || name;
+    if (name === defaultAgent) opt.selected = true;
+    selectEl.appendChild(opt);
+  }
 
-    // Wire buttons (clone to remove old listeners)
-    const cancelBtn = modal.querySelector('.convert-job-cancel');
-    const confirmBtn = modal.querySelector('.convert-job-confirm');
-    const newCancel = cancelBtn.cloneNode(true);
-    cancelBtn.parentNode.replaceChild(newCancel, cancelBtn);
-    const newConfirm = confirmBtn.cloneNode(true);
-    confirmBtn.parentNode.replaceChild(newConfirm, confirmBtn);
+  // Wire buttons (clone to remove old listeners)
+  const cancelBtn = modal.querySelector(".convert-job-cancel");
+  const confirmBtn = modal.querySelector(".convert-job-confirm");
+  const newCancel = cancelBtn.cloneNode(true);
+  cancelBtn.parentNode.replaceChild(newCancel, cancelBtn);
+  const newConfirm = confirmBtn.cloneNode(true);
+  confirmBtn.parentNode.replaceChild(newConfirm, confirmBtn);
 
-    newCancel.addEventListener('click', closeConvertJobModal);
-    newConfirm.addEventListener('click', _doConvertToJob);
+  newCancel.addEventListener("click", closeConvertJobModal);
+  newConfirm.addEventListener("click", _doConvertToJob);
 
-    modal.classList.remove('hidden');
-    requestAnimationFrame(() => selectEl.focus());
+  modal.classList.remove("hidden");
+  requestAnimationFrame(() => selectEl.focus());
 }
 
 async function _doConvertToJob() {
-    const modal = document.getElementById('convert-job-modal');
-    if (!modal) return;
-    const agent = modal.querySelector('.convert-job-agent').value;
-    const rawText = modal.dataset.rawText || '';
-    const sourceMsgId = parseInt(modal.dataset.sourceMsgId || '0', 10) || 0;
-    if (!agent) return;
+  const modal = document.getElementById("convert-job-modal");
+  if (!modal) return;
+  const agent = modal.querySelector(".convert-job-agent").value;
+  const rawText = modal.dataset.rawText || "";
+  const sourceMsgId = parseInt(modal.dataset.sourceMsgId || "0", 10) || 0;
+  if (!agent) return;
 
-    closeConvertJobModal();
+  closeConvertJobModal();
 
-    // Show status message while agent drafts the job card
-    const statusMsg = {
-        id: Date.now(),
-        sender: 'system',
-        type: 'system',
-        text: `Asking @${agent} to create a job card\u2026`,
+  // Show status message while agent drafts the job card
+  const statusMsg = {
+    id: Date.now(),
+    sender: "system",
+    type: "system",
+    text: `Asking @${agent} to create a job card\u2026`,
+    channel: window.activeChannel,
+    time: new Date().toLocaleTimeString("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }),
+  };
+  if (window.appendMessage) window.appendMessage(statusMsg);
+
+  const instruction = `${window.username}: Please read the following message and use chat_propose_job to propose it as a job. Write a concise title (max 80 chars) and a clear body (max 500 chars) summarizing the task:\n\n---\n${rawText.substring(0, 800)}\n---`;
+
+  try {
+    await fetch("/api/trigger-agent", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agent,
+        message: instruction,
         channel: window.activeChannel,
-        time: new Date().toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
-    };
-    if (window.appendMessage) window.appendMessage(statusMsg);
-
-    const instruction = `${window.username}: Please read the following message and use chat_propose_job to propose it as a job. Write a concise title (max 80 chars) and a clear body (max 500 chars) summarizing the task:\n\n---\n${rawText.substring(0, 800)}\n---`;
-
-    try {
-        await fetch('/api/trigger-agent', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({
-                agent,
-                message: instruction,
-                channel: window.activeChannel,
-                source_msg_id: sourceMsgId,
-            }),
-        });
-    } catch (e) {
-        console.error('Failed to trigger agent for job conversion:', e);
-    }
+        source_msg_id: sourceMsgId,
+      }),
+    });
+  } catch (e) {
+    console.error("Failed to trigger agent for job conversion:", e);
+  }
 }
 
 function closeConvertJobModal() {
-    const modal = document.getElementById('convert-job-modal');
-    if (modal) modal.classList.add('hidden');
+  const modal = document.getElementById("convert-job-modal");
+  if (modal) modal.classList.add("hidden");
 }
 
 // ---------------------------------------------------------------------------
@@ -1605,12 +1774,12 @@ function closeConvertJobModal() {
 // ---------------------------------------------------------------------------
 
 function showDeleteJobModal(jobId) {
-    let modal = document.getElementById('delete-job-modal');
-    if (!modal) {
-        modal = document.createElement('div');
-        modal.id = 'delete-job-modal';
-        modal.className = 'convert-job-modal hidden';
-        modal.innerHTML = `
+  let modal = document.getElementById("delete-job-modal");
+  if (!modal) {
+    modal = document.createElement("div");
+    modal.id = "delete-job-modal";
+    modal.className = "convert-job-modal hidden";
+    modal.innerHTML = `
             <div class="convert-job-dialog delete-job-dialog">
                 <h3 class="convert-job-title">Delete Job Permanently?</h3>
                 <p class="convert-job-subtitle">This removes the job and its messages permanently. This cannot be undone.</p>
@@ -1620,41 +1789,41 @@ function showDeleteJobModal(jobId) {
                     <button class="delete-job-confirm">Delete</button>
                 </div>
             </div>`;
-        modal.addEventListener('click', (e) => {
-            if (e.target === modal) closeDeleteJobModal();
-        });
-        document.body.appendChild(modal);
-    }
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) closeDeleteJobModal();
+    });
+    document.body.appendChild(modal);
+  }
 
-    pendingDeleteJobId = jobId;
-    const job = jobsData.find(a => a.id === jobId);
-    const target = modal.querySelector('.delete-job-target');
-    if (target) {
-        const title = job?.title || `Job #${jobId}`;
-        target.textContent = title;
-    }
+  pendingDeleteJobId = jobId;
+  const job = jobsData.find((a) => a.id === jobId);
+  const target = modal.querySelector(".delete-job-target");
+  if (target) {
+    const title = job?.title || `Job #${jobId}`;
+    target.textContent = title;
+  }
 
-    const cancelBtn = modal.querySelector('.convert-job-cancel');
-    const confirmBtn = modal.querySelector('.delete-job-confirm');
-    const newCancel = cancelBtn.cloneNode(true);
-    cancelBtn.parentNode.replaceChild(newCancel, cancelBtn);
-    const newConfirm = confirmBtn.cloneNode(true);
-    confirmBtn.parentNode.replaceChild(newConfirm, confirmBtn);
-    newCancel.addEventListener('click', closeDeleteJobModal);
-    newConfirm.addEventListener('click', confirmDeleteJobPermanent);
+  const cancelBtn = modal.querySelector(".convert-job-cancel");
+  const confirmBtn = modal.querySelector(".delete-job-confirm");
+  const newCancel = cancelBtn.cloneNode(true);
+  cancelBtn.parentNode.replaceChild(newCancel, cancelBtn);
+  const newConfirm = confirmBtn.cloneNode(true);
+  confirmBtn.parentNode.replaceChild(newConfirm, confirmBtn);
+  newCancel.addEventListener("click", closeDeleteJobModal);
+  newConfirm.addEventListener("click", confirmDeleteJobPermanent);
 
-    modal.classList.remove('hidden');
-    requestAnimationFrame(() => newConfirm.focus());
+  modal.classList.remove("hidden");
+  requestAnimationFrame(() => newConfirm.focus());
 }
 
 function closeDeleteJobModal() {
-    const modal = document.getElementById('delete-job-modal');
-    if (modal) modal.classList.add('hidden');
-    pendingDeleteJobId = null;
+  const modal = document.getElementById("delete-job-modal");
+  if (modal) modal.classList.add("hidden");
+  pendingDeleteJobId = null;
 }
 
 function startJobFromMessage(msgId) {
-    showConvertToJobModal(msgId);
+  showConvertToJobModal(msgId);
 }
 
 // ---------------------------------------------------------------------------
@@ -1662,77 +1831,79 @@ function startJobFromMessage(msgId) {
 // ---------------------------------------------------------------------------
 
 async function acceptProposal(msgId) {
-    const msgEl = document.querySelector(`.message[data-id="${msgId}"]`);
-    if (!msgEl) return;
-    const title = msgEl.dataset.proposalTitle;
-    const body = msgEl.dataset.proposalBody;
-    const proposalSender = msgEl.dataset.proposalSender;
-    if (!title) return;
+  const msgEl = document.querySelector(`.message[data-id="${msgId}"]`);
+  if (!msgEl) return;
+  const title = msgEl.dataset.proposalTitle;
+  const body = msgEl.dataset.proposalBody;
+  const proposalSender = msgEl.dataset.proposalSender;
+  if (!title) return;
 
-    try {
-        const resp = await fetch('/api/jobs', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({
-                title,
-                body: body || '',
-                type: 'job',
-                channel: window.activeChannel,
-                created_by: proposalSender,
-                anchor_msg_id: msgId,
-            }),
-        });
-        const job = await resp.json();
-        if (job && job.id) {
-            // Update the proposal card to show "Accepted"
-            const card = msgEl.querySelector('.proposal-card');
-            if (card) {
-                card.classList.add('proposal-resolved');
-                const actions = card.querySelector('.proposal-actions');
-                if (actions) actions.innerHTML = '<div class="proposal-status-resolved">Accepted</div>';
-            }
-            // Open the job (don't push to jobsData — WS 'create' event handles that)
-            const panel = document.getElementById('jobs-panel');
-            if (panel.classList.contains('hidden')) toggleJobsPanel();
-            // Small delay to let WS event populate jobsData
-            setTimeout(() => {
-                openJobConversation(job.id);
-                // Set reply target to the proposing agent
-                if (proposalSender) {
-                    jobReplyTargets[job.id] = proposalSender;
-                    updateJobReplyTargetUI();
-                }
-            }, 200);
+  try {
+    const resp = await fetch("/api/jobs", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title,
+        body: body || "",
+        type: "job",
+        channel: window.activeChannel,
+        created_by: proposalSender,
+        anchor_msg_id: msgId,
+      }),
+    });
+    const job = await resp.json();
+    if (job && job.id) {
+      // Update the proposal card to show "Accepted"
+      const card = msgEl.querySelector(".proposal-card");
+      if (card) {
+        card.classList.add("proposal-resolved");
+        const actions = card.querySelector(".proposal-actions");
+        if (actions)
+          actions.innerHTML =
+            '<div class="proposal-status-resolved">Accepted</div>';
+      }
+      // Open the job (don't push to jobsData — WS 'create' event handles that)
+      const panel = document.getElementById("jobs-panel");
+      if (panel.classList.contains("hidden")) toggleJobsPanel();
+      // Small delay to let WS event populate jobsData
+      setTimeout(() => {
+        openJobConversation(job.id);
+        // Set reply target to the proposing agent
+        if (proposalSender) {
+          jobReplyTargets[job.id] = proposalSender;
+          updateJobReplyTargetUI();
         }
-    } catch (e) {
-        console.error('Failed to accept proposal:', e);
+      }, 200);
     }
+  } catch (e) {
+    console.error("Failed to accept proposal:", e);
+  }
 }
 
 async function dismissProposal(msgId) {
-    // Demote on server — converts proposal to regular chat message
-    try {
-        await fetch(`/api/messages/${msgId}/demote`, {
-            method: 'POST',
-            headers: { 'X-Session-Token': window.SESSION_TOKEN },
-        });
-    } catch (e) {
-        console.error('Failed to demote proposal:', e);
-    }
+  // Demote on server — converts proposal to regular chat message
+  try {
+    await fetch(`/api/messages/${msgId}/demote`, {
+      method: "POST",
+    });
+  } catch (e) {
+    console.error("Failed to demote proposal:", e);
+  }
 }
 
 async function requestChangesProposal(msgId) {
-    // Demote proposal to chat message, then open a reply to it
-    try {
-        await fetch(`/api/messages/${msgId}/demote`, {
-            method: 'POST',
-            headers: { 'X-Session-Token': window.SESSION_TOKEN },
-        });
-        // Wait briefly for WS edit event to re-render the message as chat
-        setTimeout(() => window.startReply(msgId), 200);
-    } catch (e) {
-        console.error('Failed to request changes on proposal:', e);
-    }
+  // Demote proposal to chat message, then open a reply to it
+  try {
+    await fetch(`/api/messages/${msgId}/demote`, {
+      method: "POST",
+    });
+    // Wait briefly for WS edit event to re-render the message as chat
+    setTimeout(() => window.startReply(msgId), 200);
+  } catch (e) {
+    console.error("Failed to request changes on proposal:", e);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1740,21 +1911,21 @@ async function requestChangesProposal(msgId) {
 // ---------------------------------------------------------------------------
 
 async function openJobFromBreadcrumb(jobId) {
-    const job = jobsData.find(a => a.id === jobId);
-    if (!job) return;
-    const panel = document.getElementById('jobs-panel');
-    if (panel.classList.contains('hidden')) {
-        // Force browser to compute the hidden state BEFORE removing class
-        void panel.offsetHeight;
-        // Remove hidden class — transition should animate from -360 to 0
-        panel.classList.remove('hidden');
-        document.getElementById('jobs-toggle').classList.add('active');
-        // Force reflow AFTER class change to commit the transition start
-        // before openJobConversation modifies child DOM
-        void panel.offsetHeight;
-    }
-    // Switch to conversation view for this job
-    await openJobConversation(jobId);
+  const job = jobsData.find((a) => a.id === jobId);
+  if (!job) return;
+  const panel = document.getElementById("jobs-panel");
+  if (panel.classList.contains("hidden")) {
+    // Force browser to compute the hidden state BEFORE removing class
+    void panel.offsetHeight;
+    // Remove hidden class — transition should animate from -360 to 0
+    panel.classList.remove("hidden");
+    document.getElementById("jobs-toggle").classList.add("active");
+    // Force reflow AFTER class change to commit the transition start
+    // before openJobConversation modifies child DOM
+    void panel.offsetHeight;
+  }
+  // Switch to conversation view for this job
+  await openJobConversation(jobId);
 }
 
 // ---------------------------------------------------------------------------
@@ -1762,30 +1933,34 @@ async function openJobFromBreadcrumb(jobId) {
 // ---------------------------------------------------------------------------
 
 async function acceptSuggestion(jobId, msgIndex) {
-    try {
-        await fetch(`/api/jobs/${jobId}/messages/${msgIndex}/resolve`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({ resolution: 'accepted' }),
-        });
-        // Reload conversation to reflect change
-        await loadJobMessages(jobId);
-    } catch (e) {
-        console.error('Failed to accept suggestion:', e);
-    }
+  try {
+    await fetch(`/api/jobs/${jobId}/messages/${msgIndex}/resolve`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ resolution: "accepted" }),
+    });
+    // Reload conversation to reflect change
+    await loadJobMessages(jobId);
+  } catch (e) {
+    console.error("Failed to accept suggestion:", e);
+  }
 }
 
 async function dismissSuggestion(jobId, msgIndex) {
-    try {
-        await fetch(`/api/jobs/${jobId}/messages/${msgIndex}/resolve`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({ resolution: 'dismissed' }),
-        });
-        await loadJobMessages(jobId);
-    } catch (e) {
-        console.error('Failed to dismiss suggestion:', e);
-    }
+  try {
+    await fetch(`/api/jobs/${jobId}/messages/${msgIndex}/resolve`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ resolution: "dismissed" }),
+    });
+    await loadJobMessages(jobId);
+  } catch (e) {
+    console.error("Failed to dismiss suggestion:", e);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1793,23 +1968,22 @@ async function dismissSuggestion(jobId, msgIndex) {
 // ---------------------------------------------------------------------------
 
 async function deleteJobPermanent(jobId) {
-    showDeleteJobModal(jobId);
+  showDeleteJobModal(jobId);
 }
 
 async function confirmDeleteJobPermanent() {
-    const jobId = pendingDeleteJobId;
-    if (!jobId) return;
-    closeDeleteJobModal();
-    try {
-        await fetch(`/api/jobs/${jobId}?permanent=true`, {
-            method: 'DELETE',
-            headers: { 'X-Session-Token': window.SESSION_TOKEN },
-        });
-        jobsData = jobsData.filter(a => a.id !== jobId);
-        renderJobsList();
-    } catch (e) {
-        console.error('Failed to delete job:', e);
-    }
+  const jobId = pendingDeleteJobId;
+  if (!jobId) return;
+  closeDeleteJobModal();
+  try {
+    await fetch(`/api/jobs/${jobId}?permanent=true`, {
+      method: "DELETE",
+    });
+    jobsData = jobsData.filter((a) => a.id !== jobId);
+    renderJobsList();
+  } catch (e) {
+    console.error("Failed to delete job:", e);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1817,104 +1991,111 @@ async function confirmDeleteJobPermanent() {
 // ---------------------------------------------------------------------------
 
 function captureJobCardTops() {
-    const tops = new Map();
-    document.querySelectorAll('#jobs-list .job-card').forEach((card) => {
-        const id = Number(card.dataset.id);
-        if (!Number.isFinite(id)) return;
-        tops.set(id, card.getBoundingClientRect().top);
-    });
-    return tops;
+  const tops = new Map();
+  document.querySelectorAll("#jobs-list .job-card").forEach((card) => {
+    const id = Number(card.dataset.id);
+    if (!Number.isFinite(id)) return;
+    tops.set(id, card.getBoundingClientRect().top);
+  });
+  return tops;
 }
 
 function animateJobListReflow(prevTops) {
-    if (!prevTops || prevTops.size === 0) return;
-    const moved = [];
-    document.querySelectorAll('#jobs-list .job-card').forEach((card) => {
-        const id = Number(card.dataset.id);
-        if (!prevTops.has(id)) return;
-        const previous = prevTops.get(id);
-        const next = card.getBoundingClientRect().top;
-        const dy = previous - next;
-        if (Math.abs(dy) < 1) return;
-        moved.push({ card, dy });
-    });
-    if (moved.length === 0) return;
+  if (!prevTops || prevTops.size === 0) return;
+  const moved = [];
+  document.querySelectorAll("#jobs-list .job-card").forEach((card) => {
+    const id = Number(card.dataset.id);
+    if (!prevTops.has(id)) return;
+    const previous = prevTops.get(id);
+    const next = card.getBoundingClientRect().top;
+    const dy = previous - next;
+    if (Math.abs(dy) < 1) return;
+    moved.push({ card, dy });
+  });
+  if (moved.length === 0) return;
 
-    // FLIP: set initial offset (no transition)
-    for (const { card, dy } of moved) {
-        card.style.transition = 'none';
-        card.style.transform = `translateY(${dy}px)`;
+  // FLIP: set initial offset (no transition)
+  for (const { card, dy } of moved) {
+    card.style.transition = "none";
+    card.style.transform = `translateY(${dy}px)`;
+  }
+
+  // Force the browser to commit the offset before starting the transition
+  void document.body.offsetHeight;
+
+  // Use setTimeout to escape any browser D&D paint suppression logic
+  setTimeout(() => {
+    for (const { card } of moved) {
+      card.style.transition = "transform 260ms cubic-bezier(0.22, 1, 0.36, 1)";
+      card.style.transform = "translateY(0)";
+      const cleanup = () => {
+        card.style.transition = "";
+        card.style.transform = "";
+        card.removeEventListener("transitionend", cleanup);
+      };
+      card.addEventListener("transitionend", cleanup);
+      // Fallback cleanup in case transitionend doesn't fire
+      setTimeout(cleanup, 300);
     }
-
-    // Force the browser to commit the offset before starting the transition
-    void document.body.offsetHeight;
-
-    // Use setTimeout to escape any browser D&D paint suppression logic
-    setTimeout(() => {
-        for (const { card } of moved) {
-            card.style.transition = 'transform 260ms cubic-bezier(0.22, 1, 0.36, 1)';
-            card.style.transform = 'translateY(0)';
-            const cleanup = () => {
-                card.style.transition = '';
-                card.style.transform = '';
-                card.removeEventListener('transitionend', cleanup);
-            };
-            card.addEventListener('transitionend', cleanup);
-            // Fallback cleanup in case transitionend doesn't fire
-            setTimeout(cleanup, 300);
-        }
-    }, 20);
+  }, 20);
 }
 
 async function deleteArchiveIds(ids, trashZone) {
-    const normalizedIds = [...new Set(
-        (ids || []).map(id => Number(id)).filter(id => Number.isFinite(id))
-    )];
-    if (normalizedIds.length === 0) return;
-    const prevTops = captureJobCardTops();
-    archiveDeleteBatchIds = new Set(normalizedIds);
-    const itemsContainer = trashZone.closest('.jobs-group-items');
-    if (itemsContainer) {
-        for (const id of normalizedIds) {
-            const el = itemsContainer.querySelector(`.job-card[data-id="${id}"]`);
-            if (el) el.classList.add('archive-removing');
-        }
-    }
-    trashZone.classList.add('chomping');
-    const deletedIds = [];
+  const normalizedIds = [
+    ...new Set(
+      (ids || []).map((id) => Number(id)).filter((id) => Number.isFinite(id)),
+    ),
+  ];
+  if (normalizedIds.length === 0) return;
+  const prevTops = captureJobCardTops();
+  archiveDeleteBatchIds = new Set(normalizedIds);
+  const itemsContainer = trashZone.closest(".jobs-group-items");
+  if (itemsContainer) {
     for (const id of normalizedIds) {
-        try {
-            const resp = await fetch(`/api/jobs/${id}?permanent=true`, {
-                method: 'DELETE',
-                headers: { 'X-Session-Token': window.SESSION_TOKEN },
-            });
-            if (resp.ok) deletedIds.push(id);
-        } catch (err) { console.error('Failed to delete job:', err); }
+      const el = itemsContainer.querySelector(`.job-card[data-id="${id}"]`);
+      if (el) el.classList.add("archive-removing");
     }
-    if (deletedIds.length > 0) {
-        const deletedSet = new Set(deletedIds);
-        jobsData = jobsData.filter(a => !deletedSet.has(Number(a.id)));
-        for (const id of deletedIds) delete jobUnread[id];
-        renderJobsList();
-        animateJobListReflow(prevTops);
-        updateJobsBadge();
+  }
+  trashZone.classList.add("chomping");
+  const deletedIds = [];
+  for (const id of normalizedIds) {
+    try {
+      const resp = await fetch(`/api/jobs/${id}?permanent=true`, {
+        method: "DELETE",
+      });
+      if (resp.ok) deletedIds.push(id);
+    } catch (err) {
+      console.error("Failed to delete job:", err);
     }
-    setTimeout(() => { trashZone.classList.remove('chomping'); }, 500);
-    setTimeout(() => { archiveDeleteBatchIds = null; }, 1200);
+  }
+  if (deletedIds.length > 0) {
+    const deletedSet = new Set(deletedIds);
+    jobsData = jobsData.filter((a) => !deletedSet.has(Number(a.id)));
+    for (const id of deletedIds) delete jobUnread[id];
+    renderJobsList();
+    animateJobListReflow(prevTops);
+    updateJobsBadge();
+  }
+  setTimeout(() => {
+    trashZone.classList.remove("chomping");
+  }, 500);
+  setTimeout(() => {
+    archiveDeleteBatchIds = null;
+  }, 1200);
 }
 
 function updateArchiveTrashHint(container) {
-    const trash = container.querySelector('.archive-trash-zone');
-    if (!trash) return;
-    const count = container.querySelectorAll('.archive-selected').length;
-    const hint = trash.querySelector('.archive-trash-hint');
-    if (count > 0) {
-        trash.classList.add('has-selection');
-        hint.textContent = `Delete ${count} selected`;
-    } else {
-        trash.classList.remove('has-selection');
-        hint.textContent = 'Drag here to delete';
-    }
+  const trash = container.querySelector(".archive-trash-zone");
+  if (!trash) return;
+  const count = container.querySelectorAll(".archive-selected").length;
+  const hint = trash.querySelector(".archive-trash-hint");
+  if (count > 0) {
+    trash.classList.add("has-selection");
+    hint.textContent = `Delete ${count} selected`;
+  } else {
+    trash.classList.remove("has-selection");
+    hint.textContent = "Drag here to delete";
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1922,35 +2103,35 @@ function updateArchiveTrashHint(container) {
 // ---------------------------------------------------------------------------
 
 function syncJobUnreadCache() {
-    const validIds = new Set((jobsData || []).map(a => Number(a.id)));
-    for (const id of validIds) {
-        if (!Object.prototype.hasOwnProperty.call(jobUnread, id)) {
-            jobUnread[id] = 0;
-        }
+  const validIds = new Set((jobsData || []).map((a) => Number(a.id)));
+  for (const id of validIds) {
+    if (!Object.prototype.hasOwnProperty.call(jobUnread, id)) {
+      jobUnread[id] = 0;
     }
-    for (const key of Object.keys(jobUnread)) {
-        const id = Number(key);
-        if (!validIds.has(id)) {
-            delete jobUnread[key];
-        }
+  }
+  for (const key of Object.keys(jobUnread)) {
+    const id = Number(key);
+    if (!validIds.has(id)) {
+      delete jobUnread[key];
     }
+  }
 }
 
 function updateJobsBadge() {
-    const badge = document.getElementById('jobs-badge');
-    if (!badge) return;
-    let total = 0;
-    for (const count of Object.values(jobUnread)) {
-        total += Number(count || 0);
-    }
-    badge.textContent = total > 99 ? '99+' : String(total);
-    badge.classList.toggle('hidden', total === 0);
+  const badge = document.getElementById("jobs-badge");
+  if (!badge) return;
+  let total = 0;
+  for (const count of Object.values(jobUnread)) {
+    total += Number(count || 0);
+  }
+  badge.textContent = total > 99 ? "99+" : String(total);
+  badge.classList.toggle("hidden", total === 0);
 }
 
 function markJobRead(jobId) {
-    if (jobId == null) return;
-    jobUnread[jobId] = 0;
-    updateJobsBadge();
+  if (jobId == null) return;
+  jobUnread[jobId] = 0;
+  updateJobsBadge();
 }
 
 // ---------------------------------------------------------------------------
@@ -1958,129 +2139,140 @@ function markJobRead(jobId) {
 // ---------------------------------------------------------------------------
 
 function setupJobMentions() {
-    const input = document.getElementById('jobs-conv-input-text');
-    if (!input) return;
+  const input = document.getElementById("jobs-conv-input-text");
+  if (!input) return;
 
-    input.addEventListener('input', updateJobMentionMenu);
-    input.addEventListener('keydown', (e) => {
-        if (jobMentionVisible) {
-            const menu = document.getElementById('job-mention-menu');
-            const items = menu.querySelectorAll('.mention-item');
-            if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                jobMentionIndex = (jobMentionIndex - 1 + items.length) % items.length;
-                items.forEach((el, i) => el.classList.toggle('active', i === jobMentionIndex));
-                return;
-            }
-            if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                jobMentionIndex = (jobMentionIndex + 1) % items.length;
-                items.forEach((el, i) => el.classList.toggle('active', i === jobMentionIndex));
-                return;
-            }
-            if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
-                e.preventDefault();
-                const active = items[jobMentionIndex];
-                if (active) selectJobMention(active.dataset.name);
-                return;
-            }
-            if (e.key === 'Escape') {
-                menu.classList.add('hidden');
-                jobMentionVisible = false;
-                return;
-            }
-        }
-        // Note: Enter-to-send is handled by setupJobsInput() — don't duplicate here
-    });
+  input.addEventListener("input", updateJobMentionMenu);
+  input.addEventListener("keydown", (e) => {
+    if (jobMentionVisible) {
+      const menu = document.getElementById("job-mention-menu");
+      const items = menu.querySelectorAll(".mention-item");
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        jobMentionIndex = (jobMentionIndex - 1 + items.length) % items.length;
+        items.forEach((el, i) =>
+          el.classList.toggle("active", i === jobMentionIndex),
+        );
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        jobMentionIndex = (jobMentionIndex + 1) % items.length;
+        items.forEach((el, i) =>
+          el.classList.toggle("active", i === jobMentionIndex),
+        );
+        return;
+      }
+      if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) {
+        e.preventDefault();
+        const active = items[jobMentionIndex];
+        if (active) selectJobMention(active.dataset.name);
+        return;
+      }
+      if (e.key === "Escape") {
+        menu.classList.add("hidden");
+        jobMentionVisible = false;
+        return;
+      }
+    }
+    // Note: Enter-to-send is handled by setupJobsInput() — don't duplicate here
+  });
 }
 
 function updateJobMentionMenu() {
-    const menu = document.getElementById('job-mention-menu');
-    const input = document.getElementById('jobs-conv-input-text');
-    const text = input.value;
-    const cursor = input.selectionStart;
+  const menu = document.getElementById("job-mention-menu");
+  const input = document.getElementById("jobs-conv-input-text");
+  const text = input.value;
+  const cursor = input.selectionStart;
 
-    let atPos = -1;
-    for (let i = cursor - 1; i >= 0; i--) {
-        if (text[i] === '@') { atPos = i; break; }
-        if (!/[\w\-\s]/.test(text[i])) break;
-        if (cursor - i > 30) break;
+  let atPos = -1;
+  for (let i = cursor - 1; i >= 0; i--) {
+    if (text[i] === "@") {
+      atPos = i;
+      break;
     }
+    if (!/[\w\-\s]/.test(text[i])) break;
+    if (cursor - i > 30) break;
+  }
 
-    if (atPos < 0 || (atPos > 0 && /\w/.test(text[atPos - 1]))) {
-        menu.classList.add('hidden');
-        jobMentionVisible = false;
-        return;
-    }
+  if (atPos < 0 || (atPos > 0 && /\w/.test(text[atPos - 1]))) {
+    menu.classList.add("hidden");
+    jobMentionVisible = false;
+    return;
+  }
 
-    const query = text.slice(atPos + 1, cursor).toLowerCase();
-    jobMentionStart = atPos;
+  const query = text.slice(atPos + 1, cursor).toLowerCase();
+  jobMentionStart = atPos;
 
-    const candidates = window.getMentionCandidates();
-    const matches = candidates.filter(c =>
-        c.name.toLowerCase().includes(query) || c.label.toLowerCase().includes(query)
-    );
+  const candidates = window.getMentionCandidates();
+  const matches = candidates.filter(
+    (c) =>
+      c.name.toLowerCase().includes(query) ||
+      c.label.toLowerCase().includes(query),
+  );
 
-    if (matches.length === 0) {
-        menu.classList.add('hidden');
-        jobMentionVisible = false;
-        return;
-    }
+  if (matches.length === 0) {
+    menu.classList.add("hidden");
+    jobMentionVisible = false;
+    return;
+  }
 
-    menu.innerHTML = '';
-    jobMentionIndex = Math.min(jobMentionIndex, matches.length - 1);
+  menu.innerHTML = "";
+  jobMentionIndex = Math.min(jobMentionIndex, matches.length - 1);
 
-    matches.forEach((item, i) => {
-        const row = document.createElement('div');
-        row.className = 'mention-item' + (i === jobMentionIndex ? ' active' : '');
-        row.dataset.name = item.name;
-        row.innerHTML = `<span class="mention-dot" style="background: ${item.color}"></span><span class="mention-name">${window.escapeHtml(item.label)}</span>`;
-        row.addEventListener('mousedown', (e) => {
-            e.preventDefault();
-            selectJobMention(item.name);
-        });
-        row.addEventListener('mouseenter', () => {
-            jobMentionIndex = i;
-            menu.querySelectorAll('.mention-item').forEach((el, j) => el.classList.toggle('active', j === i));
-        });
-        menu.appendChild(row);
+  matches.forEach((item, i) => {
+    const row = document.createElement("div");
+    row.className = "mention-item" + (i === jobMentionIndex ? " active" : "");
+    row.dataset.name = item.name;
+    row.innerHTML = `<span class="mention-dot" style="background: ${item.color}"></span><span class="mention-name">${window.escapeHtml(item.label)}</span>`;
+    row.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      selectJobMention(item.name);
     });
+    row.addEventListener("mouseenter", () => {
+      jobMentionIndex = i;
+      menu
+        .querySelectorAll(".mention-item")
+        .forEach((el, j) => el.classList.toggle("active", j === i));
+    });
+    menu.appendChild(row);
+  });
 
-    menu.classList.remove('hidden');
-    jobMentionVisible = true;
+  menu.classList.remove("hidden");
+  jobMentionVisible = true;
 }
 
 function selectJobMention(name) {
-    const input = document.getElementById('jobs-conv-input-text');
-    window._lastMentionedAgent = name; // track for future job creation
-    const text = input.value;
-    const cursor = input.selectionStart;
-    const before = text.slice(0, jobMentionStart);
-    const after = text.slice(cursor);
-    const mention = `@${name} `;
-    input.value = before + mention + after;
-    const newPos = jobMentionStart + mention.length;
-    input.setSelectionRange(newPos, newPos);
-    input.focus();
-    document.getElementById('job-mention-menu').classList.add('hidden');
-    jobMentionVisible = false;
+  const input = document.getElementById("jobs-conv-input-text");
+  window._lastMentionedAgent = name; // track for future job creation
+  const text = input.value;
+  const cursor = input.selectionStart;
+  const before = text.slice(0, jobMentionStart);
+  const after = text.slice(cursor);
+  const mention = `@${name} `;
+  input.value = before + mention + after;
+  const newPos = jobMentionStart + mention.length;
+  input.setSelectionRange(newPos, newPos);
+  input.focus();
+  document.getElementById("job-mention-menu").classList.add("hidden");
+  jobMentionVisible = false;
 }
 
 // ---------------------------------------------------------------------------
 // Hub subscriptions -- handle job WebSocket events
 // ---------------------------------------------------------------------------
 
-Hub.on('jobs', function (event) {
-    jobsData = event.data || [];
-    syncJobUnreadCache();
-    updateJobsBadge();
-    renderJobsList();
-    // Unhide breadcrumbs that were hidden because jobsData was empty during replay
-    _unhideResolvedBreadcrumbs();
+Hub.on("jobs", function (event) {
+  jobsData = event.data || [];
+  syncJobUnreadCache();
+  updateJobsBadge();
+  renderJobsList();
+  // Unhide breadcrumbs that were hidden because jobsData was empty during replay
+  _unhideResolvedBreadcrumbs();
 });
 
-Hub.on('job', function (event) {
-    handleJobEvent(event.action, event.data);
+Hub.on("job", function (event) {
+  handleJobEvent(event.action, event.data);
 });
 
 // ---------------------------------------------------------------------------
@@ -2088,9 +2280,9 @@ Hub.on('job', function (event) {
 // ---------------------------------------------------------------------------
 
 function _jobsInit() {
-    setupJobsGrip();
-    setupJobsInput();
-    setupJobMentions();
+  setupJobsGrip();
+  setupJobsInput();
+  setupJobMentions();
 }
 
 // ---------------------------------------------------------------------------

--- a/static/launcher.css
+++ b/static/launcher.css
@@ -203,6 +203,11 @@
   border-color: var(--text-dim);
 }
 
+.launcher-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .launcher-btn.primary {
   border-color: var(--accent);
   color: var(--accent);

--- a/static/launcher.css
+++ b/static/launcher.css
@@ -1,0 +1,472 @@
+/* --- Launcher panel (right-side slide-out) --- */
+
+#launcher-panel {
+  --panel-w: 380px;
+  width: var(--panel-w);
+  min-width: 280px;
+  max-width: 50vw;
+  flex-shrink: 0;
+  background: var(--bg-header);
+  border-left: none;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  margin-right: 0;
+  transition:
+    margin-right 0.25s ease,
+    opacity 0.2s ease;
+  position: relative;
+}
+
+#launcher-panel.hidden {
+  margin-right: calc(-1 * var(--panel-w));
+  opacity: 0;
+  pointer-events: none;
+}
+
+.launcher-header {
+  display: flex;
+  align-items: center;
+  padding: var(--sb-padding);
+  font-size: var(--sb-title-fs);
+  font-weight: var(--sb-title-fw);
+  line-height: var(--sb-title-lh);
+  color: var(--text-dim);
+  border-bottom: var(--sb-card-border-width) solid var(--border);
+  flex-shrink: 0;
+  gap: var(--sb-gap);
+}
+
+.add-agent-btn {
+  margin-left: auto;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
+}
+
+.add-agent-btn:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+#launcher-list {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0;
+}
+
+/* --- Agent card --- */
+
+.launcher-card {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--sb-card-border-color);
+  transition: background var(--duration-fast) ease;
+}
+
+.launcher-card:hover {
+  background: var(--white-03);
+}
+
+.launcher-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.launcher-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.launcher-dot.online {
+  background: var(--online);
+}
+.launcher-dot.offline {
+  background: var(--text-dim);
+}
+.launcher-dot.crashed {
+  background: var(--error-color);
+}
+
+.launcher-card-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.launcher-card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.launcher-card-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* --- Status badges --- */
+
+.launcher-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+.launcher-badge.running {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.launcher-badge.crashed {
+  background: var(--error-soft);
+  color: var(--error-color);
+}
+
+.launcher-badge.stopped {
+  background: var(--white-06);
+  color: var(--text-dim);
+}
+
+/* --- Instance rows --- */
+
+.launcher-instance {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0 4px 16px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.launcher-instance-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launcher-instance-pid {
+  font-size: 10px;
+  opacity: 0.6;
+}
+
+/* --- Action buttons --- */
+
+.launcher-actions {
+  display: flex;
+  gap: 6px;
+  padding: 6px 0 2px 16px;
+  flex-wrap: wrap;
+}
+
+.launcher-btn {
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.launcher-btn:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.launcher-btn.primary {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.launcher-btn.primary:hover {
+  background: var(--accent-soft);
+  color: var(--text);
+}
+
+.launcher-btn.danger {
+  border-color: var(--danger);
+  color: var(--error-color);
+}
+
+.launcher-btn.danger:hover {
+  background: var(--danger-soft);
+}
+
+/* --- Launch config form --- */
+
+.launch-config {
+  padding: 8px 16px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--white-02);
+}
+
+.launch-config.hidden {
+  display: none;
+}
+
+.launch-config-field {
+  margin-bottom: 8px;
+}
+
+.launch-config-field label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  margin-bottom: 3px;
+}
+
+.launch-config-field input[type="text"],
+.launch-config-field textarea {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 5px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-input);
+  color: var(--text);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.launch-config-field input[type="text"]:focus,
+.launch-config-field textarea:focus {
+  border-color: var(--accent);
+}
+
+.launch-config-field textarea {
+  resize: vertical;
+  min-height: 32px;
+  max-height: 80px;
+}
+
+/* --- Flag toggles --- */
+
+.launch-flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.launch-flag-toggle {
+  font-family: inherit;
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: all 0.15s;
+  user-select: none;
+}
+
+.launch-flag-toggle.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.launch-flag-toggle:hover {
+  border-color: var(--text-dim);
+}
+
+/* --- Logs drawer --- */
+
+.launcher-logs {
+  max-height: 160px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin: 4px 16px 6px 16px;
+  padding: 6px 8px;
+  font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-dim);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.launcher-logs.hidden {
+  display: none;
+}
+
+.launcher-logs-empty {
+  font-style: italic;
+  opacity: 0.5;
+}
+
+/* --- Add Agent form --- */
+
+#add-agent-form {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--white-02);
+}
+
+#add-agent-form.hidden {
+  display: none;
+}
+
+.add-agent-field {
+  margin-bottom: 8px;
+}
+
+.add-agent-field label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  margin-bottom: 3px;
+}
+
+.add-agent-field input[type="text"] {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 5px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-input);
+  color: var(--text);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.add-agent-field input[type="text"]:focus {
+  border-color: var(--accent);
+}
+
+/* --- Colour swatches --- */
+
+.colour-swatches {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.colour-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    transform 0.1s;
+}
+
+.colour-swatch:hover {
+  transform: scale(1.15);
+}
+
+.colour-swatch.selected {
+  border-color: var(--text);
+  box-shadow: 0 0 0 2px var(--bg-header);
+}
+
+.add-agent-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+/* --- Restore banner --- */
+
+#restore-banner {
+  background: var(--bg-elevated);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  margin: 8px 16px;
+  padding: 10px 14px;
+}
+
+#restore-banner .restore-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+
+#restore-banner .restore-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+#restore-banner .restore-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+#restore-banner .restore-item input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
+#restore-banner .restore-actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* Badge on launcher toggle button */
+
+.launcher-badge-count {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  font-size: 9px;
+  font-weight: 700;
+  min-width: 14px;
+  height: 14px;
+  line-height: 14px;
+  text-align: center;
+  padding: 0 3px;
+  border-radius: var(--radius-full);
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.launcher-badge-count.hidden {
+  display: none;
+}

--- a/static/launcher.js
+++ b/static/launcher.js
@@ -18,6 +18,7 @@
 
 let launcherDefinitions = {}; // { name: { command, color, label, cwd } }
 let launcherFlagPresets = {}; // { base: [{ label, flag }] }
+let launcherBuiltinNames = {}; // { name: true }
 let launcherProcesses = []; // [{ name, base, state, pid, flags, cwd, started_at }]
 let launcherLogs = {}; // { name: ["line1", ...] }
 let launcherLogsOpen = {}; // { name: bool }
@@ -108,6 +109,10 @@ async function fetchDefinitions() {
     const data = await res.json();
     launcherDefinitions = data.definitions || {};
     launcherFlagPresets = data.flag_presets || {};
+    launcherBuiltinNames = {};
+    (data.builtin_names || []).forEach(function (name) {
+      launcherBuiltinNames[name] = true;
+    });
     renderLauncherPanel();
   } catch (e) {
     console.error("[launcher] fetchDefinitions error:", e);
@@ -159,6 +164,7 @@ function renderLauncherPanel() {
   // Group processes by base
   const procsByBase = {};
   for (const p of launcherProcesses) {
+    if (p.state === "stopped") continue;
     const base = p.base || p.name;
     if (!procsByBase[base]) procsByBase[base] = [];
     procsByBase[base].push(p);
@@ -217,6 +223,7 @@ function buildAgentCard(base, def, instances) {
   const crashed = partitions.crashed;
   const hasRunning = active.length > 0;
   const hasCrashed = crashed.length > 0;
+  const isBuiltin = !!launcherBuiltinNames[base];
 
   // Header: dot + info + badge
   var header = document.createElement("div");
@@ -381,6 +388,16 @@ function buildAgentCard(base, def, instances) {
     window.toggleLaunchConfig(this.getAttribute("data-base"));
   };
   mainActs.appendChild(launchBtn);
+  if (!isBuiltin && instances.length === 0) {
+    var deleteBtn = document.createElement("button");
+    deleteBtn.className = "launcher-btn danger";
+    deleteBtn.textContent = "Delete";
+    deleteBtn.setAttribute("data-base", base);
+    deleteBtn.onclick = function () {
+      window.deleteAgentDefinition(this.getAttribute("data-base"));
+    };
+    mainActs.appendChild(deleteBtn);
+  }
   el.appendChild(mainActs);
 
   // Launch config (if open)
@@ -529,6 +546,31 @@ async function stopAgent(name) {
     await fetchManagedAgents();
   } catch (e) {
     console.error("[launcher] stopAgent error:", e);
+  }
+}
+
+async function deleteAgentDefinition(base) {
+  if (!base) return;
+  if (!window.confirm("Delete custom agent '" + base + "'?")) return;
+
+  try {
+    var res = await fetch(
+      "/api/agent-definitions/" + encodeURIComponent(base),
+      {
+        method: "DELETE",
+      },
+    );
+    if (!res.ok) {
+      var err = await res.json().catch(function () {
+        return {};
+      });
+      console.error("[launcher] delete failed:", err);
+      return;
+    }
+    await fetchDefinitions();
+    await fetchManagedAgents();
+  } catch (e) {
+    console.error("[launcher] deleteAgentDefinition error:", e);
   }
 }
 
@@ -916,6 +958,7 @@ if (typeof window !== "undefined") {
   window.toggleAddAgentForm = toggleAddAgentForm;
   window.launchAgent = launchAgent;
   window.stopAgent = stopAgent;
+  window.deleteAgentDefinition = deleteAgentDefinition;
   window.toggleLaunchConfig = toggleLaunchConfig;
   window.toggleAgentLogs = toggleAgentLogs;
   window.selectColourSwatch = selectColourSwatch;

--- a/static/launcher.js
+++ b/static/launcher.js
@@ -35,6 +35,52 @@ const COLOUR_SWATCHES = [
   "#8b5cf6",
 ];
 
+function normalizeManagedAgentsPayload(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (payload && Array.isArray(payload.data)) return payload.data;
+  if (payload && Array.isArray(payload.processes)) return payload.processes;
+  return [];
+}
+
+function normalizeRestoreAgentsPayload(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (payload && Array.isArray(payload.data)) return payload.data;
+  if (payload && Array.isArray(payload.agents)) return payload.agents;
+  return [];
+}
+
+function normalizeAgentLogEvent(event) {
+  var source =
+    event &&
+    event.data &&
+    typeof event.data === "object" &&
+    !Array.isArray(event.data)
+      ? event.data
+      : event || {};
+
+  return {
+    name: source.name || "",
+    line: typeof source.line === "string" ? source.line : "",
+    lines: Array.isArray(source.lines) ? source.lines : [],
+  };
+}
+
+function buildRestoreLaunchBody(agent) {
+  var body = {
+    flags: Array.isArray(agent && agent.flags) ? agent.flags : [],
+    extra_args: Array.isArray(agent && agent.extra_args) ? agent.extra_args : [],
+  };
+
+  if (agent && agent.cwd) body.cwd = agent.cwd;
+  if (agent && agent.instance_label) {
+    body.instance_label = agent.instance_label;
+  } else if (agent && agent.name && agent.base && agent.name !== agent.base) {
+    body.instance_label = agent.name;
+  }
+
+  return body;
+}
+
 // ---------------------------------------------------------------------------
 // Data fetching
 // ---------------------------------------------------------------------------
@@ -57,7 +103,7 @@ async function fetchManagedAgents() {
     const res = await fetch("/api/agents/managed");
     if (!res.ok) return;
     const data = await res.json();
-    launcherProcesses = data.processes || [];
+    launcherProcesses = normalizeManagedAgentsPayload(data);
     renderLauncherPanel();
   } catch (e) {
     console.error("[launcher] fetchManagedAgents error:", e);
@@ -687,8 +733,9 @@ async function fetchRestoreAgents() {
     var res = await fetch("/api/agents/restore");
     if (!res.ok) return;
     var data = await res.json();
-    if (data.agents && data.agents.length > 0) {
-      showRestoreBanner(data.agents);
+    var agents = normalizeRestoreAgentsPayload(data);
+    if (agents.length > 0) {
+      showRestoreBanner(agents);
     }
   } catch (e) {
     console.error("[launcher] fetchRestoreAgents error:", e);
@@ -722,6 +769,7 @@ function showRestoreBanner(agents) {
     cb.checked = true;
     cb.value = agent.name || agent.base || "";
     cb.setAttribute("data-base", agent.base || "");
+    cb.setAttribute("data-launch-body", JSON.stringify(buildRestoreLaunchBody(agent)));
     item.appendChild(cb);
     var span = document.createElement("span");
     span.textContent = agent.label || agent.name || agent.base;
@@ -755,21 +803,28 @@ async function relaunchSelected() {
   var launches = [];
   checkboxes.forEach(function (cb) {
     var base = cb.getAttribute("data-base") || cb.value;
-    if (base) launches.push(base);
+    if (!base) return;
+    var body = {};
+    try {
+      body = JSON.parse(cb.getAttribute("data-launch-body") || "{}");
+    } catch (_err) {
+      body = {};
+    }
+    launches.push({ base: base, body: body });
   });
 
   for (var li = 0; li < launches.length; li++) {
     try {
       await fetch(
-        "/api/agents/" + encodeURIComponent(launches[li]) + "/launch",
+        "/api/agents/" + encodeURIComponent(launches[li].base) + "/launch",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({}),
+          body: JSON.stringify(launches[li].body),
         },
       );
     } catch (e) {
-      console.error("[launcher] relaunch error for", launches[li], e);
+      console.error("[launcher] relaunch error for", launches[li].base, e);
     }
   }
 
@@ -792,59 +847,75 @@ async function dismissRestore() {
 // Hub event subscriptions
 // ---------------------------------------------------------------------------
 
-Hub.on("agent_processes", function (event) {
-  launcherProcesses = event.processes || event.data || [];
-  renderLauncherPanel();
-});
+if (typeof Hub !== "undefined") {
+  Hub.on("agent_processes", function (event) {
+    launcherProcesses = normalizeManagedAgentsPayload(event);
+    renderLauncherPanel();
+  });
 
-Hub.on("agent_log", function (event) {
-  var name = event.name;
-  if (!name) return;
-  if (!launcherLogs[name]) launcherLogs[name] = [];
-  if (event.line) {
-    launcherLogs[name].push(event.line);
-    // Cap at 500 lines
-    if (launcherLogs[name].length > 500) {
-      launcherLogs[name] = launcherLogs[name].slice(-500);
+  Hub.on("agent_log", function (event) {
+    var logEvent = normalizeAgentLogEvent(event);
+    var name = logEvent.name;
+    if (!name) return;
+    if (!launcherLogs[name]) launcherLogs[name] = [];
+    if (logEvent.line) {
+      launcherLogs[name].push(logEvent.line);
+      // Cap at 500 lines
+      if (launcherLogs[name].length > 500) {
+        launcherLogs[name] = launcherLogs[name].slice(-500);
+      }
     }
-  }
-  if (event.lines) {
-    launcherLogs[name] = launcherLogs[name].concat(event.lines);
-    if (launcherLogs[name].length > 500) {
-      launcherLogs[name] = launcherLogs[name].slice(-500);
+    if (logEvent.lines.length > 0) {
+      launcherLogs[name] = launcherLogs[name].concat(logEvent.lines);
+      if (launcherLogs[name].length > 500) {
+        launcherLogs[name] = launcherLogs[name].slice(-500);
+      }
     }
-  }
-  if (launcherLogsOpen[name]) {
-    renderAgentLogs(name);
-  }
-});
+    if (launcherLogsOpen[name]) {
+      renderAgentLogs(name);
+    }
+  });
 
-Hub.on("session_restore", function (event) {
-  var agents = event.agents || (event.data && event.data.agents) || [];
-  if (agents.length > 0) {
-    showRestoreBanner(agents);
-  }
-});
+  Hub.on("session_restore", function (event) {
+    var agents = normalizeRestoreAgentsPayload(event);
+    if (agents.length > 0) {
+      showRestoreBanner(agents);
+    }
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Init: fetch restore agents on load
 // ---------------------------------------------------------------------------
 
-document.addEventListener("DOMContentLoaded", function () {
-  fetchRestoreAgents();
-});
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", function () {
+    fetchRestoreAgents();
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Window exports (for onclick handlers)
 // ---------------------------------------------------------------------------
 
-window.toggleLauncherPanel = toggleLauncherPanel;
-window.toggleAddAgentForm = toggleAddAgentForm;
-window.launchAgent = launchAgent;
-window.stopAgent = stopAgent;
-window.toggleLaunchConfig = toggleLaunchConfig;
-window.toggleAgentLogs = toggleAgentLogs;
-window.selectColourSwatch = selectColourSwatch;
-window.saveNewAgent = saveNewAgent;
-window.relaunchSelected = relaunchSelected;
-window.dismissRestore = dismissRestore;
+if (typeof window !== "undefined") {
+  window.toggleLauncherPanel = toggleLauncherPanel;
+  window.toggleAddAgentForm = toggleAddAgentForm;
+  window.launchAgent = launchAgent;
+  window.stopAgent = stopAgent;
+  window.toggleLaunchConfig = toggleLaunchConfig;
+  window.toggleAgentLogs = toggleAgentLogs;
+  window.selectColourSwatch = selectColourSwatch;
+  window.saveNewAgent = saveNewAgent;
+  window.relaunchSelected = relaunchSelected;
+  window.dismissRestore = dismissRestore;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    buildRestoreLaunchBody,
+    normalizeAgentLogEvent,
+    normalizeManagedAgentsPayload,
+    normalizeRestoreAgentsPayload,
+  };
+}

--- a/static/launcher.js
+++ b/static/launcher.js
@@ -1,0 +1,850 @@
+/**
+ * launcher.js -- Agent Launcher panel UI module
+ *
+ * Depends on core.js (Hub) loaded first.
+ * Uses escapeHtml() from chat.js for ALL user content.
+ *
+ * Owns all launcher state, rendering, and interaction logic.
+ * Subscribes to Hub for WS events.
+ *
+ * NOTE: All user-provided strings are sanitised via escapeHtml() before
+ * insertion into the DOM, following the same XSS-prevention pattern used
+ * throughout the codebase (jobs.js, chat.js, rules-panel.js).
+ */
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let launcherDefinitions = {}; // { name: { command, color, label, cwd } }
+let launcherFlagPresets = {}; // { base: [{ label, flag }] }
+let launcherProcesses = []; // [{ name, base, state, pid, flags, cwd, started_at }]
+let launcherLogs = {}; // { name: ["line1", ...] }
+let launcherLogsOpen = {}; // { name: bool }
+let launcherConfigOpen = {}; // { base: bool }
+let _selectedColour = "#7c3aed";
+
+const COLOUR_SWATCHES = [
+  "#7c3aed",
+  "#3b82f6",
+  "#06b6d4",
+  "#10b981",
+  "#f59e0b",
+  "#ef4444",
+  "#ec4899",
+  "#8b5cf6",
+];
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+
+async function fetchDefinitions() {
+  try {
+    const res = await fetch("/api/agent-definitions");
+    if (!res.ok) return;
+    const data = await res.json();
+    launcherDefinitions = data.definitions || {};
+    launcherFlagPresets = data.flag_presets || {};
+    renderLauncherPanel();
+  } catch (e) {
+    console.error("[launcher] fetchDefinitions error:", e);
+  }
+}
+
+async function fetchManagedAgents() {
+  try {
+    const res = await fetch("/api/agents/managed");
+    if (!res.ok) return;
+    const data = await res.json();
+    launcherProcesses = data.processes || [];
+    renderLauncherPanel();
+  } catch (e) {
+    console.error("[launcher] fetchManagedAgents error:", e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Panel toggle
+// ---------------------------------------------------------------------------
+
+function toggleLauncherPanel() {
+  const panel = document.getElementById("launcher-panel");
+  const btn = document.getElementById("launcher-toggle");
+  if (!panel) return;
+  const isHidden = panel.classList.toggle("hidden");
+  if (btn) btn.classList.toggle("active", !isHidden);
+  if (!isHidden) {
+    fetchDefinitions();
+    fetchManagedAgents();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+function renderLauncherPanel() {
+  const list = document.getElementById("launcher-list");
+  if (!list) return;
+
+  const esc =
+    window.escapeHtml ||
+    function (s) {
+      return String(s);
+    };
+
+  // Group processes by base
+  const procsByBase = {};
+  for (const p of launcherProcesses) {
+    const base = p.base || p.name;
+    if (!procsByBase[base]) procsByBase[base] = [];
+    procsByBase[base].push(p);
+  }
+
+  // Render cards for each definition
+  const bases = Object.keys(launcherDefinitions);
+  if (bases.length === 0 && launcherProcesses.length === 0) {
+    list.textContent = "";
+    const empty = document.createElement("div");
+    empty.style.cssText =
+      "padding:16px;color:var(--text-dim);font-size:12px;text-align:center;";
+    empty.textContent = "No agents defined. Click + Add Agent to get started.";
+    list.appendChild(empty);
+    return;
+  }
+
+  // Build new content in a fragment to minimise reflows
+  const frag = document.createDocumentFragment();
+
+  for (const base of bases) {
+    const def = launcherDefinitions[base];
+    const instances = procsByBase[base] || [];
+    frag.appendChild(buildAgentCard(base, def, instances));
+  }
+
+  // Render any processes whose base isn't in definitions
+  for (const base of Object.keys(procsByBase)) {
+    if (!launcherDefinitions[base]) {
+      const instances = procsByBase[base];
+      frag.appendChild(
+        buildAgentCard(
+          base,
+          { command: "", color: "#888", label: base },
+          instances,
+        ),
+      );
+    }
+  }
+
+  list.textContent = "";
+  list.appendChild(frag);
+}
+
+function buildAgentCard(base, def, instances) {
+  const esc =
+    window.escapeHtml ||
+    function (s) {
+      return String(s);
+    };
+  const el = document.createElement("div");
+  el.className = "launcher-card";
+
+  const running = instances.filter(function (p) {
+    return p.state === "running";
+  });
+  const crashed = instances.filter(function (p) {
+    return p.state === "crashed";
+  });
+  const hasRunning = running.length > 0;
+  const hasCrashed = crashed.length > 0;
+
+  // Header: dot + info + badge
+  var header = document.createElement("div");
+  header.className = "launcher-card-header";
+
+  var dot = document.createElement("span");
+  dot.className =
+    "launcher-dot " +
+    (hasRunning ? "online" : hasCrashed ? "crashed" : "offline");
+  header.appendChild(dot);
+
+  var info = document.createElement("div");
+  info.className = "launcher-card-info";
+  var nameDiv = document.createElement("div");
+  nameDiv.className = "launcher-card-name";
+  if (def.color) nameDiv.style.color = def.color;
+  nameDiv.textContent = def.label || base;
+  info.appendChild(nameDiv);
+  if (def.command) {
+    var cmdDiv = document.createElement("div");
+    cmdDiv.className = "launcher-card-meta";
+    cmdDiv.textContent = def.command;
+    info.appendChild(cmdDiv);
+  }
+  if (def.cwd) {
+    var cwdDiv = document.createElement("div");
+    cwdDiv.className = "launcher-card-meta";
+    cwdDiv.textContent = def.cwd;
+    info.appendChild(cwdDiv);
+  }
+  header.appendChild(info);
+
+  var badge = document.createElement("span");
+  badge.className =
+    "launcher-badge " +
+    (hasRunning ? "running" : hasCrashed ? "crashed" : "stopped");
+  badge.textContent = hasRunning
+    ? "running"
+    : hasCrashed
+      ? "crashed"
+      : "stopped";
+  header.appendChild(badge);
+
+  el.appendChild(header);
+
+  // Running instances
+  for (var ri = 0; ri < running.length; ri++) {
+    var p = running[ri];
+    var inst = document.createElement("div");
+    inst.className = "launcher-instance";
+    var iName = document.createElement("span");
+    iName.className = "launcher-instance-name";
+    iName.textContent = p.name;
+    inst.appendChild(iName);
+    if (p.pid) {
+      var pidSpan = document.createElement("span");
+      pidSpan.className = "launcher-instance-pid";
+      pidSpan.textContent = "PID " + p.pid;
+      inst.appendChild(pidSpan);
+    }
+    if (p.started_at) {
+      var upSpan = document.createElement("span");
+      upSpan.className = "launcher-instance-pid";
+      upSpan.textContent = formatUptime(p.started_at);
+      inst.appendChild(upSpan);
+    }
+    el.appendChild(inst);
+
+    var acts = document.createElement("div");
+    acts.className = "launcher-actions";
+    var stopBtn = document.createElement("button");
+    stopBtn.className = "launcher-btn danger";
+    stopBtn.textContent = "Stop";
+    stopBtn.setAttribute("data-name", p.name);
+    stopBtn.onclick = function () {
+      window.stopAgent(this.getAttribute("data-name"));
+    };
+    acts.appendChild(stopBtn);
+    var logsBtn = document.createElement("button");
+    logsBtn.className = "launcher-btn";
+    logsBtn.textContent = "Logs";
+    logsBtn.setAttribute("data-name", p.name);
+    logsBtn.onclick = function () {
+      window.toggleAgentLogs(this.getAttribute("data-name"));
+    };
+    acts.appendChild(logsBtn);
+    el.appendChild(acts);
+
+    if (launcherLogsOpen[p.name]) {
+      var logsDiv = document.createElement("div");
+      logsDiv.className = "launcher-logs";
+      logsDiv.id = "logs-" + p.name;
+      var lines = launcherLogs[p.name];
+      if (lines && lines.length > 0) {
+        logsDiv.textContent = lines.join("\n");
+      } else {
+        var emptySpan = document.createElement("span");
+        emptySpan.className = "launcher-logs-empty";
+        emptySpan.textContent = "No logs yet...";
+        logsDiv.appendChild(emptySpan);
+      }
+      el.appendChild(logsDiv);
+    }
+  }
+
+  // Crashed instances
+  for (var ci = 0; ci < crashed.length; ci++) {
+    var cp = crashed[ci];
+    var cInst = document.createElement("div");
+    cInst.className = "launcher-instance";
+    var cName = document.createElement("span");
+    cName.className = "launcher-instance-name";
+    cName.textContent = cp.name + " (crashed)";
+    cInst.appendChild(cName);
+    el.appendChild(cInst);
+
+    var cActs = document.createElement("div");
+    cActs.className = "launcher-actions";
+    var relaunchBtn = document.createElement("button");
+    relaunchBtn.className = "launcher-btn primary";
+    relaunchBtn.textContent = "Relaunch";
+    relaunchBtn.setAttribute("data-base", base);
+    relaunchBtn.onclick = function () {
+      window.launchAgent(this.getAttribute("data-base"));
+    };
+    cActs.appendChild(relaunchBtn);
+    var cLogsBtn = document.createElement("button");
+    cLogsBtn.className = "launcher-btn";
+    cLogsBtn.textContent = "Logs";
+    cLogsBtn.setAttribute("data-name", cp.name);
+    cLogsBtn.onclick = function () {
+      window.toggleAgentLogs(this.getAttribute("data-name"));
+    };
+    cActs.appendChild(cLogsBtn);
+    el.appendChild(cActs);
+
+    if (launcherLogsOpen[cp.name]) {
+      var cLogsDiv = document.createElement("div");
+      cLogsDiv.className = "launcher-logs";
+      cLogsDiv.id = "logs-" + cp.name;
+      var cLines = launcherLogs[cp.name];
+      if (cLines && cLines.length > 0) {
+        cLogsDiv.textContent = cLines.join("\n");
+      } else {
+        var cEmptySpan = document.createElement("span");
+        cEmptySpan.className = "launcher-logs-empty";
+        cEmptySpan.textContent = "No logs yet...";
+        cLogsDiv.appendChild(cEmptySpan);
+      }
+      el.appendChild(cLogsDiv);
+    }
+  }
+
+  // Actions row: Launch / Launch Another
+  var mainActs = document.createElement("div");
+  mainActs.className = "launcher-actions";
+  var launchBtn = document.createElement("button");
+  launchBtn.className = "launcher-btn primary";
+  launchBtn.textContent = hasRunning ? "Launch Another" : "Launch";
+  launchBtn.setAttribute("data-base", base);
+  launchBtn.onclick = function () {
+    window.toggleLaunchConfig(this.getAttribute("data-base"));
+  };
+  mainActs.appendChild(launchBtn);
+  el.appendChild(mainActs);
+
+  // Launch config (if open)
+  if (launcherConfigOpen[base]) {
+    el.appendChild(buildLaunchConfig(base, def));
+  }
+
+  return el;
+}
+
+function buildLaunchConfig(base, def) {
+  var esc =
+    window.escapeHtml ||
+    function (s) {
+      return String(s);
+    };
+  var container = document.createElement("div");
+  container.className = "launch-config";
+
+  var defaultCwd = def.cwd || "";
+  var presets = launcherFlagPresets[base] || [];
+
+  // CWD field
+  var cwdField = document.createElement("div");
+  cwdField.className = "launch-config-field";
+  var cwdLabel = document.createElement("label");
+  cwdLabel.textContent = "Working directory";
+  cwdField.appendChild(cwdLabel);
+  var cwdInput = document.createElement("input");
+  cwdInput.type = "text";
+  cwdInput.id = "launch-cwd-" + base;
+  cwdInput.value = defaultCwd;
+  cwdInput.placeholder = "Default cwd";
+  cwdField.appendChild(cwdInput);
+  container.appendChild(cwdField);
+
+  // Flag presets
+  if (presets.length > 0) {
+    var flagField = document.createElement("div");
+    flagField.className = "launch-config-field";
+    var flagLabel = document.createElement("label");
+    flagLabel.textContent = "Flags";
+    flagField.appendChild(flagLabel);
+    var flagsWrap = document.createElement("div");
+    flagsWrap.className = "launch-flags";
+    flagsWrap.id = "launch-flags-" + base;
+    for (var fi = 0; fi < presets.length; fi++) {
+      var flagBtn = document.createElement("button");
+      flagBtn.className = "launch-flag-toggle";
+      flagBtn.setAttribute("data-flag", presets[fi].flag);
+      flagBtn.textContent = presets[fi].label;
+      flagBtn.onclick = function () {
+        this.classList.toggle("active");
+      };
+      flagsWrap.appendChild(flagBtn);
+    }
+    flagField.appendChild(flagsWrap);
+    container.appendChild(flagField);
+  }
+
+  // Extra arguments
+  var extraField = document.createElement("div");
+  extraField.className = "launch-config-field";
+  var extraLabel = document.createElement("label");
+  extraLabel.textContent = "Extra arguments";
+  extraField.appendChild(extraLabel);
+  var extraInput = document.createElement("textarea");
+  extraInput.id = "launch-extra-" + base;
+  extraInput.rows = 1;
+  extraInput.placeholder = "Additional args...";
+  extraField.appendChild(extraInput);
+  container.appendChild(extraField);
+
+  // Launch button
+  var launchBtn = document.createElement("button");
+  launchBtn.className = "launcher-btn primary";
+  launchBtn.textContent = "Launch " + (def.label || base);
+  launchBtn.setAttribute("data-base", base);
+  launchBtn.onclick = function () {
+    window.launchAgent(this.getAttribute("data-base"));
+  };
+  container.appendChild(launchBtn);
+
+  return container;
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+async function launchAgent(base) {
+  var cwdInput = document.getElementById("launch-cwd-" + base);
+  var extraInput = document.getElementById("launch-extra-" + base);
+
+  // Gather active flags from the config form for this base
+  var flags = [];
+  var flagsContainer = document.getElementById("launch-flags-" + base);
+  if (flagsContainer) {
+    var flagEls = flagsContainer.querySelectorAll(".launch-flag-toggle.active");
+    flagEls.forEach(function (el) {
+      var flag = el.getAttribute("data-flag");
+      if (flag) flags.push(flag);
+    });
+  }
+
+  var body = {
+    flags: flags,
+    cwd: cwdInput ? cwdInput.value : undefined,
+    extra_args: extraInput ? extraInput.value : undefined,
+  };
+
+  try {
+    var res = await fetch(
+      "/api/agents/" + encodeURIComponent(base) + "/launch",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!res.ok) {
+      var err = await res.json().catch(function () {
+        return {};
+      });
+      console.error("[launcher] launch failed:", err);
+    }
+    // Close config and refresh
+    launcherConfigOpen[base] = false;
+    await fetchManagedAgents();
+  } catch (e) {
+    console.error("[launcher] launchAgent error:", e);
+  }
+}
+
+async function stopAgent(name) {
+  try {
+    var res = await fetch("/api/agents/" + encodeURIComponent(name) + "/stop", {
+      method: "POST",
+    });
+    if (!res.ok) {
+      var err = await res.json().catch(function () {
+        return {};
+      });
+      console.error("[launcher] stop failed:", err);
+    }
+    await fetchManagedAgents();
+  } catch (e) {
+    console.error("[launcher] stopAgent error:", e);
+  }
+}
+
+function toggleLaunchConfig(base) {
+  launcherConfigOpen[base] = !launcherConfigOpen[base];
+  renderLauncherPanel();
+}
+
+async function toggleAgentLogs(name) {
+  launcherLogsOpen[name] = !launcherLogsOpen[name];
+  if (launcherLogsOpen[name]) {
+    await fetchAgentLogs(name);
+  }
+  renderLauncherPanel();
+}
+
+async function fetchAgentLogs(name) {
+  try {
+    var res = await fetch("/api/agents/" + encodeURIComponent(name) + "/logs");
+    if (!res.ok) return;
+    var data = await res.json();
+    launcherLogs[name] = data.lines || [];
+  } catch (e) {
+    console.error("[launcher] fetchAgentLogs error:", e);
+  }
+}
+
+function renderAgentLogs(name) {
+  var el = document.getElementById("logs-" + name);
+  if (!el) return;
+  var lines = launcherLogs[name] || [];
+  if (lines.length > 0) {
+    el.textContent = lines.join("\n");
+  } else {
+    el.textContent = "";
+    var emptySpan = document.createElement("span");
+    emptySpan.className = "launcher-logs-empty";
+    emptySpan.textContent = "No logs yet...";
+    el.appendChild(emptySpan);
+  }
+  // Auto-scroll to bottom
+  el.scrollTop = el.scrollHeight;
+}
+
+// ---------------------------------------------------------------------------
+// Uptime formatting
+// ---------------------------------------------------------------------------
+
+function formatUptime(startedAt) {
+  var start = new Date(startedAt);
+  var now = new Date();
+  var diff = Math.floor((now - start) / 1000);
+  if (diff < 60) return diff + "s";
+  if (diff < 3600) return Math.floor(diff / 60) + "m";
+  if (diff < 86400)
+    return (
+      Math.floor(diff / 3600) + "h " + Math.floor((diff % 3600) / 60) + "m"
+    );
+  return (
+    Math.floor(diff / 86400) + "d " + Math.floor((diff % 86400) / 3600) + "h"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add Agent form
+// ---------------------------------------------------------------------------
+
+function toggleAddAgentForm() {
+  var form = document.getElementById("add-agent-form");
+  if (!form) return;
+  var isHidden = form.classList.toggle("hidden");
+  if (!isHidden) {
+    renderAddAgentForm();
+  }
+}
+
+function renderAddAgentForm() {
+  var form = document.getElementById("add-agent-form");
+  if (!form) return;
+  form.textContent = "";
+
+  // Name field
+  var nameField = document.createElement("div");
+  nameField.className = "add-agent-field";
+  var nameLabel = document.createElement("label");
+  nameLabel.textContent = "Agent name";
+  nameField.appendChild(nameLabel);
+  var nameInput = document.createElement("input");
+  nameInput.type = "text";
+  nameInput.id = "new-agent-name";
+  nameInput.placeholder = "e.g. claude";
+  nameField.appendChild(nameInput);
+  form.appendChild(nameField);
+
+  // Command field
+  var cmdField = document.createElement("div");
+  cmdField.className = "add-agent-field";
+  var cmdLabel = document.createElement("label");
+  cmdLabel.textContent = "Command";
+  cmdField.appendChild(cmdLabel);
+  var cmdInput = document.createElement("input");
+  cmdInput.type = "text";
+  cmdInput.id = "new-agent-command";
+  cmdInput.placeholder = "e.g. claude --dangerously-skip-permissions";
+  cmdField.appendChild(cmdInput);
+  form.appendChild(cmdField);
+
+  // Label field
+  var lblField = document.createElement("div");
+  lblField.className = "add-agent-field";
+  var lblLabel = document.createElement("label");
+  lblLabel.textContent = "Display label";
+  lblField.appendChild(lblLabel);
+  var lblInput = document.createElement("input");
+  lblInput.type = "text";
+  lblInput.id = "new-agent-label";
+  lblInput.placeholder = "e.g. Claude Code";
+  lblField.appendChild(lblInput);
+  form.appendChild(lblField);
+
+  // Colour field
+  var colField = document.createElement("div");
+  colField.className = "add-agent-field";
+  var colLabel = document.createElement("label");
+  colLabel.textContent = "Colour";
+  colField.appendChild(colLabel);
+  var swatches = document.createElement("div");
+  swatches.className = "colour-swatches";
+  for (var si = 0; si < COLOUR_SWATCHES.length; si++) {
+    var swatch = document.createElement("div");
+    swatch.className =
+      "colour-swatch" +
+      (COLOUR_SWATCHES[si] === _selectedColour ? " selected" : "");
+    swatch.style.background = COLOUR_SWATCHES[si];
+    swatch.setAttribute("data-colour", COLOUR_SWATCHES[si]);
+    swatch.onclick = function () {
+      selectColourSwatch(this.getAttribute("data-colour"), this);
+    };
+    swatches.appendChild(swatch);
+  }
+  colField.appendChild(swatches);
+  form.appendChild(colField);
+
+  // Actions
+  var actions = document.createElement("div");
+  actions.className = "add-agent-actions";
+  var saveBtn = document.createElement("button");
+  saveBtn.className = "launcher-btn primary";
+  saveBtn.textContent = "Save";
+  saveBtn.onclick = saveNewAgent;
+  actions.appendChild(saveBtn);
+  var cancelBtn = document.createElement("button");
+  cancelBtn.className = "launcher-btn";
+  cancelBtn.textContent = "Cancel";
+  cancelBtn.onclick = toggleAddAgentForm;
+  actions.appendChild(cancelBtn);
+  form.appendChild(actions);
+}
+
+function selectColourSwatch(colour, el) {
+  _selectedColour = colour;
+  // Update selection state
+  var swatches = el.parentElement.querySelectorAll(".colour-swatch");
+  swatches.forEach(function (s) {
+    s.classList.remove("selected");
+  });
+  el.classList.add("selected");
+}
+
+async function saveNewAgent() {
+  var nameEl = document.getElementById("new-agent-name");
+  var cmdEl = document.getElementById("new-agent-command");
+  var labelEl = document.getElementById("new-agent-label");
+
+  var name = nameEl ? nameEl.value.trim() : "";
+  var command = cmdEl ? cmdEl.value.trim() : "";
+  var label = labelEl ? labelEl.value.trim() : "";
+
+  if (!name || !command) {
+    console.warn("[launcher] Name and command are required");
+    return;
+  }
+
+  try {
+    var res = await fetch("/api/agent-definitions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: name,
+        command: command,
+        label: label || name,
+        color: _selectedColour,
+      }),
+    });
+    if (!res.ok) {
+      var err = await res.json().catch(function () {
+        return {};
+      });
+      console.error("[launcher] saveNewAgent failed:", err);
+      return;
+    }
+    toggleAddAgentForm();
+    await fetchDefinitions();
+  } catch (e) {
+    console.error("[launcher] saveNewAgent error:", e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session restore
+// ---------------------------------------------------------------------------
+
+async function fetchRestoreAgents() {
+  try {
+    var res = await fetch("/api/agents/restore");
+    if (!res.ok) return;
+    var data = await res.json();
+    if (data.agents && data.agents.length > 0) {
+      showRestoreBanner(data.agents);
+    }
+  } catch (e) {
+    console.error("[launcher] fetchRestoreAgents error:", e);
+  }
+}
+
+function showRestoreBanner(agents) {
+  // Remove existing banner if any
+  var existing = document.getElementById("restore-banner");
+  if (existing) existing.remove();
+
+  var timeline = document.getElementById("timeline");
+  if (!timeline) return;
+
+  var banner = document.createElement("div");
+  banner.id = "restore-banner";
+
+  var title = document.createElement("div");
+  title.className = "restore-title";
+  title.textContent = "Restore previous agents?";
+  banner.appendChild(title);
+
+  var list = document.createElement("div");
+  list.className = "restore-list";
+  for (var ai = 0; ai < agents.length; ai++) {
+    var agent = agents[ai];
+    var item = document.createElement("label");
+    item.className = "restore-item";
+    var cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.checked = true;
+    cb.value = agent.name || agent.base || "";
+    cb.setAttribute("data-base", agent.base || "");
+    item.appendChild(cb);
+    var span = document.createElement("span");
+    span.textContent = agent.label || agent.name || agent.base;
+    item.appendChild(span);
+    list.appendChild(item);
+  }
+  banner.appendChild(list);
+
+  var actions = document.createElement("div");
+  actions.className = "restore-actions";
+  var restoreBtn = document.createElement("button");
+  restoreBtn.className = "launcher-btn primary";
+  restoreBtn.textContent = "Restore";
+  restoreBtn.onclick = relaunchSelected;
+  actions.appendChild(restoreBtn);
+  var dismissBtn = document.createElement("button");
+  dismissBtn.className = "launcher-btn";
+  dismissBtn.textContent = "Dismiss";
+  dismissBtn.onclick = dismissRestore;
+  actions.appendChild(dismissBtn);
+  banner.appendChild(actions);
+
+  timeline.insertBefore(banner, timeline.firstChild);
+}
+
+async function relaunchSelected() {
+  var banner = document.getElementById("restore-banner");
+  if (!banner) return;
+
+  var checkboxes = banner.querySelectorAll('input[type="checkbox"]:checked');
+  var launches = [];
+  checkboxes.forEach(function (cb) {
+    var base = cb.getAttribute("data-base") || cb.value;
+    if (base) launches.push(base);
+  });
+
+  for (var li = 0; li < launches.length; li++) {
+    try {
+      await fetch(
+        "/api/agents/" + encodeURIComponent(launches[li]) + "/launch",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
+    } catch (e) {
+      console.error("[launcher] relaunch error for", launches[li], e);
+    }
+  }
+
+  banner.remove();
+  fetchManagedAgents();
+}
+
+async function dismissRestore() {
+  var banner = document.getElementById("restore-banner");
+  if (banner) banner.remove();
+
+  try {
+    await fetch("/api/agents/restore/dismiss", { method: "POST" });
+  } catch (e) {
+    console.error("[launcher] dismissRestore error:", e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hub event subscriptions
+// ---------------------------------------------------------------------------
+
+Hub.on("agent_processes", function (event) {
+  launcherProcesses = event.processes || event.data || [];
+  renderLauncherPanel();
+});
+
+Hub.on("agent_log", function (event) {
+  var name = event.name;
+  if (!name) return;
+  if (!launcherLogs[name]) launcherLogs[name] = [];
+  if (event.line) {
+    launcherLogs[name].push(event.line);
+    // Cap at 500 lines
+    if (launcherLogs[name].length > 500) {
+      launcherLogs[name] = launcherLogs[name].slice(-500);
+    }
+  }
+  if (event.lines) {
+    launcherLogs[name] = launcherLogs[name].concat(event.lines);
+    if (launcherLogs[name].length > 500) {
+      launcherLogs[name] = launcherLogs[name].slice(-500);
+    }
+  }
+  if (launcherLogsOpen[name]) {
+    renderAgentLogs(name);
+  }
+});
+
+Hub.on("session_restore", function (event) {
+  var agents = event.agents || (event.data && event.data.agents) || [];
+  if (agents.length > 0) {
+    showRestoreBanner(agents);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Init: fetch restore agents on load
+// ---------------------------------------------------------------------------
+
+document.addEventListener("DOMContentLoaded", function () {
+  fetchRestoreAgents();
+});
+
+// ---------------------------------------------------------------------------
+// Window exports (for onclick handlers)
+// ---------------------------------------------------------------------------
+
+window.toggleLauncherPanel = toggleLauncherPanel;
+window.toggleAddAgentForm = toggleAddAgentForm;
+window.launchAgent = launchAgent;
+window.stopAgent = stopAgent;
+window.toggleLaunchConfig = toggleLaunchConfig;
+window.toggleAgentLogs = toggleAgentLogs;
+window.selectColourSwatch = selectColourSwatch;
+window.saveNewAgent = saveNewAgent;
+window.relaunchSelected = relaunchSelected;
+window.dismissRestore = dismissRestore;

--- a/static/launcher.js
+++ b/static/launcher.js
@@ -65,6 +65,22 @@ function normalizeAgentLogEvent(event) {
   };
 }
 
+function partitionLauncherInstances(instances) {
+  var active = [];
+  var crashed = [];
+
+  for (var ii = 0; ii < instances.length; ii++) {
+    var instance = instances[ii];
+    if (instance.state === "running" || instance.state === "starting") {
+      active.push(instance);
+    } else if (instance.state === "crashed") {
+      crashed.push(instance);
+    }
+  }
+
+  return { active: active, crashed: crashed };
+}
+
 function buildRestoreLaunchBody(agent) {
   var body = {
     flags: Array.isArray(agent && agent.flags) ? agent.flags : [],
@@ -196,13 +212,10 @@ function buildAgentCard(base, def, instances) {
   const el = document.createElement("div");
   el.className = "launcher-card";
 
-  const running = instances.filter(function (p) {
-    return p.state === "running";
-  });
-  const crashed = instances.filter(function (p) {
-    return p.state === "crashed";
-  });
-  const hasRunning = running.length > 0;
+  const partitions = partitionLauncherInstances(instances);
+  const active = partitions.active;
+  const crashed = partitions.crashed;
+  const hasRunning = active.length > 0;
   const hasCrashed = crashed.length > 0;
 
   // Header: dot + info + badge
@@ -250,8 +263,8 @@ function buildAgentCard(base, def, instances) {
   el.appendChild(header);
 
   // Running instances
-  for (var ri = 0; ri < running.length; ri++) {
-    var p = running[ri];
+  for (var ri = 0; ri < active.length; ri++) {
+    var p = active[ri];
     var inst = document.createElement("div");
     inst.className = "launcher-instance";
     var iName = document.createElement("span");
@@ -917,5 +930,6 @@ if (typeof module !== "undefined" && module.exports) {
     normalizeAgentLogEvent,
     normalizeManagedAgentsPayload,
     normalizeRestoreAgentsPayload,
+    partitionLauncherInstances,
   };
 }

--- a/static/rules-panel.js
+++ b/static/rules-panel.js
@@ -1,7 +1,7 @@
 // rules-panel.js -- Rules sidebar panel: render, CRUD, drag/drop, badges
 // Extracted from chat.js PR 5.  Reads shared state via window.* bridges.
 
-'use strict';
+"use strict";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -15,23 +15,23 @@ const RULE_REASON_MAX_CHARS = 240;
 // ---------------------------------------------------------------------------
 
 function autoGrowTextarea(el) {
-    el.style.height = 'auto';
-    el.style.height = el.scrollHeight + 'px';
+  el.style.height = "auto";
+  el.style.height = el.scrollHeight + "px";
 }
 
 function setupCharCounter(textareaId, counterId) {
-    const ta = document.getElementById(textareaId);
-    const counter = document.getElementById(counterId);
-    if (!ta || !counter) return;
+  const ta = document.getElementById(textareaId);
+  const counter = document.getElementById(counterId);
+  if (!ta || !counter) return;
 
-    function update() {
-        autoGrowTextarea(ta);
-        const len = ta.value.length;
-        counter.textContent = `${len}/${RULE_MAX_CHARS}`;
-        counter.classList.toggle('over', len >= RULE_MAX_CHARS);
-    }
-    ta.addEventListener('input', update);
-    update();
+  function update() {
+    autoGrowTextarea(ta);
+    const len = ta.value.length;
+    counter.textContent = `${len}/${RULE_MAX_CHARS}`;
+    counter.classList.toggle("over", len >= RULE_MAX_CHARS);
+  }
+  ta.addEventListener("input", update);
+  update();
 }
 
 // ---------------------------------------------------------------------------
@@ -39,46 +39,49 @@ function setupCharCounter(textareaId, counterId) {
 // ---------------------------------------------------------------------------
 
 function setupRulesGrip() {
-    const grip = document.getElementById('rules-grip');
-    const panel = document.getElementById('rules-panel');
-    if (!grip || !panel) return;
+  const grip = document.getElementById("rules-grip");
+  const panel = document.getElementById("rules-panel");
+  if (!grip || !panel) return;
 
-    let dragging = false;
-    let startX = 0;
-    let startWidth = 0;
+  let dragging = false;
+  let startX = 0;
+  let startWidth = 0;
 
-    grip.addEventListener('mousedown', (e) => {
-        e.preventDefault();
-        dragging = true;
-        startX = e.clientX;
-        startWidth = panel.offsetWidth;
-        grip.classList.add('dragging');
-        panel.style.transition = 'none';
-        document.body.style.cursor = 'col-resize';
-        document.body.style.userSelect = 'none';
-    });
+  grip.addEventListener("mousedown", (e) => {
+    e.preventDefault();
+    dragging = true;
+    startX = e.clientX;
+    startWidth = panel.offsetWidth;
+    grip.classList.add("dragging");
+    panel.style.transition = "none";
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  });
 
-    document.addEventListener('mousemove', (e) => {
-        if (!dragging) return;
-        const delta = startX - e.clientX;
-        const newWidth = Math.min(Math.max(startWidth + delta, 220), window.innerWidth * 0.5);
-        panel.style.setProperty('--panel-w', newWidth + 'px');
-        panel.style.width = newWidth + 'px';
-        panel.style.minWidth = newWidth + 'px';
-    });
+  document.addEventListener("mousemove", (e) => {
+    if (!dragging) return;
+    const delta = startX - e.clientX;
+    const newWidth = Math.min(
+      Math.max(startWidth + delta, 220),
+      window.innerWidth * 0.5,
+    );
+    panel.style.setProperty("--panel-w", newWidth + "px");
+    panel.style.width = newWidth + "px";
+    panel.style.minWidth = newWidth + "px";
+  });
 
-    document.addEventListener('mouseup', () => {
-        if (!dragging) return;
-        dragging = false;
-        grip.classList.remove('dragging');
-        panel.style.transition = '';
-        document.body.style.cursor = '';
-        document.body.style.userSelect = '';
-    });
+  document.addEventListener("mouseup", () => {
+    if (!dragging) return;
+    dragging = false;
+    grip.classList.remove("dragging");
+    panel.style.transition = "";
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  });
 }
 
 function setupRuleForm() {
-    // Form is now inline via showCreateRule(), no persistent elements to set up
+  // Form is now inline via showCreateRule(), no persistent elements to set up
 }
 
 // ---------------------------------------------------------------------------
@@ -94,52 +97,58 @@ let _seenRuleIds = new Set();
 // ---------------------------------------------------------------------------
 
 function handleRuleEvent(action, rule) {
-    const rules = window.rules;
-    if (action === 'propose') {
-        rules.push(rule);
-    } else if (['activate', 'deactivate', 'edit', 'approve'].includes(action)) {
-        const idx = rules.findIndex(r => r.id === rule.id);
-        if (idx >= 0) rules[idx] = rule;
-    } else if (action === 'delete') {
-        window.rules = rules.filter(r => r.id !== rule.id);
-        _seenRuleIds.delete(rule.id);
-    }
-    renderRulesPanel();
-    updateRulesBadge();
+  const rules = window.rules;
+  if (action === "propose") {
+    rules.push(rule);
+  } else if (["activate", "deactivate", "edit", "approve"].includes(action)) {
+    const idx = rules.findIndex((r) => r.id === rule.id);
+    if (idx >= 0) rules[idx] = rule;
+  } else if (action === "delete") {
+    window.rules = rules.filter((r) => r.id !== rule.id);
+    _seenRuleIds.delete(rule.id);
+  }
+  renderRulesPanel();
+  updateRulesBadge();
 }
 
 function toggleRulesPanel() {
-    window._preserveScroll(() => {
-        const panel = document.getElementById('rules-panel');
-        panel.classList.toggle('hidden');
-        document.getElementById('rules-toggle').classList.toggle('active', !panel.classList.contains('hidden'));
-        if (!panel.classList.contains('hidden')) {
-            // Mark all current drafts as seen
-            for (const r of window.rules) {
-                if (r.status === 'proposed' || r.status === 'draft') _seenRuleIds.add(r.id);
-            }
-            updateRulesBadge();
-            renderRulesPanel();
-        }
-    });
+  window._preserveScroll(() => {
+    const panel = document.getElementById("rules-panel");
+    panel.classList.toggle("hidden");
+    document
+      .getElementById("rules-toggle")
+      .classList.toggle("active", !panel.classList.contains("hidden"));
+    if (!panel.classList.contains("hidden")) {
+      // Mark all current drafts as seen
+      for (const r of window.rules) {
+        if (r.status === "proposed" || r.status === "draft")
+          _seenRuleIds.add(r.id);
+      }
+      updateRulesBadge();
+      renderRulesPanel();
+    }
+  });
 }
 
 function remindAgents() {
-    const btn = document.querySelector('.rules-remind-btn');
-    if (btn) btn.disabled = true;
-    fetch('/api/rules/remind', { method: 'POST', headers: { 'X-Session-Token': window.SESSION_TOKEN } })
-        .then(r => r.json())
-        .then(() => {
-            if (btn) {
-                const orig = btn.textContent;
-                btn.textContent = 'Queued — next trigger';
-                setTimeout(() => { btn.textContent = orig; btn.disabled = false; }, 2500);
-            }
-        })
-        .catch(err => {
-            console.error('remind failed', err);
-            if (btn) btn.disabled = false;
-        });
+  const btn = document.querySelector(".rules-remind-btn");
+  if (btn) btn.disabled = true;
+  fetch("/api/rules/remind", { method: "POST" })
+    .then((r) => r.json())
+    .then(() => {
+      if (btn) {
+        const orig = btn.textContent;
+        btn.textContent = "Queued — next trigger";
+        setTimeout(() => {
+          btn.textContent = orig;
+          btn.disabled = false;
+        }, 2500);
+      }
+    })
+    .catch((err) => {
+      console.error("remind failed", err);
+      if (btn) btn.disabled = false;
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -147,201 +156,229 @@ function remindAgents() {
 // ---------------------------------------------------------------------------
 
 function renderRulesPanel() {
-    const rules = window.rules;
-    const list = document.getElementById('rules-list');
-    if (!list) return;
+  const rules = window.rules;
+  const list = document.getElementById("rules-list");
+  if (!list) return;
 
-    // Preserve in-progress create form across re-renders
-    const activeForm = list.querySelector('.job-create-form');
-    let savedForm = null, savedFocusSelector = null, savedSelStart = 0, savedSelEnd = 0;
-    if (activeForm) {
-        const focused = document.activeElement;
-        if (focused && activeForm.contains(focused)) {
-            savedFocusSelector = focused.tagName.toLowerCase() + (focused.className ? '.' + focused.className.split(' ')[0] : '');
-            savedSelStart = focused.selectionStart || 0;
-            savedSelEnd = focused.selectionEnd || 0;
-        }
-        savedForm = activeForm.parentNode.removeChild(activeForm);
+  // Preserve in-progress create form across re-renders
+  const activeForm = list.querySelector(".job-create-form");
+  let savedForm = null,
+    savedFocusSelector = null,
+    savedSelStart = 0,
+    savedSelEnd = 0;
+  if (activeForm) {
+    const focused = document.activeElement;
+    if (focused && activeForm.contains(focused)) {
+      savedFocusSelector =
+        focused.tagName.toLowerCase() +
+        (focused.className ? "." + focused.className.split(" ")[0] : "");
+      savedSelStart = focused.selectionStart || 0;
+      savedSelEnd = focused.selectionEnd || 0;
     }
-    list.innerHTML = '';
+    savedForm = activeForm.parentNode.removeChild(activeForm);
+  }
+  list.innerHTML = "";
 
-    const normalize = (s) => s === 'proposed' ? 'draft' : (s === 'approved' ? 'active' : (s || 'draft'));
-    // Filter out pending rules — they only exist as proposal cards in the timeline
-    const panelRules = rules.filter(r => r.status !== 'pending');
-    const activeCount = panelRules.filter(r => normalize(r.status) === 'active').length;
+  const normalize = (s) =>
+    s === "proposed" ? "draft" : s === "approved" ? "active" : s || "draft";
+  // Filter out pending rules — they only exist as proposal cards in the timeline
+  const panelRules = rules.filter((r) => r.status !== "pending");
+  const activeCount = panelRules.filter(
+    (r) => normalize(r.status) === "active",
+  ).length;
 
-    // Update header counter
-    const counter = document.getElementById('rules-counter');
-    if (counter) counter.textContent = `${activeCount}/10`;
+  // Update header counter
+  const counter = document.getElementById("rules-counter");
+  if (counter) counter.textContent = `${activeCount}/10`;
 
-    if (panelRules.length === 0) {
-        const ghost = document.createElement('div');
-        ghost.className = 'sb-ghost-card';
-        ghost.innerHTML = `
+  if (panelRules.length === 0) {
+    const ghost = document.createElement("div");
+    ghost.className = "sb-ghost-card";
+    ghost.innerHTML = `
             <div class="sb-ghost-title">No rules yet</div>
             <div class="sb-ghost-meta">Tell your agents how to work</div>
         `;
-        ghost.onclick = () => showCreateRule();
-        list.appendChild(ghost);
-        // Centered helper text
-        const helper = document.createElement('div');
-        helper.className = 'rules-centered-hint';
-        helper.textContent = 'New rules are sent on the next agent trigger';
-        list.appendChild(helper);
-        if (savedForm) {
-            list.prepend(savedForm);
-            if (savedFocusSelector) {
-                const el = savedForm.querySelector(savedFocusSelector);
-                if (el) { el.focus(); try { el.setSelectionRange(savedSelStart, savedSelEnd); } catch {} }
-            }
+    ghost.onclick = () => showCreateRule();
+    list.appendChild(ghost);
+    // Centered helper text
+    const helper = document.createElement("div");
+    helper.className = "rules-centered-hint";
+    helper.textContent = "New rules are sent on the next agent trigger";
+    list.appendChild(helper);
+    if (savedForm) {
+      list.prepend(savedForm);
+      if (savedFocusSelector) {
+        const el = savedForm.querySelector(savedFocusSelector);
+        if (el) {
+          el.focus();
+          try {
+            el.setSelectionRange(savedSelStart, savedSelEnd);
+          } catch {}
         }
-        return;
+      }
+    }
+    return;
+  }
+
+  // Group order: drafts, active, archive (mirrors jobs: to-do, active, closed)
+  const groups = [
+    { key: "draft", label: "DRAFTS", items: [] },
+    { key: "active", label: "ACTIVE", items: [] },
+    { key: "archived", label: "ARCHIVE", items: [] },
+  ];
+  for (const r of panelRules) {
+    const status = normalize(r.status);
+    const g = groups.find((g) => g.key === status);
+    if (g) g.items.push(r);
+    else groups[2].items.push(r);
+  }
+
+  // Soft warning at 7+ active
+  if (activeCount >= 7) {
+    const warning = document.createElement("div");
+    warning.className = "rules-soft-warning";
+    warning.textContent = "Less than seven active rules tends to work better";
+    list.appendChild(warning);
+  }
+
+  for (const group of groups) {
+    group.items.sort((a, b) => b.id - a.id);
+
+    const isCollapsible = group.key === "archived";
+    const isCollapsed = isCollapsible && !_rulesArchivedExpanded;
+
+    const header = document.createElement("div");
+    header.className =
+      "rules-group-header " + group.key + (isCollapsed ? " collapsed" : "");
+    const isEmpty = group.items.length === 0;
+    header.textContent = isEmpty
+      ? group.label
+      : `${group.label} (${group.items.length})`;
+    if (isEmpty) header.classList.add("empty-group");
+    if (isCollapsible) {
+      header.onclick = () => {
+        _rulesArchivedExpanded = !_rulesArchivedExpanded;
+        header.classList.toggle("collapsed");
+        const container = header.nextElementSibling;
+        if (container) container.classList.toggle("collapsed");
+      };
     }
 
-    // Group order: drafts, active, archive (mirrors jobs: to-do, active, closed)
-    const groups = [
-        { key: 'draft', label: 'DRAFTS', items: [] },
-        { key: 'active', label: 'ACTIVE', items: [] },
-        { key: 'archived', label: 'ARCHIVE', items: [] },
-    ];
-    for (const r of panelRules) {
-        const status = normalize(r.status);
-        const g = groups.find(g => g.key === status);
-        if (g) g.items.push(r);
-        else groups[2].items.push(r);
-    }
+    // Drop target: drag a rule card onto this header to change its status
+    header.addEventListener("dragover", (e) => {
+      if (!_draggedRuleId) return;
+      e.preventDefault();
+      header.classList.add("drop-target");
+    });
+    header.addEventListener("dragleave", () => {
+      header.classList.remove("drop-target");
+    });
+    header.addEventListener("drop", (e) => {
+      e.preventDefault();
+      header.classList.remove("drop-target");
+      if (!_draggedRuleId) return;
+      const id = _draggedRuleId;
+      const d = rules.find((r) => r.id === id);
+      if (!d) return;
+      const currentStatus = normalize(d.status);
+      if (currentStatus === group.key) return;
+      if (group.key === "active") {
+        window.ws.send(JSON.stringify({ type: "rule_activate", id }));
+      } else if (group.key === "draft") {
+        window.ws.send(JSON.stringify({ type: "rule_make_draft", id }));
+      } else {
+        window.ws.send(JSON.stringify({ type: "rule_deactivate", id }));
+      }
+    });
 
-    // Soft warning at 7+ active
-    if (activeCount >= 7) {
-        const warning = document.createElement('div');
-        warning.className = 'rules-soft-warning';
-        warning.textContent = 'Less than seven active rules tends to work better';
-        list.appendChild(warning);
-    }
+    list.appendChild(header);
 
-    for (const group of groups) {
-        group.items.sort((a, b) => b.id - a.id);
+    const itemsContainer = document.createElement("div");
+    itemsContainer.className =
+      "rules-group-items" + (isCollapsed ? " collapsed" : "");
+    const itemsInner = document.createElement("div");
+    itemsInner.className = "rules-group-items-inner";
 
-        const isCollapsible = group.key === 'archived';
-        const isCollapsed = isCollapsible && !_rulesArchivedExpanded;
+    for (const d of group.items) {
+      const card = document.createElement("div");
+      card.className = "rule-card";
+      card.dataset.id = d.id;
+      card.draggable = true;
+      card.onclick = () => editRule(d.id);
 
-        const header = document.createElement('div');
-        header.className = 'rules-group-header ' + group.key + (isCollapsed ? ' collapsed' : '');
-        const isEmpty = group.items.length === 0;
-        header.textContent = isEmpty ? group.label : `${group.label} (${group.items.length})`;
-        if (isEmpty) header.classList.add('empty-group');
-        if (isCollapsible) {
-            header.onclick = () => {
-                _rulesArchivedExpanded = !_rulesArchivedExpanded;
-                header.classList.toggle('collapsed');
-                const container = header.nextElementSibling;
-                if (container) container.classList.toggle('collapsed');
-            };
-        }
+      card.addEventListener("dragstart", (e) => {
+        _draggedRuleId = d.id;
+        card.classList.add("dragging");
+        e.dataTransfer.effectAllowed = "move";
+      });
+      card.addEventListener("dragend", () => {
+        _draggedRuleId = null;
+        card.classList.remove("dragging");
+      });
 
-        // Drop target: drag a rule card onto this header to change its status
-        header.addEventListener('dragover', (e) => {
-            if (!_draggedRuleId) return;
-            e.preventDefault();
-            header.classList.add('drop-target');
-        });
-        header.addEventListener('dragleave', () => {
-            header.classList.remove('drop-target');
-        });
-        header.addEventListener('drop', (e) => {
-            e.preventDefault();
-            header.classList.remove('drop-target');
-            if (!_draggedRuleId) return;
-            const id = _draggedRuleId;
-            const d = rules.find(r => r.id === id);
-            if (!d) return;
-            const currentStatus = normalize(d.status);
-            if (currentStatus === group.key) return;
-            if (group.key === 'active') {
-                window.ws.send(JSON.stringify({ type: 'rule_activate', id }));
-            } else if (group.key === 'draft') {
-                window.ws.send(JSON.stringify({ type: 'rule_make_draft', id }));
-            } else {
-                window.ws.send(JSON.stringify({ type: 'rule_deactivate', id }));
-            }
-        });
+      const displayStatus = normalize(d.status);
 
-        list.appendChild(header);
-
-        const itemsContainer = document.createElement('div');
-        itemsContainer.className = 'rules-group-items' + (isCollapsed ? ' collapsed' : '');
-        const itemsInner = document.createElement('div');
-        itemsInner.className = 'rules-group-items-inner';
-
-        for (const d of group.items) {
-            const card = document.createElement('div');
-            card.className = 'rule-card';
-            card.dataset.id = d.id;
-            card.draggable = true;
-            card.onclick = () => editRule(d.id);
-
-            card.addEventListener('dragstart', (e) => {
-                _draggedRuleId = d.id;
-                card.classList.add('dragging');
-                e.dataTransfer.effectAllowed = 'move';
-            });
-            card.addEventListener('dragend', () => {
-                _draggedRuleId = null;
-                card.classList.remove('dragging');
-            });
-
-            const displayStatus = normalize(d.status);
-
-            card.innerHTML = `
+      card.innerHTML = `
                 <div class="rule-card-header">
                     <span class="rule-status-dot ${displayStatus}"></span>
-                    <div class="rule-text">${window.escapeHtml(d.text || d.decision || '')}</div>
+                    <div class="rule-text">${window.escapeHtml(d.text || d.decision || "")}</div>
                 </div>
             `;
-            itemsInner.appendChild(card);
-        }
-
-        // Trash zone for archived rules — same style as Jobs
-        if (group.key === 'archived' && group.items.length > 0) {
-            const trashZone = document.createElement('div');
-            trashZone.className = 'archive-trash-zone visible';
-            trashZone.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M6 4V3h4v1M5 4v8.5h6V4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="archive-trash-hint">Drag here to delete</span>`;
-
-            trashZone.addEventListener('dragover', (e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; trashZone.classList.add('hover'); });
-            trashZone.addEventListener('dragleave', () => { trashZone.classList.remove('hover'); });
-            trashZone.addEventListener('drop', async (e) => {
-                e.preventDefault();
-                trashZone.classList.remove('hover');
-                if (!_draggedRuleId) return;
-                const id = _draggedRuleId;
-                const d = rules.find(r => r.id === id);
-                if (!d) return;
-                trashZone.classList.add('chomping');
-                window.ws.send(JSON.stringify({ type: 'rule_delete', id }));
-                setTimeout(() => trashZone.classList.remove('chomping'), 500);
-            });
-
-            itemsInner.appendChild(trashZone);
-        }
-
-        itemsContainer.appendChild(itemsInner);
-        list.appendChild(itemsContainer);
+      itemsInner.appendChild(card);
     }
 
-    // Centered helper text at bottom
-    const helper = document.createElement('div');
-    helper.className = 'rules-centered-hint';
-    helper.textContent = 'New rules are sent on the next agent trigger';
-    list.appendChild(helper);
+    // Trash zone for archived rules — same style as Jobs
+    if (group.key === "archived" && group.items.length > 0) {
+      const trashZone = document.createElement("div");
+      trashZone.className = "archive-trash-zone visible";
+      trashZone.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M6 4V3h4v1M5 4v8.5h6V4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="archive-trash-hint">Drag here to delete</span>`;
 
-    // Re-insert preserved create form at top
-    if (savedForm) {
-        list.prepend(savedForm);
-        if (savedFocusSelector) {
-            const el = savedForm.querySelector(savedFocusSelector);
-            if (el) { el.focus(); try { el.setSelectionRange(savedSelStart, savedSelEnd); } catch {} }
-        }
+      trashZone.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        trashZone.classList.add("hover");
+      });
+      trashZone.addEventListener("dragleave", () => {
+        trashZone.classList.remove("hover");
+      });
+      trashZone.addEventListener("drop", async (e) => {
+        e.preventDefault();
+        trashZone.classList.remove("hover");
+        if (!_draggedRuleId) return;
+        const id = _draggedRuleId;
+        const d = rules.find((r) => r.id === id);
+        if (!d) return;
+        trashZone.classList.add("chomping");
+        window.ws.send(JSON.stringify({ type: "rule_delete", id }));
+        setTimeout(() => trashZone.classList.remove("chomping"), 500);
+      });
+
+      itemsInner.appendChild(trashZone);
     }
+
+    itemsContainer.appendChild(itemsInner);
+    list.appendChild(itemsContainer);
+  }
+
+  // Centered helper text at bottom
+  const helper = document.createElement("div");
+  helper.className = "rules-centered-hint";
+  helper.textContent = "New rules are sent on the next agent trigger";
+  list.appendChild(helper);
+
+  // Re-insert preserved create form at top
+  if (savedForm) {
+    list.prepend(savedForm);
+    if (savedFocusSelector) {
+      const el = savedForm.querySelector(savedFocusSelector);
+      if (el) {
+        el.focus();
+        try {
+          el.setSelectionRange(savedSelStart, savedSelEnd);
+        } catch {}
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -349,21 +386,26 @@ function renderRulesPanel() {
 // ---------------------------------------------------------------------------
 
 function updateRulesBadge() {
-    const rules = window.rules;
-    const badge = document.getElementById('rules-badge');
-    if (!badge) return;
-    // Only count unseen proposals — not all drafts
-    const panel = document.getElementById('rules-panel');
-    const panelOpen = panel && !panel.classList.contains('hidden');
-    if (panelOpen) {
-        // Panel is open — everything is seen
-        for (const r of rules) {
-            if (r.status === 'proposed' || r.status === 'draft') _seenRuleIds.add(r.id);
-        }
+  const rules = window.rules;
+  const badge = document.getElementById("rules-badge");
+  if (!badge) return;
+  // Only count unseen proposals — not all drafts
+  const panel = document.getElementById("rules-panel");
+  const panelOpen = panel && !panel.classList.contains("hidden");
+  if (panelOpen) {
+    // Panel is open — everything is seen
+    for (const r of rules) {
+      if (r.status === "proposed" || r.status === "draft")
+        _seenRuleIds.add(r.id);
     }
-    const count = rules.filter(r => (r.status === 'proposed' || r.status === 'draft') && !_seenRuleIds.has(r.id)).length;
-    badge.textContent = count;
-    badge.classList.toggle('hidden', count === 0);
+  }
+  const count = rules.filter(
+    (r) =>
+      (r.status === "proposed" || r.status === "draft") &&
+      !_seenRuleIds.has(r.id),
+  ).length;
+  badge.textContent = count;
+  badge.classList.toggle("hidden", count === 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -371,75 +413,83 @@ function updateRulesBadge() {
 // ---------------------------------------------------------------------------
 
 function showCreateRule() {
-    const list = document.getElementById('rules-list');
-    if (!list) return;
-    const existing = list.querySelector('.job-create-form');
-    if (existing) { existing.remove(); return; }
+  const list = document.getElementById("rules-list");
+  if (!list) return;
+  const existing = list.querySelector(".job-create-form");
+  if (existing) {
+    existing.remove();
+    return;
+  }
 
-    const form = document.createElement('div');
-    form.className = 'job-create-form';
-    form.innerHTML = `
+  const form = document.createElement("div");
+  form.className = "job-create-form";
+  form.innerHTML = `
         <input type="text" placeholder="Write a short rule agents should follow" class="rule-create-text" maxlength="160" autofocus>
         <div class="job-create-actions">
             <button class="cancel-btn" onclick="this.closest('.job-create-form').remove()">Cancel</button>
             <button class="create-btn" onclick="submitCreateRule(this)">Create</button>
         </div>
     `;
-    list.prepend(form);
-    const textInput = form.querySelector('.rule-create-text');
-    textInput.focus();
-    textInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            submitCreateRule(form.querySelector('.create-btn'));
-        } else if (e.key === 'Escape') {
-            form.remove();
-        }
-    });
+  list.prepend(form);
+  const textInput = form.querySelector(".rule-create-text");
+  textInput.focus();
+  textInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submitCreateRule(form.querySelector(".create-btn"));
+    } else if (e.key === "Escape") {
+      form.remove();
+    }
+  });
 }
 
 function submitCreateRule(btn) {
-    const form = btn.closest('.job-create-form');
-    const textInput = form.querySelector('.rule-create-text');
-    const text = (textInput.value || '').trim();
-    if (!text) { textInput.focus(); return; }
+  const form = btn.closest(".job-create-form");
+  const textInput = form.querySelector(".rule-create-text");
+  const text = (textInput.value || "").trim();
+  if (!text) {
+    textInput.focus();
+    return;
+  }
 
-    window.ws.send(JSON.stringify({
-        type: 'rule_propose',
-        text: text,
-        author: window.username,
-        channel: window.activeChannel,
-    }));
-    form.remove();
+  window.ws.send(
+    JSON.stringify({
+      type: "rule_propose",
+      text: text,
+      author: window.username,
+      channel: window.activeChannel,
+    }),
+  );
+  form.remove();
 }
 
 function toggleRuleStatus(id) {
-    const rules = window.rules;
-    const d = rules.find(r => r.id === id);
-    if (!d) return;
+  const rules = window.rules;
+  const d = rules.find((r) => r.id === id);
+  if (!d) return;
 
-    if (d.status === 'active' || d.status === 'approved') {
-        window.ws.send(JSON.stringify({ type: 'rule_deactivate', id }));
-    } else {
-        window.ws.send(JSON.stringify({ type: 'rule_activate', id }));
-    }
+  if (d.status === "active" || d.status === "approved") {
+    window.ws.send(JSON.stringify({ type: "rule_deactivate", id }));
+  } else {
+    window.ws.send(JSON.stringify({ type: "rule_activate", id }));
+  }
 }
 
 function editRule(id) {
-    const rules = window.rules;
-    const d = rules.find(r => r.id === id);
-    if (!d) return;
+  const rules = window.rules;
+  const d = rules.find((r) => r.id === id);
+  if (!d) return;
 
-    const card = document.querySelector(`.rule-card[data-id="${id}"]`);
-    if (!card || card.classList.contains('editing')) return;
-    card.classList.add('editing');
+  const card = document.querySelector(`.rule-card[data-id="${id}"]`);
+  if (!card || card.classList.contains("editing")) return;
+  card.classList.add("editing");
 
-    const editArea = document.createElement('div');
-    editArea.className = 'rule-edit-area';
-    editArea.onclick = (e) => e.stopPropagation();
-    editArea.innerHTML = `
-        <textarea class="rule-edit-field" maxlength="${RULE_MAX_CHARS}" rows="1" data-limit="${RULE_MAX_CHARS}">${window.escapeHtml(d.text || '')}</textarea>
-        <div class="char-counter">${(d.text || '').length}/${RULE_MAX_CHARS}</div>
+  const editArea = document.createElement("div");
+  editArea.className = "rule-edit-area";
+  editArea.onclick = (e) => e.stopPropagation();
+  editArea.innerHTML = `
+        <textarea class="rule-edit-field" maxlength="${RULE_MAX_CHARS}" rows="1" data-limit="${RULE_MAX_CHARS}">${window.escapeHtml(d.text || "")}</textarea>
+        <div class="char-counter">${(d.text || "").length}/${RULE_MAX_CHARS}</div>
         <div class="rule-edit-actions">
             <button class="save-btn" onclick="event.stopPropagation();saveRuleEdit(${id})">Save</button>
             <button class="cancel-btn" onclick="event.stopPropagation();cancelRuleEdit(${id})">Cancel</button>
@@ -447,60 +497,62 @@ function editRule(id) {
             <button class="delete-inline-btn" onclick="event.stopPropagation();deleteRule(${id})">Delete</button>
         </div>
     `;
-    card.appendChild(editArea);
+  card.appendChild(editArea);
 
-    // Wire auto-grow + counters on edit fields
-    editArea.querySelectorAll('.rule-edit-field').forEach(ta => {
-        const counter = ta.nextElementSibling;
-        const limit = parseInt(ta.dataset.limit) || RULE_MAX_CHARS;
-        autoGrowTextarea(ta);
-        ta.addEventListener('input', () => {
-            autoGrowTextarea(ta);
-            if (counter && counter.classList.contains('char-counter')) {
-                counter.textContent = `${ta.value.length}/${limit}`;
-                counter.classList.toggle('over', ta.value.length >= limit);
-            }
-        });
+  // Wire auto-grow + counters on edit fields
+  editArea.querySelectorAll(".rule-edit-field").forEach((ta) => {
+    const counter = ta.nextElementSibling;
+    const limit = parseInt(ta.dataset.limit) || RULE_MAX_CHARS;
+    autoGrowTextarea(ta);
+    ta.addEventListener("input", () => {
+      autoGrowTextarea(ta);
+      if (counter && counter.classList.contains("char-counter")) {
+        counter.textContent = `${ta.value.length}/${limit}`;
+        counter.classList.toggle("over", ta.value.length >= limit);
+      }
     });
+  });
 
-    // Focus the textarea, cursor at end
-    const firstField = editArea.querySelector('textarea');
-    firstField.focus();
-    firstField.selectionStart = firstField.selectionEnd = firstField.value.length;
+  // Focus the textarea, cursor at end
+  const firstField = editArea.querySelector("textarea");
+  firstField.focus();
+  firstField.selectionStart = firstField.selectionEnd = firstField.value.length;
 }
 
 function saveRuleEdit(id) {
-    const card = document.querySelector(`.rule-card[data-id="${id}"]`);
-    if (!card) return;
+  const card = document.querySelector(`.rule-card[data-id="${id}"]`);
+  if (!card) return;
 
-    const field = card.querySelector('.rule-edit-field');
-    const newText = field?.value.trim();
+  const field = card.querySelector(".rule-edit-field");
+  const newText = field?.value.trim();
 
-    if (!newText) return;
+  if (!newText) return;
 
-    window.ws.send(JSON.stringify({
-        type: 'rule_edit',
-        id,
-        text: newText,
-    }));
+  window.ws.send(
+    JSON.stringify({
+      type: "rule_edit",
+      id,
+      text: newText,
+    }),
+  );
 }
 
 function cancelRuleEdit(id) {
-    const card = document.querySelector(`.rule-card[data-id="${id}"]`);
-    if (!card) return;
-    card.classList.remove('editing');
-    const editArea = card.querySelector('.rule-edit-area');
-    if (editArea) editArea.remove();
+  const card = document.querySelector(`.rule-card[data-id="${id}"]`);
+  if (!card) return;
+  card.classList.remove("editing");
+  const editArea = card.querySelector(".rule-edit-area");
+  if (editArea) editArea.remove();
 }
 
 function startDeleteRule(id) {
-    const card = document.querySelector(`.rule-card[data-id="${id}"]`);
-    if (!card) return;
-    const actions = card.querySelector('.rule-actions');
-    if (!actions || actions.dataset.confirming) return;
-    actions.dataset.confirming = '1';
-    actions.style.opacity = '1';
-    actions.innerHTML = `
+  const card = document.querySelector(`.rule-card[data-id="${id}"]`);
+  if (!card) return;
+  const actions = card.querySelector(".rule-actions");
+  if (!actions || actions.dataset.confirming) return;
+  actions.dataset.confirming = "1";
+  actions.style.opacity = "1";
+  actions.innerHTML = `
         <span style="font-size:11px;color:var(--error-color);white-space:nowrap;margin-right:4px">Delete?</span>
         <button class="confirm-yes" style="background:var(--error-color);color:#fff;border:none;border-radius:4px;padding:2px 8px;font-size:11px;font-weight:600;cursor:pointer;font-family:inherit" onclick="deleteRule(${id})">Yes</button>
         <button class="confirm-no" style="background:transparent;color:var(--text-dim);border:1px solid var(--border);border-radius:4px;padding:2px 8px;font-size:11px;font-weight:600;cursor:pointer;font-family:inherit" onclick="cancelDeleteRule(${id})">No</button>
@@ -508,24 +560,24 @@ function startDeleteRule(id) {
 }
 
 function deleteRule(id) {
-    const rules = window.rules;
-    const d = rules.find(r => r.id === id);
-    window.ws.send(JSON.stringify({ type: 'rule_delete', id }));
+  const rules = window.rules;
+  const d = rules.find((r) => r.id === id);
+  window.ws.send(JSON.stringify({ type: "rule_delete", id }));
 
-    // Prefill a rejection message to the proposer
-    const author = d?.author || d?.owner;
-    if (d && author && author.toLowerCase() !== window.username.toLowerCase()) {
-        const input = document.getElementById('input');
-        const reasonBit = d.reason ? ` (reason: ${d.reason})` : '';
-        input.value = `@${author} Rule rejected: "${d.text || d.decision || ''}"${reasonBit} — `;
-        input.focus();
-        input.selectionStart = input.selectionEnd = input.value.length;
-        input.dispatchEvent(new Event('input'));
-    }
+  // Prefill a rejection message to the proposer
+  const author = d?.author || d?.owner;
+  if (d && author && author.toLowerCase() !== window.username.toLowerCase()) {
+    const input = document.getElementById("input");
+    const reasonBit = d.reason ? ` (reason: ${d.reason})` : "";
+    input.value = `@${author} Rule rejected: "${d.text || d.decision || ""}"${reasonBit} — `;
+    input.focus();
+    input.selectionStart = input.selectionEnd = input.value.length;
+    input.dispatchEvent(new Event("input"));
+  }
 }
 
 function cancelDeleteRule(id) {
-    renderRulesPanel();
+  renderRulesPanel();
 }
 
 // ---------------------------------------------------------------------------
@@ -533,27 +585,26 @@ function cancelDeleteRule(id) {
 // ---------------------------------------------------------------------------
 
 async function resolveRuleProposal(msgId, action) {
-    try {
-        await fetch(`/api/messages/${msgId}/resolve_rule_proposal`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({ action }),
-        });
-    } catch (e) {
-        console.error('Failed to resolve rule proposal:', e);
-    }
+  try {
+    await fetch(`/api/messages/${msgId}/resolve_rule_proposal`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action }),
+    });
+  } catch (e) {
+    console.error("Failed to resolve rule proposal:", e);
+  }
 }
 
 async function dismissRuleProposal(msgId) {
-    // Demote to regular chat message — same as job proposal dismiss
-    try {
-        await fetch(`/api/messages/${msgId}/demote_rule_proposal`, {
-            method: 'POST',
-            headers: { 'X-Session-Token': window.SESSION_TOKEN },
-        });
-    } catch (e) {
-        console.error('Failed to dismiss rule proposal:', e);
-    }
+  // Demote to regular chat message — same as job proposal dismiss
+  try {
+    await fetch(`/api/messages/${msgId}/demote_rule_proposal`, {
+      method: "POST",
+    });
+  } catch (e) {
+    console.error("Failed to dismiss rule proposal:", e);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -561,8 +612,8 @@ async function dismissRuleProposal(msgId) {
 // ---------------------------------------------------------------------------
 
 function _rulesPanelInit() {
-    setupRuleForm();
-    setupRulesGrip();
+  setupRuleForm();
+  setupRulesGrip();
 }
 
 // ---------------------------------------------------------------------------

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -7,7 +7,7 @@
  * Owns all session state, rendering, and interaction logic.
  * Subscribes to Hub for WS events and watches Store for channel changes.
  *
- * Reads from window: activeChannel, username, SESSION_TOKEN, ws,
+ * Reads from window: activeChannel, username, ws,
  *                    agentConfig, escapeHtml, switchChannel
  */
 
@@ -28,60 +28,71 @@ let sessionIndicatorTargetChannel = null;
 
 if (!window._messageRenderers) window._messageRenderers = {};
 
-function _renderSessionDraftResolvedCard(label, detail = '') {
-    return `
+function _renderSessionDraftResolvedCard(label, detail = "") {
+  return `
         <div class="proposal-card session-proposal-card proposal-resolved">
             <div class="proposal-header">
                 <span class="proposal-pill">Session Proposal</span>
             </div>
             <div class="proposal-title">${window.escapeHtml(label)}</div>
-            ${detail ? `<div class="proposal-body session-proposal-desc">${window.escapeHtml(detail)}</div>` : ''}
+            ${detail ? `<div class="proposal-body session-proposal-desc">${window.escapeHtml(detail)}</div>` : ""}
         </div>`;
 }
 
-window._messageRenderers['session_start'] = function (el, msg) {
-    el.classList.add('system-msg', 'session-banner', 'session-banner-start');
-    const goal = msg.metadata?.goal ? ` -- ${window.escapeHtml(msg.metadata.goal)}` : '';
-    el.innerHTML = `<span class="session-banner-icon">&#9654;</span> <strong>${window.escapeHtml(msg.text)}</strong>${goal}`;
+window._messageRenderers["session_start"] = function (el, msg) {
+  el.classList.add("system-msg", "session-banner", "session-banner-start");
+  const goal = msg.metadata?.goal
+    ? ` -- ${window.escapeHtml(msg.metadata.goal)}`
+    : "";
+  el.innerHTML = `<span class="session-banner-icon">&#9654;</span> <strong>${window.escapeHtml(msg.text)}</strong>${goal}`;
 };
 
-window._messageRenderers['session_end'] = function (el, msg) {
-    el.classList.add('system-msg', 'session-banner', 'session-banner-end');
-    const outputId = msg.metadata?.output_message_id;
-    const jumpLink = outputId ? ` <span class="session-output-link" onclick="scrollToSessionOutput(${outputId})">View output</span>` : '';
-    el.innerHTML = `<span class="session-banner-icon">&#9632;</span> <strong>${window.escapeHtml(msg.text)}</strong>${jumpLink}`;
+window._messageRenderers["session_end"] = function (el, msg) {
+  el.classList.add("system-msg", "session-banner", "session-banner-end");
+  const outputId = msg.metadata?.output_message_id;
+  const jumpLink = outputId
+    ? ` <span class="session-output-link" onclick="scrollToSessionOutput(${outputId})">View output</span>`
+    : "";
+  el.innerHTML = `<span class="session-banner-icon">&#9632;</span> <strong>${window.escapeHtml(msg.text)}</strong>${jumpLink}`;
 };
 
-window._messageRenderers['session_phase'] = function (el, msg) {
-    el.classList.add('system-msg', 'session-banner', 'session-banner-phase');
-    el.innerHTML = `<span class="session-banner-icon">&#9656;</span> ${window.escapeHtml(msg.text)}`;
+window._messageRenderers["session_phase"] = function (el, msg) {
+  el.classList.add("system-msg", "session-banner", "session-banner-phase");
+  el.innerHTML = `<span class="session-banner-icon">&#9656;</span> ${window.escapeHtml(msg.text)}`;
 };
 
-window._messageRenderers['session_draft'] = function (el, msg) {
-    el.classList.add('system-msg', 'session-draft-card');
-    const meta = msg.metadata || {};
-    const valid = meta.valid;
-    const errors = meta.errors || [];
-    const tmpl = meta.template || {};
-    const draftId = meta.draft_id || '';
-    const proposedBy = meta.proposed_by || '?';
-    const revision = meta.revision || 1;
-    const proposedByColor = window.getColor ? window.getColor(proposedBy) : 'var(--text-dim)';
+window._messageRenderers["session_draft"] = function (el, msg) {
+  el.classList.add("system-msg", "session-draft-card");
+  const meta = msg.metadata || {};
+  const valid = meta.valid;
+  const errors = meta.errors || [];
+  const tmpl = meta.template || {};
+  const draftId = meta.draft_id || "";
+  const proposedBy = meta.proposed_by || "?";
+  const revision = meta.revision || 1;
+  const proposedByColor = window.getColor
+    ? window.getColor(proposedBy)
+    : "var(--text-dim)";
 
-    // Check if superseded by a newer revision
-    const isSuperseded = _isSupersededDraft(draftId, revision);
+  // Check if superseded by a newer revision
+  const isSuperseded = _isSupersededDraft(draftId, revision);
 
-    // Always store draft identity for supersession lookups
-    el.dataset.draftId = draftId;
-    el.dataset.draftRevision = revision;
+  // Always store draft identity for supersession lookups
+  el.dataset.draftId = draftId;
+  el.dataset.draftRevision = revision;
 
-    if (isSuperseded) {
-        el.classList.add('session-draft-superseded');
-        el.innerHTML = _renderSessionDraftResolvedCard('Superseded draft', `Replaced by revision ${revision}.`);
-    } else if (!valid) {
-        el.classList.add('session-draft-invalid');
-        const errorList = errors.map(e => `<li>${window.escapeHtml(e)}</li>`).join('');
-        el.innerHTML = `
+  if (isSuperseded) {
+    el.classList.add("session-draft-superseded");
+    el.innerHTML = _renderSessionDraftResolvedCard(
+      "Superseded draft",
+      `Replaced by revision ${revision}.`,
+    );
+  } else if (!valid) {
+    el.classList.add("session-draft-invalid");
+    const errorList = errors
+      .map((e) => `<li>${window.escapeHtml(e)}</li>`)
+      .join("");
+    el.innerHTML = `
             <div class="proposal-card session-proposal-card session-proposal-invalid">
                 <div class="proposal-header">
                     <span class="proposal-pill">Session Proposal</span>
@@ -95,36 +106,41 @@ window._messageRenderers['session_draft'] = function (el, msg) {
                     <button class="proposal-dismiss" onclick="dismissDraft(${msg.id})">Dismiss</button>
                 </div>
             </div>`;
-    } else {
-        const phases = tmpl.phases || [];
-        const phasesDetailHtml = phases.map((p, i) => {
-            const parts = (p.participants || [])
-                .map(r => `<span class="session-draft-phase-participant-pill">${window.escapeHtml(r)}</span>`)
-                .join('');
-            const promptText = p.prompt ? window.escapeHtml(p.prompt) : '';
-            return `<div class="session-draft-phase-detail">
+  } else {
+    const phases = tmpl.phases || [];
+    const phasesDetailHtml = phases
+      .map((p, i) => {
+        const parts = (p.participants || [])
+          .map(
+            (r) =>
+              `<span class="session-draft-phase-participant-pill">${window.escapeHtml(r)}</span>`,
+          )
+          .join("");
+        const promptText = p.prompt ? window.escapeHtml(p.prompt) : "";
+        return `<div class="session-draft-phase-detail">
                 <span class="session-draft-phase-num">${i + 1}</span>
                 <div class="session-draft-phase-copy">
                     <div class="session-draft-phase-top">
                         <span class="session-draft-phase-name">${window.escapeHtml(p.name)}</span>
-                        ${parts ? `<span class="session-draft-phase-participants">${parts}</span>` : ''}
+                        ${parts ? `<span class="session-draft-phase-participants">${parts}</span>` : ""}
                     </div>
-                    ${promptText ? `<div class="session-draft-phase-prompt">${promptText}</div>` : ''}
+                    ${promptText ? `<div class="session-draft-phase-prompt">${promptText}</div>` : ""}
                 </div>
             </div>`;
-        }).join('');
-        const metaLabel = revision > 1 ? `rev ${revision}` : '';
-        el.dataset.draftTemplate = JSON.stringify(tmpl);
-        el.dataset.draftMsgId = msg.id;
-        el.innerHTML = `
+      })
+      .join("");
+    const metaLabel = revision > 1 ? `rev ${revision}` : "";
+    el.dataset.draftTemplate = JSON.stringify(tmpl);
+    el.dataset.draftMsgId = msg.id;
+    el.innerHTML = `
             <div class="proposal-card session-proposal-card">
                 <div class="proposal-header">
                     <span class="proposal-pill">Session Proposal</span>
                     <span class="proposal-author" style="color: ${proposedByColor}">${window.escapeHtml(proposedBy)}</span>
-                    ${metaLabel ? `<span class="session-draft-meta">${metaLabel}</span>` : ''}
+                    ${metaLabel ? `<span class="session-draft-meta">${metaLabel}</span>` : ""}
                 </div>
-                <div class="proposal-title">${window.escapeHtml(tmpl.name || '?')}</div>
-                ${tmpl.description ? `<div class="proposal-body session-proposal-desc">${window.escapeHtml(tmpl.description)}</div>` : ''}
+                <div class="proposal-title">${window.escapeHtml(tmpl.name || "?")}</div>
+                ${tmpl.description ? `<div class="proposal-body session-proposal-desc">${window.escapeHtml(tmpl.description)}</div>` : ""}
                 <div class="session-draft-details">
                     ${phasesDetailHtml}
                 </div>
@@ -135,11 +151,11 @@ window._messageRenderers['session_draft'] = function (el, msg) {
                     <button class="proposal-dismiss" onclick="dismissDraft(${msg.id})">Dismiss</button>
                 </div>
             </div>`;
-        // Supersede older revisions of the same draft
-        if (revision > 1) {
-            setTimeout(() => _supersedePreviousDrafts(draftId, revision), 0);
-        }
+    // Supersede older revisions of the same draft
+    if (revision > 1) {
+      setTimeout(() => _supersedePreviousDrafts(draftId, revision), 0);
     }
+  }
 };
 
 // ---------------------------------------------------------------------------
@@ -147,47 +163,50 @@ window._messageRenderers['session_draft'] = function (el, msg) {
 // ---------------------------------------------------------------------------
 
 async function fetchSessionTemplates() {
-    try {
-        const res = await fetch('/api/sessions/templates', { headers: { 'X-Session-Token': window.SESSION_TOKEN } });
-        if (res.ok) sessionTemplates = await res.json();
-    } catch (e) {
-        console.warn('Failed to fetch session templates', e);
-    }
+  try {
+    const res = await fetch("/api/sessions/templates", {});
+    if (res.ok) sessionTemplates = await res.json();
+  } catch (e) {
+    console.warn("Failed to fetch session templates", e);
+  }
 }
 
 async function fetchAllActiveSessions() {
-    try {
-        const res = await fetch('/api/sessions/active-all', { headers: { 'X-Session-Token': window.SESSION_TOKEN } });
-        if (res.ok) {
-            const sessions = await res.json();
-            activeSessionsByChannel = {};
-            (sessions || []).forEach(session => {
-                const channel = session?.channel || 'general';
-                activeSessionsByChannel[channel] = session;
-            });
-            activeSession = activeSessionsByChannel[window.activeChannel] || null;
-            updateSessionBar();
-        }
-    } catch (e) {
-        console.warn('Failed to fetch active sessions', e);
+  try {
+    const res = await fetch("/api/sessions/active-all", {});
+    if (res.ok) {
+      const sessions = await res.json();
+      activeSessionsByChannel = {};
+      (sessions || []).forEach((session) => {
+        const channel = session?.channel || "general";
+        activeSessionsByChannel[channel] = session;
+      });
+      activeSession = activeSessionsByChannel[window.activeChannel] || null;
+      updateSessionBar();
     }
+  } catch (e) {
+    console.warn("Failed to fetch active sessions", e);
+  }
 }
 
 async function fetchActiveSession(channelName) {
-    if (channelName === undefined) channelName = window.activeChannel;
-    try {
-        const res = await fetch(`/api/sessions/active?channel=${encodeURIComponent(channelName)}`, { headers: { 'X-Session-Token': window.SESSION_TOKEN } });
-        if (res.ok) {
-            const data = await res.json();
-            if (data) activeSessionsByChannel[channelName] = data;
-            else delete activeSessionsByChannel[channelName];
-            if (channelName !== window.activeChannel) return;
-            activeSession = data;
-            updateSessionBar();
-        }
-    } catch (e) {
-        console.warn('Failed to fetch active session', e);
+  if (channelName === undefined) channelName = window.activeChannel;
+  try {
+    const res = await fetch(
+      `/api/sessions/active?channel=${encodeURIComponent(channelName)}`,
+      {},
+    );
+    if (res.ok) {
+      const data = await res.json();
+      if (data) activeSessionsByChannel[channelName] = data;
+      else delete activeSessionsByChannel[channelName];
+      if (channelName !== window.activeChannel) return;
+      activeSession = data;
+      updateSessionBar();
     }
+  } catch (e) {
+    console.warn("Failed to fetch active session", e);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -195,25 +214,29 @@ async function fetchActiveSession(channelName) {
 // ---------------------------------------------------------------------------
 
 function handleSessionEvent(action, session) {
-    if (!session) return;
-    const channel = session.channel || 'general';
+  if (!session) return;
+  const channel = session.channel || "general";
 
-    if (action === 'create' || action === 'update') {
-        activeSessionsByChannel[channel] = session;
-        if (channel === window.activeChannel) {
-            activeSession = session;
-        }
-    } else if (action === 'complete' || action === 'interrupt') {
-        delete activeSessionsByChannel[channel];
-        if (channel === window.activeChannel) {
-            activeSession = null;
-        }
-        // Highlight the output message
-        if (channel === window.activeChannel && action === 'complete' && session.output_message_id) {
-            highlightSessionOutput(session.output_message_id);
-        }
+  if (action === "create" || action === "update") {
+    activeSessionsByChannel[channel] = session;
+    if (channel === window.activeChannel) {
+      activeSession = session;
     }
-    updateSessionBar();
+  } else if (action === "complete" || action === "interrupt") {
+    delete activeSessionsByChannel[channel];
+    if (channel === window.activeChannel) {
+      activeSession = null;
+    }
+    // Highlight the output message
+    if (
+      channel === window.activeChannel &&
+      action === "complete" &&
+      session.output_message_id
+    ) {
+      highlightSessionOutput(session.output_message_id);
+    }
+  }
+  updateSessionBar();
 }
 
 // ---------------------------------------------------------------------------
@@ -221,86 +244,95 @@ function handleSessionEvent(action, session) {
 // ---------------------------------------------------------------------------
 
 function updateSessionBar() {
-    const bar = document.getElementById('session-bar');
-    if (!bar) return;
-    const templateEl = bar.querySelector('.session-template');
-    const phaseEl = bar.querySelector('.session-phase');
-    const waitingEl = bar.querySelector('.session-waiting');
-    const endBtn = document.getElementById('session-end-btn');
-    const jumpBtn = document.getElementById('session-jump-btn');
+  const bar = document.getElementById("session-bar");
+  if (!bar) return;
+  const templateEl = bar.querySelector(".session-template");
+  const phaseEl = bar.querySelector(".session-phase");
+  const waitingEl = bar.querySelector(".session-waiting");
+  const endBtn = document.getElementById("session-end-btn");
+  const jumpBtn = document.getElementById("session-jump-btn");
 
-    if (!activeSession) {
-        const otherSessions = Object.values(activeSessionsByChannel)
-            .filter(session => session && (session.channel || 'general') !== window.activeChannel);
+  if (!activeSession) {
+    const otherSessions = Object.values(activeSessionsByChannel).filter(
+      (session) =>
+        session && (session.channel || "general") !== window.activeChannel,
+    );
 
-        if (!otherSessions.length) {
-            clearEndSessionConfirm();
-            sessionIndicatorTargetChannel = null;
-            bar.classList.add('hidden');
-            bar.classList.remove('session-elsewhere');
-            return;
-        }
-
-        const target = otherSessions[0];
-        const extraCount = otherSessions.length - 1;
-        const targetChannel = target.channel || 'general';
-        const targetName = target.template_name || target.template_id || 'Session';
-        const channelListText = otherSessions.map(session => `#${session.channel || 'general'}`).join(', ');
-
-        sessionIndicatorTargetChannel = targetChannel;
-        clearEndSessionConfirm();
-        bar.classList.remove('hidden');
-        bar.classList.add('session-elsewhere');
-        templateEl.textContent = otherSessions.length === 1
-            ? `Session active in #${targetChannel}`
-            : `${otherSessions.length} sessions active elsewhere`;
-        phaseEl.textContent = otherSessions.length === 1
-            ? targetName
-            : channelListText;
-        waitingEl.style.display = 'none';
-        if (jumpBtn) {
-            jumpBtn.textContent = extraCount > 0
-                ? `Go to #${targetChannel} (+${extraCount})`
-                : `Go to #${targetChannel}`;
-            jumpBtn.classList.remove('hidden');
-            jumpBtn.style.display = '';
-        }
-        if (endBtn) endBtn.style.display = 'none';
-        return;
+    if (!otherSessions.length) {
+      clearEndSessionConfirm();
+      sessionIndicatorTargetChannel = null;
+      bar.classList.add("hidden");
+      bar.classList.remove("session-elsewhere");
+      return;
     }
 
-    bar.classList.remove('hidden');
-    bar.classList.remove('session-elsewhere');
-    sessionIndicatorTargetChannel = null;
-    const s = activeSession;
-    const templateName = s.template_name || s.template_id || '?';
-    const phaseName = s.phase_name || `Phase ${(s.current_phase || 0) + 1}`;
-    const totalPhases = s.total_phases || '?';
-    const phaseNum = (s.current_phase || 0) + 1;
+    const target = otherSessions[0];
+    const extraCount = otherSessions.length - 1;
+    const targetChannel = target.channel || "general";
+    const targetName = target.template_name || target.template_id || "Session";
+    const channelListText = otherSessions
+      .map((session) => `#${session.channel || "general"}`)
+      .join(", ");
 
-    templateEl.textContent = templateName;
-    phaseEl.textContent = `${phaseName} (${phaseNum}/${totalPhases})`;
+    sessionIndicatorTargetChannel = targetChannel;
+    clearEndSessionConfirm();
+    bar.classList.remove("hidden");
+    bar.classList.add("session-elsewhere");
+    templateEl.textContent =
+      otherSessions.length === 1
+        ? `Session active in #${targetChannel}`
+        : `${otherSessions.length} sessions active elsewhere`;
+    phaseEl.textContent =
+      otherSessions.length === 1 ? targetName : channelListText;
+    waitingEl.style.display = "none";
     if (jumpBtn) {
-        jumpBtn.classList.add('hidden');
-        jumpBtn.style.display = 'none';
+      jumpBtn.textContent =
+        extraCount > 0
+          ? `Go to #${targetChannel} (+${extraCount})`
+          : `Go to #${targetChannel}`;
+      jumpBtn.classList.remove("hidden");
+      jumpBtn.style.display = "";
     }
-    if (endBtn) endBtn.style.display = '';
+    if (endBtn) endBtn.style.display = "none";
+    return;
+  }
 
-    const waitingAgent = s.current_agent || s.waiting_on;
-    if (s.state === 'waiting' && waitingAgent) {
-        waitingEl.textContent = `Waiting for ${waitingAgent}`;
-        waitingEl.style.display = '';
-    } else if (s.state === 'paused') {
-        waitingEl.textContent = 'Paused';
-        waitingEl.style.display = '';
-    } else {
-        waitingEl.style.display = 'none';
-    }
+  bar.classList.remove("hidden");
+  bar.classList.remove("session-elsewhere");
+  sessionIndicatorTargetChannel = null;
+  const s = activeSession;
+  const templateName = s.template_name || s.template_id || "?";
+  const phaseName = s.phase_name || `Phase ${(s.current_phase || 0) + 1}`;
+  const totalPhases = s.total_phases || "?";
+  const phaseNum = (s.current_phase || 0) + 1;
+
+  templateEl.textContent = templateName;
+  phaseEl.textContent = `${phaseName} (${phaseNum}/${totalPhases})`;
+  if (jumpBtn) {
+    jumpBtn.classList.add("hidden");
+    jumpBtn.style.display = "none";
+  }
+  if (endBtn) endBtn.style.display = "";
+
+  const waitingAgent = s.current_agent || s.waiting_on;
+  if (s.state === "waiting" && waitingAgent) {
+    waitingEl.textContent = `Waiting for ${waitingAgent}`;
+    waitingEl.style.display = "";
+  } else if (s.state === "paused") {
+    waitingEl.textContent = "Paused";
+    waitingEl.style.display = "";
+  } else {
+    waitingEl.style.display = "none";
+  }
 }
 
 function jumpToSessionChannel() {
-    if (!sessionIndicatorTargetChannel || sessionIndicatorTargetChannel === window.activeChannel) return;
-    window.switchChannel(sessionIndicatorTargetChannel);
+  if (
+    !sessionIndicatorTargetChannel ||
+    sessionIndicatorTargetChannel === window.activeChannel
+  )
+    return;
+  window.switchChannel(sessionIndicatorTargetChannel);
 }
 
 // ---------------------------------------------------------------------------
@@ -308,68 +340,80 @@ function jumpToSessionChannel() {
 // ---------------------------------------------------------------------------
 
 function _getAvailableAgents() {
-    return Object.entries(window.agentConfig || {})
-        .filter(([_, cfg]) => cfg.state === 'active')
-        .map(([name]) => name);
+  return Object.entries(window.agentConfig || {})
+    .filter(([_, cfg]) => cfg.state === "active")
+    .map(([name]) => name);
 }
 
 function _autoCast(roles, agents) {
-    const cast = {};
-    let pool = [...agents];
-    for (const role of roles) {
-        if (!pool.length) pool = [...agents];
-        if (!pool.length) return null;
-        cast[role] = pool.shift();
-    }
-    return cast;
+  const cast = {};
+  let pool = [...agents];
+  for (const role of roles) {
+    if (!pool.length) pool = [...agents];
+    if (!pool.length) return null;
+    cast[role] = pool.shift();
+  }
+  return cast;
 }
 
 function syncSessionCastRole(selectEl) {
-    const role = selectEl?.dataset?.role;
-    if (!role) return;
-    const value = selectEl.value;
-    document.querySelectorAll('.session-cast-select').forEach(sel => {
-        if (sel !== selectEl && sel.dataset.role === role) {
-            sel.value = value;
-        }
-    });
+  const role = selectEl?.dataset?.role;
+  if (!role) return;
+  const value = selectEl.value;
+  document.querySelectorAll(".session-cast-select").forEach((sel) => {
+    if (sel !== selectEl && sel.dataset.role === role) {
+      sel.value = value;
+    }
+  });
 }
 
 function buildSessionCastEditor(tmpl, cast, assignees) {
-    const phases = tmpl.phases || [];
-    if (!phases.length) {
-        return (tmpl.roles || []).map(role => {
-            const assigned = cast ? cast[role] : '';
-            const options = assignees.map(a =>
-                `<option value="${window.escapeHtml(a)}" ${a === assigned ? 'selected' : ''}>${window.escapeHtml(a)}</option>`
-            ).join('');
-            return `<div class="session-cast-row">
+  const phases = tmpl.phases || [];
+  if (!phases.length) {
+    return (tmpl.roles || [])
+      .map((role) => {
+        const assigned = cast ? cast[role] : "";
+        const options = assignees
+          .map(
+            (a) =>
+              `<option value="${window.escapeHtml(a)}" ${a === assigned ? "selected" : ""}>${window.escapeHtml(a)}</option>`,
+          )
+          .join("");
+        return `<div class="session-cast-row">
                 <span class="session-cast-role">${window.escapeHtml(role)}</span>
                 <select class="session-cast-select" data-role="${window.escapeHtml(role)}" onchange="syncSessionCastRole(this)">${options}</select>
             </div>`;
-        }).join('');
-    }
+      })
+      .join("");
+  }
 
-    return phases.map((phase, idx) => {
-        const participantRows = (phase.participants || []).map(role => {
-            const assigned = cast ? cast[role] : '';
-            const options = assignees.map(a =>
-                `<option value="${window.escapeHtml(a)}" ${a === assigned ? 'selected' : ''}>${window.escapeHtml(a)}</option>`
-            ).join('');
-            return `<div class="session-cast-row">
+  return phases
+    .map((phase, idx) => {
+      const participantRows = (phase.participants || [])
+        .map((role) => {
+          const assigned = cast ? cast[role] : "";
+          const options = assignees
+            .map(
+              (a) =>
+                `<option value="${window.escapeHtml(a)}" ${a === assigned ? "selected" : ""}>${window.escapeHtml(a)}</option>`,
+            )
+            .join("");
+          return `<div class="session-cast-row">
                 <span class="session-cast-role">${window.escapeHtml(role)}</span>
                 <select class="session-cast-select" data-role="${window.escapeHtml(role)}" onchange="syncSessionCastRole(this)">${options}</select>
             </div>`;
-        }).join('');
+        })
+        .join("");
 
-        return `<div class="session-cast-phase">
+      return `<div class="session-cast-phase">
             <div class="session-cast-phase-head">
                 <span class="session-cast-phase-num">${idx + 1}.</span>
                 <span class="session-cast-phase-name">${window.escapeHtml(phase.name || `Phase ${idx + 1}`)}</span>
             </div>
             <div class="session-cast-phase-list">${participantRows}</div>
         </div>`;
-    }).join('');
+    })
+    .join("");
 }
 
 // ---------------------------------------------------------------------------
@@ -377,29 +421,37 @@ function buildSessionCastEditor(tmpl, cast, assignees) {
 // ---------------------------------------------------------------------------
 
 function showSessionLauncher() {
-    let existing = document.getElementById('session-launcher-modal');
-    if (existing) existing.remove();
+  let existing = document.getElementById("session-launcher-modal");
+  if (existing) existing.remove();
 
-    const modal = document.createElement('div');
-    modal.id = 'session-launcher-modal';
-    modal.className = 'session-launcher-overlay';
-    modal.onclick = (e) => { if (e.target === modal) modal.remove(); };
+  const modal = document.createElement("div");
+  modal.id = "session-launcher-modal";
+  modal.className = "session-launcher-overlay";
+  modal.onclick = (e) => {
+    if (e.target === modal) modal.remove();
+  };
 
-    let templateOptions = sessionTemplates.map(t =>
-        `<div class="session-tmpl-card" onclick="showCastPreview('${window.escapeHtml(t.id)}')" title="${window.escapeHtml(t.description || '')}">
-            ${t.is_custom ? `<span class="session-tmpl-delete-wrap"><button class="session-tmpl-delete" onclick="toggleDeleteSessionTemplateConfirm(this, '${window.escapeHtml(t.id)}', event)" title="Delete custom template">Delete</button></span>` : ''}
+  let templateOptions = sessionTemplates
+    .map(
+      (t) =>
+        `<div class="session-tmpl-card" onclick="showCastPreview('${window.escapeHtml(t.id)}')" title="${window.escapeHtml(t.description || "")}">
+            ${t.is_custom ? `<span class="session-tmpl-delete-wrap"><button class="session-tmpl-delete" onclick="toggleDeleteSessionTemplateConfirm(this, '${window.escapeHtml(t.id)}', event)" title="Delete custom template">Delete</button></span>` : ""}
             <div class="session-tmpl-name">${window.escapeHtml(t.name)}</div>
-            <div class="session-tmpl-desc">${window.escapeHtml(t.description || '')}</div>
-            <div class="session-tmpl-roles">${(t.roles || []).map(r => `<span class="session-role-pill">${window.escapeHtml(r)}</span>`).join(' ')}</div>
-        </div>`
-    ).join('');
+            <div class="session-tmpl-desc">${window.escapeHtml(t.description || "")}</div>
+            <div class="session-tmpl-roles">${(t.roles || []).map((r) => `<span class="session-role-pill">${window.escapeHtml(r)}</span>`).join(" ")}</div>
+        </div>`,
+    )
+    .join("");
 
-    // "Design a session" card -- lets user describe what they want and pick an agent to draft it
-    const agents = _getAvailableAgents();
-    const agentOptions = agents.map(a =>
-        `<option value="${window.escapeHtml(a)}">${window.escapeHtml(a)}</option>`
-    ).join('');
-    const designCard = `
+  // "Design a session" card -- lets user describe what they want and pick an agent to draft it
+  const agents = _getAvailableAgents();
+  const agentOptions = agents
+    .map(
+      (a) =>
+        `<option value="${window.escapeHtml(a)}">${window.escapeHtml(a)}</option>`,
+    )
+    .join("");
+  const designCard = `
         <div class="session-tmpl-card session-design-card">
             <div class="session-tmpl-name">+ Design a session</div>
             <div class="session-tmpl-desc">Ask an agent to draft a custom session template</div>
@@ -410,7 +462,7 @@ function showSessionLauncher() {
             </div>
         </div>`;
 
-    modal.innerHTML = `
+  modal.innerHTML = `
         <div class="session-launcher-dialog">
             <div class="session-launcher-header">
                 <span>Start a Session</span>
@@ -425,48 +477,56 @@ function showSessionLauncher() {
             <div id="session-step-cast" class="hidden"></div>
         </div>
     `;
-    document.body.appendChild(modal);
-    document.getElementById('session-goal-input')?.focus();
+  document.body.appendChild(modal);
+  document.getElementById("session-goal-input")?.focus();
 }
 
 async function sendDesignRequest() {
-    const agent = document.getElementById('session-design-agent')?.value;
-    const desc = document.getElementById('session-design-desc')?.value?.trim();
-    if (!agent || !desc) return;
-    const modal = document.getElementById('session-launcher-modal');
-    if (modal) modal.remove();
-    try {
-        const res = await fetch('/api/sessions/request-draft', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({ agent: agent, description: desc, channel: window.activeChannel, sender: window.username }),
-        });
-        if (!res.ok) alert('Failed to send design request (HTTP ' + res.status + ')');
-    } catch (e) {
-        alert('Error: ' + e.message);
-    }
+  const agent = document.getElementById("session-design-agent")?.value;
+  const desc = document.getElementById("session-design-desc")?.value?.trim();
+  if (!agent || !desc) return;
+  const modal = document.getElementById("session-launcher-modal");
+  if (modal) modal.remove();
+  try {
+    const res = await fetch("/api/sessions/request-draft", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agent: agent,
+        description: desc,
+        channel: window.activeChannel,
+        sender: window.username,
+      }),
+    });
+    if (!res.ok)
+      alert("Failed to send design request (HTTP " + res.status + ")");
+  } catch (e) {
+    alert("Error: " + e.message);
+  }
 }
 
 function showCastPreview(templateId) {
-    const tmpl = sessionTemplates.find(t => t.id === templateId);
-    if (!tmpl) return;
+  const tmpl = sessionTemplates.find((t) => t.id === templateId);
+  if (!tmpl) return;
 
-    const agents = _getAvailableAgents();
-    const cast = _autoCast(tmpl.roles || [], agents);
+  const agents = _getAvailableAgents();
+  const cast = _autoCast(tmpl.roles || [], agents);
 
-    // All possible assignees: agents + "user" (self) + "none" (skip)
-    const assignees = [...agents, window.username];
+  // All possible assignees: agents + "user" (self) + "none" (skip)
+  const assignees = [...agents, window.username];
 
-    const castStep = document.getElementById('session-step-cast');
-    const tmplStep = document.getElementById('session-step-templates');
-    if (!castStep || !tmplStep) return;
+  const castStep = document.getElementById("session-step-cast");
+  const tmplStep = document.getElementById("session-step-templates");
+  if (!castStep || !tmplStep) return;
 
-    tmplStep.classList.add('hidden');
-    castStep.classList.remove('hidden');
+  tmplStep.classList.add("hidden");
+  castStep.classList.remove("hidden");
 
-    const roleRows = buildSessionCastEditor(tmpl, cast, assignees);
+  const roleRows = buildSessionCastEditor(tmpl, cast, assignees);
 
-    castStep.innerHTML = `
+  castStep.innerHTML = `
         <div class="session-cast-header">
             <button class="session-back-btn" onclick="sessionCastBack()">&larr;</button>
             <span>${window.escapeHtml(tmpl.name)} -- Cast</span>
@@ -477,44 +537,48 @@ function showCastPreview(templateId) {
 }
 
 function sessionCastBack() {
-    const castStep = document.getElementById('session-step-cast');
-    const tmplStep = document.getElementById('session-step-templates');
-    if (castStep) castStep.classList.add('hidden');
-    if (tmplStep) tmplStep.classList.remove('hidden');
+  const castStep = document.getElementById("session-step-cast");
+  const tmplStep = document.getElementById("session-step-templates");
+  if (castStep) castStep.classList.add("hidden");
+  if (tmplStep) tmplStep.classList.remove("hidden");
 }
 
 async function launchSessionWithCast(templateId) {
-    const goalInput = document.getElementById('session-goal-input');
-    const goal = goalInput ? goalInput.value.trim() : '';
+  const goalInput = document.getElementById("session-goal-input");
+  const goal = goalInput ? goalInput.value.trim() : "";
 
-    // Read cast from dropdowns
-    const cast = {};
-    document.querySelectorAll('#session-step-cast .session-cast-select').forEach(sel => {
-        cast[sel.dataset.role] = sel.value;
+  // Read cast from dropdowns
+  const cast = {};
+  document
+    .querySelectorAll("#session-step-cast .session-cast-select")
+    .forEach((sel) => {
+      cast[sel.dataset.role] = sel.value;
     });
 
-    const modal = document.getElementById('session-launcher-modal');
-    if (modal) modal.remove();
+  const modal = document.getElementById("session-launcher-modal");
+  if (modal) modal.remove();
 
-    try {
-        const res = await fetch('/api/sessions/start', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({
-                template_id: templateId,
-                channel: window.activeChannel,
-                cast: cast,
-                goal: goal,
-                started_by: window.username,
-            }),
-        });
-        if (!res.ok) {
-            const data = await res.json();
-            alert(data.error || 'Failed to start session');
-        }
-    } catch (e) {
-        alert('Error starting session: ' + e.message);
+  try {
+    const res = await fetch("/api/sessions/start", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        template_id: templateId,
+        channel: window.activeChannel,
+        cast: cast,
+        goal: goal,
+        started_by: window.username,
+      }),
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      alert(data.error || "Failed to start session");
     }
+  } catch (e) {
+    alert("Error starting session: " + e.message);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -522,32 +586,32 @@ async function launchSessionWithCast(templateId) {
 // ---------------------------------------------------------------------------
 
 function clearEndSessionConfirm() {
-    const btn = document.getElementById('session-end-btn');
-    const confirm = document.getElementById('session-end-confirm');
-    if (confirm) confirm.remove();
-    if (btn) {
-        btn.textContent = 'End Session';
-        btn.classList.remove('confirming');
-    }
+  const btn = document.getElementById("session-end-btn");
+  const confirm = document.getElementById("session-end-confirm");
+  if (confirm) confirm.remove();
+  if (btn) {
+    btn.textContent = "End Session";
+    btn.classList.remove("confirming");
+  }
 }
 
 function toggleEndSessionConfirm(event) {
-    event.stopPropagation();
-    const btn = event.currentTarget;
-    const controls = document.getElementById('session-end-controls');
-    const existing = document.getElementById('session-end-confirm');
-    if (existing) {
-        clearEndSessionConfirm();
-        return;
-    }
+  event.stopPropagation();
+  const btn = event.currentTarget;
+  const controls = document.getElementById("session-end-controls");
+  const existing = document.getElementById("session-end-confirm");
+  if (existing) {
+    clearEndSessionConfirm();
+    return;
+  }
 
-    btn.textContent = 'End Session?';
-    btn.classList.add('confirming');
+  btn.textContent = "End Session?";
+  btn.classList.add("confirming");
 
-    const confirmWrap = document.createElement('span');
-    confirmWrap.id = 'session-end-confirm';
-    confirmWrap.className = 'session-inline-confirm';
-    confirmWrap.innerHTML = `
+  const confirmWrap = document.createElement("span");
+  confirmWrap.id = "session-end-confirm";
+  confirmWrap.className = "session-inline-confirm";
+  confirmWrap.innerHTML = `
         <button class="session-inline-confirm-yes ch-confirm-yes" title="Confirm end session">
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.5 3.5 6.5-7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
@@ -555,35 +619,36 @@ function toggleEndSessionConfirm(event) {
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
         </button>
     `;
-    (controls || btn.parentElement || btn).appendChild(confirmWrap);
+  (controls || btn.parentElement || btn).appendChild(confirmWrap);
 
-    confirmWrap.querySelector('.session-inline-confirm-yes').onclick = async (e) => {
-        e.stopPropagation();
-        await endActiveSession();
-    };
-    confirmWrap.querySelector('.session-inline-confirm-no').onclick = (e) => {
-        e.stopPropagation();
-        clearEndSessionConfirm();
-    };
+  confirmWrap.querySelector(".session-inline-confirm-yes").onclick = async (
+    e,
+  ) => {
+    e.stopPropagation();
+    await endActiveSession();
+  };
+  confirmWrap.querySelector(".session-inline-confirm-no").onclick = (e) => {
+    e.stopPropagation();
+    clearEndSessionConfirm();
+  };
 }
 
 async function endActiveSession() {
-    if (!activeSession) return;
+  if (!activeSession) return;
 
-    try {
-        const res = await fetch(`/api/sessions/${activeSession.id}/end`, {
-            method: 'POST',
-            headers: { 'X-Session-Token': window.SESSION_TOKEN },
-        });
-        if (!res.ok) {
-            const data = await res.json();
-            alert(data.error || 'Failed to end session');
-        }
-    } catch (e) {
-        alert('Error ending session: ' + e.message);
-    } finally {
-        clearEndSessionConfirm();
+  try {
+    const res = await fetch(`/api/sessions/${activeSession.id}/end`, {
+      method: "POST",
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      alert(data.error || "Failed to end session");
     }
+  } catch (e) {
+    alert("Error ending session: " + e.message);
+  } finally {
+    clearEndSessionConfirm();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -591,60 +656,68 @@ async function endActiveSession() {
 // ---------------------------------------------------------------------------
 
 function _isSupersededDraft(draftId, revision) {
-    if (!draftId) return false;
-    const allDrafts = document.querySelectorAll('.session-draft-card');
-    for (const card of allDrafts) {
-        if (card.dataset.draftId === draftId && parseInt(card.dataset.draftRevision || '0') > revision) {
-            return true;
-        }
+  if (!draftId) return false;
+  const allDrafts = document.querySelectorAll(".session-draft-card");
+  for (const card of allDrafts) {
+    if (
+      card.dataset.draftId === draftId &&
+      parseInt(card.dataset.draftRevision || "0") > revision
+    ) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 function _supersedePreviousDrafts(draftId, currentRevision) {
-    if (!draftId) return;
-    const allDrafts = document.querySelectorAll('.session-draft-card');
-    for (const card of allDrafts) {
-        if (card.dataset.draftId === draftId && parseInt(card.dataset.draftRevision || '0') < currentRevision) {
-            if (!card.classList.contains('session-draft-superseded')) {
-                card.classList.add('session-draft-superseded');
-                card.innerHTML = _renderSessionDraftResolvedCard(
-                    `Superseded (rev ${card.dataset.draftRevision})`,
-                    'A newer revision is now the active draft.'
-                );
-            }
-        }
+  if (!draftId) return;
+  const allDrafts = document.querySelectorAll(".session-draft-card");
+  for (const card of allDrafts) {
+    if (
+      card.dataset.draftId === draftId &&
+      parseInt(card.dataset.draftRevision || "0") < currentRevision
+    ) {
+      if (!card.classList.contains("session-draft-superseded")) {
+        card.classList.add("session-draft-superseded");
+        card.innerHTML = _renderSessionDraftResolvedCard(
+          `Superseded (rev ${card.dataset.draftRevision})`,
+          "A newer revision is now the active draft.",
+        );
+      }
     }
+  }
 }
 
 function runDraft(msgId) {
-    const el = document.querySelector(`.message[data-id="${msgId}"]`);
-    if (!el || !el.dataset.draftTemplate) return;
-    const tmpl = JSON.parse(el.dataset.draftTemplate);
+  const el = document.querySelector(`.message[data-id="${msgId}"]`);
+  if (!el || !el.dataset.draftTemplate) return;
+  const tmpl = JSON.parse(el.dataset.draftTemplate);
 
-    // Open the cast preview modal with draft context
-    showDraftCastPreview(tmpl, msgId);
+  // Open the cast preview modal with draft context
+  showDraftCastPreview(tmpl, msgId);
 }
 
 function showDraftCastPreview(tmpl, draftMsgId) {
-    const agents = _getAvailableAgents();
-    const cast = _autoCast(tmpl.roles || [], agents);
-    const assignees = [...agents, window.username];
+  const agents = _getAvailableAgents();
+  const cast = _autoCast(tmpl.roles || [], agents);
+  const assignees = [...agents, window.username];
 
-    let existing = document.getElementById('session-launcher-modal');
-    if (existing) existing.remove();
+  let existing = document.getElementById("session-launcher-modal");
+  if (existing) existing.remove();
 
-    const modal = document.createElement('div');
-    modal.id = 'session-launcher-modal';
-    modal.className = 'session-launcher-overlay';
-    modal.onclick = (e) => { if (e.target === modal) modal.remove(); };
+  const modal = document.createElement("div");
+  modal.id = "session-launcher-modal";
+  modal.className = "session-launcher-overlay";
+  modal.onclick = (e) => {
+    if (e.target === modal) modal.remove();
+  };
 
-    const roleRows = buildSessionCastEditor(tmpl, cast, assignees);
+  const roleRows = buildSessionCastEditor(tmpl, cast, assignees);
 
-    modal.innerHTML = `
+  modal.innerHTML = `
         <div class="session-launcher-dialog">
             <div class="session-launcher-header">
-                <span>${window.escapeHtml(tmpl.name || '?')} -- Cast</span>
+                <span>${window.escapeHtml(tmpl.name || "?")} -- Cast</span>
                 <button onclick="this.closest('.session-launcher-overlay').remove()">&times;</button>
             </div>
             <div class="session-launcher-goal">
@@ -656,89 +729,99 @@ function showDraftCastPreview(tmpl, draftMsgId) {
             </div>
         </div>
     `;
-    document.body.appendChild(modal);
+  document.body.appendChild(modal);
 }
 
 async function launchDraftSession(draftMsgId) {
-    const goalInput = document.getElementById('session-goal-input');
-    const goal = goalInput ? goalInput.value.trim() : '';
+  const goalInput = document.getElementById("session-goal-input");
+  const goal = goalInput ? goalInput.value.trim() : "";
 
-    const cast = {};
-    document.querySelectorAll('#session-step-cast .session-cast-select').forEach(sel => {
-        cast[sel.dataset.role] = sel.value;
+  const cast = {};
+  document
+    .querySelectorAll("#session-step-cast .session-cast-select")
+    .forEach((sel) => {
+      cast[sel.dataset.role] = sel.value;
     });
 
-    const modal = document.getElementById('session-launcher-modal');
-    if (modal) modal.remove();
+  const modal = document.getElementById("session-launcher-modal");
+  if (modal) modal.remove();
 
-    try {
-        const res = await fetch('/api/sessions/start', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({
-                draft_message_id: draftMsgId,
-                channel: window.activeChannel,
-                cast: cast,
-                goal: goal,
-                started_by: window.username,
-            }),
-        });
-        if (!res.ok) {
-            const data = await res.json();
-            alert(data.error || 'Failed to start session from draft');
-        }
-    } catch (e) {
-        alert('Error: ' + e.message);
+  try {
+    const res = await fetch("/api/sessions/start", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        draft_message_id: draftMsgId,
+        channel: window.activeChannel,
+        cast: cast,
+        goal: goal,
+        started_by: window.username,
+      }),
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      alert(data.error || "Failed to start session from draft");
     }
+  } catch (e) {
+    alert("Error: " + e.message);
+  }
 }
 
 async function saveDraft(msgId, btn) {
-    try {
-        const res = await fetch('/api/sessions/save-draft', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
-            body: JSON.stringify({ message_id: msgId }),
-        });
-        if (res.ok) {
-            if (btn) {
-                btn.textContent = 'Saved';
-                btn.disabled = true;
-                btn.classList.add('saved');
-            }
-            fetchSessionTemplates();
-        } else {
-            const data = await res.json();
-            alert(data.error || 'Failed to save template');
-        }
-    } catch (e) {
-        alert('Error: ' + e.message);
+  try {
+    const res = await fetch("/api/sessions/save-draft", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message_id: msgId }),
+    });
+    if (res.ok) {
+      if (btn) {
+        btn.textContent = "Saved";
+        btn.disabled = true;
+        btn.classList.add("saved");
+      }
+      fetchSessionTemplates();
+    } else {
+      const data = await res.json();
+      alert(data.error || "Failed to save template");
     }
+  } catch (e) {
+    alert("Error: " + e.message);
+  }
 }
 
 function clearSessionTemplateDeleteConfirms() {
-    document.querySelectorAll('.session-tmpl-delete-confirm').forEach(el => el.remove());
-    document.querySelectorAll('.session-tmpl-delete.confirming').forEach(btn => {
-        btn.classList.remove('confirming');
-        btn.textContent = 'Delete';
+  document
+    .querySelectorAll(".session-tmpl-delete-confirm")
+    .forEach((el) => el.remove());
+  document
+    .querySelectorAll(".session-tmpl-delete.confirming")
+    .forEach((btn) => {
+      btn.classList.remove("confirming");
+      btn.textContent = "Delete";
     });
 }
 
 function toggleDeleteSessionTemplateConfirm(btn, templateId, event) {
-    if (event) event.stopPropagation();
-    const wrap = btn.closest('.session-tmpl-delete-wrap');
-    const existing = wrap?.querySelector('.session-tmpl-delete-confirm');
-    if (existing) {
-        clearSessionTemplateDeleteConfirms();
-        return;
-    }
-
+  if (event) event.stopPropagation();
+  const wrap = btn.closest(".session-tmpl-delete-wrap");
+  const existing = wrap?.querySelector(".session-tmpl-delete-confirm");
+  if (existing) {
     clearSessionTemplateDeleteConfirms();
-    btn.classList.add('confirming');
-    btn.textContent = 'Delete?';
+    return;
+  }
 
-    const confirmWrap = document.createElement('span');
-    confirmWrap.className = 'session-tmpl-delete-confirm';
-    confirmWrap.innerHTML = `
+  clearSessionTemplateDeleteConfirms();
+  btn.classList.add("confirming");
+  btn.textContent = "Delete?";
+
+  const confirmWrap = document.createElement("span");
+  confirmWrap.className = "session-tmpl-delete-confirm";
+  confirmWrap.innerHTML = `
         <button class="session-inline-confirm-yes ch-confirm-yes" title="Confirm delete">
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.5 3.5 6.5-7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
@@ -746,155 +829,166 @@ function toggleDeleteSessionTemplateConfirm(btn, templateId, event) {
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
         </button>
     `;
-    wrap.appendChild(confirmWrap);
+  wrap.appendChild(confirmWrap);
 
-    confirmWrap.querySelector('.session-inline-confirm-yes').onclick = async (e) => {
-        e.stopPropagation();
-        await deleteSessionTemplate(templateId);
-    };
-    confirmWrap.querySelector('.session-inline-confirm-no').onclick = (e) => {
-        e.stopPropagation();
-        clearSessionTemplateDeleteConfirms();
-    };
+  confirmWrap.querySelector(".session-inline-confirm-yes").onclick = async (
+    e,
+  ) => {
+    e.stopPropagation();
+    await deleteSessionTemplate(templateId);
+  };
+  confirmWrap.querySelector(".session-inline-confirm-no").onclick = (e) => {
+    e.stopPropagation();
+    clearSessionTemplateDeleteConfirms();
+  };
 }
 
 async function deleteSessionTemplate(templateId) {
-    try {
-        const res = await fetch(`/api/sessions/templates/${encodeURIComponent(templateId)}`, {
-            method: 'DELETE',
-            headers: { 'X-Session-Token': window.SESSION_TOKEN },
-        });
-        if (res.ok) {
-            await fetchSessionTemplates();
-            showSessionLauncher();
-        } else {
-            const data = await res.json();
-            alert(data.error || 'Failed to delete template');
-        }
-    } catch (e) {
-        alert('Error: ' + e.message);
-    } finally {
-        clearSessionTemplateDeleteConfirms();
+  try {
+    const res = await fetch(
+      `/api/sessions/templates/${encodeURIComponent(templateId)}`,
+      {
+        method: "DELETE",
+      },
+    );
+    if (res.ok) {
+      await fetchSessionTemplates();
+      showSessionLauncher();
+    } else {
+      const data = await res.json();
+      alert(data.error || "Failed to delete template");
     }
+  } catch (e) {
+    alert("Error: " + e.message);
+  } finally {
+    clearSessionTemplateDeleteConfirms();
+  }
 }
 
 function requestDraftChanges(draftId, proposedBy, msgId) {
-    const el = document.querySelector(`.message[data-id="${msgId}"]`);
-    if (!el) return;
-    const actions = el.querySelector('.proposal-actions') || el.querySelector('.session-draft-actions');
-    if (!actions) return;
+  const el = document.querySelector(`.message[data-id="${msgId}"]`);
+  if (!el) return;
+  const actions =
+    el.querySelector(".proposal-actions") ||
+    el.querySelector(".session-draft-actions");
+  if (!actions) return;
 
-    // Only allow one inline editor per draft card.
-    const existingInputs = el.querySelectorAll('.draft-changes-input');
-    if (existingInputs.length) {
-        existingInputs.forEach((row, idx) => {
-            if (idx > 0) row.remove();
-        });
-        existingInputs[0].querySelector('textarea')?.focus();
-        return;
-    }
+  // Only allow one inline editor per draft card.
+  const existingInputs = el.querySelectorAll(".draft-changes-input");
+  if (existingInputs.length) {
+    existingInputs.forEach((row, idx) => {
+      if (idx > 0) row.remove();
+    });
+    existingInputs[0].querySelector("textarea")?.focus();
+    return;
+  }
 
-    const inputRow = document.createElement('div');
-    inputRow.className = 'draft-changes-input';
-    inputRow.innerHTML = `
+  const inputRow = document.createElement("div");
+  inputRow.className = "draft-changes-input";
+  inputRow.innerHTML = `
         <textarea class="draft-changes-textarea" rows="2" placeholder="What changes do you want?"></textarea>
         <div class="draft-changes-btns">
             <button class="session-draft-btn run" onclick="submitDraftChanges('${window.escapeHtml(draftId)}', '${window.escapeHtml(proposedBy)}', ${msgId})">Send</button>
             <button class="session-draft-btn dismiss" onclick="dismissDraftChanges(this)">Cancel</button>
         </div>
     `;
-    actions.after(inputRow);
-    const ta = inputRow.querySelector('textarea');
-    ta.focus();
-    ta.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
-            e.preventDefault();
-            submitDraftChanges(draftId, proposedBy, msgId);
-        }
-        if (e.key === 'Escape') inputRow.remove();
-    });
+  actions.after(inputRow);
+  const ta = inputRow.querySelector("textarea");
+  ta.focus();
+  ta.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submitDraftChanges(draftId, proposedBy, msgId);
+    }
+    if (e.key === "Escape") inputRow.remove();
+  });
 }
 
 function submitDraftChanges(draftId, proposedBy, msgId) {
-    const el = document.querySelector(`.message[data-id="${msgId}"]`);
-    if (!el) return;
-    const inputRow = el.querySelector('.draft-changes-input');
-    const ta = inputRow?.querySelector('textarea');
-    const feedback = ta?.value?.trim();
-    if (!feedback) return;
+  const el = document.querySelector(`.message[data-id="${msgId}"]`);
+  if (!el) return;
+  const inputRow = el.querySelector(".draft-changes-input");
+  const ta = inputRow?.querySelector("textarea");
+  const feedback = ta?.value?.trim();
+  if (!feedback) return;
 
-    const tmplJson = el.dataset.draftTemplate || '';
-    const text = `@${proposedBy} Please revise session draft [${draftId}]: ${feedback}\n\nCurrent draft:\n\`\`\`session\n${tmplJson}\n\`\`\``;
-    if (window.ws && window.ws.readyState === WebSocket.OPEN) {
-        window.ws.send(JSON.stringify({
-            type: 'message',
-            text: text,
-            sender: window.username,
-            channel: window.activeChannel,
-        }));
-    } else {
-        alert('Connection lost. Reconnect and try again.');
-        return;
-    }
-    if (inputRow) inputRow.remove();
+  const tmplJson = el.dataset.draftTemplate || "";
+  const text = `@${proposedBy} Please revise session draft [${draftId}]: ${feedback}\n\nCurrent draft:\n\`\`\`session\n${tmplJson}\n\`\`\``;
+  if (window.ws && window.ws.readyState === WebSocket.OPEN) {
+    window.ws.send(
+      JSON.stringify({
+        type: "message",
+        text: text,
+        sender: window.username,
+        channel: window.activeChannel,
+      }),
+    );
+  } else {
+    alert("Connection lost. Reconnect and try again.");
+    return;
+  }
+  if (inputRow) inputRow.remove();
 }
 
 function dismissDraft(msgId) {
-    fetch(`/api/messages/${msgId}/demote`, {
-        method: 'POST',
-        headers: { 'X-Session-Token': window.SESSION_TOKEN },
-    }).then((res) => {
-        if (!res.ok) alert('Failed to dismiss session proposal (HTTP ' + res.status + ')');
-    }).catch((e) => {
-        console.error('Failed to demote session draft:', e);
-        alert('Failed to dismiss session proposal');
+  fetch(`/api/messages/${msgId}/demote`, {
+    method: "POST",
+  })
+    .then((res) => {
+      if (!res.ok)
+        alert("Failed to dismiss session proposal (HTTP " + res.status + ")");
+    })
+    .catch((e) => {
+      console.error("Failed to demote session draft:", e);
+      alert("Failed to dismiss session proposal");
     });
 }
 
 function dismissDraftChanges(btn) {
-    const row = btn.closest('.draft-changes-input');
-    if (row) row.remove();
+  const row = btn.closest(".draft-changes-input");
+  if (row) row.remove();
 }
 
 function highlightSessionOutput(messageId) {
-    const el = document.querySelector(`.message[data-id="${messageId}"]`);
-    if (el) el.classList.add('session-output');
+  const el = document.querySelector(`.message[data-id="${messageId}"]`);
+  if (el) el.classList.add("session-output");
 }
 
 function scrollToSessionOutput(messageId) {
-    const el = document.querySelector(`.message[data-id="${messageId}"]`);
-    if (el) {
-        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        el.classList.add('session-output');
-        el.classList.add('session-output-flash');
-        setTimeout(() => el.classList.remove('session-output-flash'), 2000);
-    }
+  const el = document.querySelector(`.message[data-id="${messageId}"]`);
+  if (el) {
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.classList.add("session-output");
+    el.classList.add("session-output-flash");
+    setTimeout(() => el.classList.remove("session-output-flash"), 2000);
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Hub subscription -- handle session WebSocket events
 // ---------------------------------------------------------------------------
 
-Hub.on('session', function (event) {
-    handleSessionEvent(event.action, event.data);
+Hub.on("session", function (event) {
+  handleSessionEvent(event.action, event.data);
 });
 
-Hub.on('channel_renamed', function (event) {
-    // Migrate session cache key so Store watcher resolves the correct session
-    if (activeSessionsByChannel[event.old_name]) {
-        activeSessionsByChannel[event.new_name] = activeSessionsByChannel[event.old_name];
-        delete activeSessionsByChannel[event.old_name];
-    }
+Hub.on("channel_renamed", function (event) {
+  // Migrate session cache key so Store watcher resolves the correct session
+  if (activeSessionsByChannel[event.old_name]) {
+    activeSessionsByChannel[event.new_name] =
+      activeSessionsByChannel[event.old_name];
+    delete activeSessionsByChannel[event.old_name];
+  }
 });
 
 // ---------------------------------------------------------------------------
 // Store integration -- react to channel changes
 // ---------------------------------------------------------------------------
 
-Store.watch('activeChannel', function (newChannel) {
-    activeSession = activeSessionsByChannel[newChannel] || null;
-    updateSessionBar();
-    fetchActiveSession(newChannel);
+Store.watch("activeChannel", function (newChannel) {
+  activeSession = activeSessionsByChannel[newChannel] || null;
+  updateSessionBar();
+  fetchActiveSession(newChannel);
 });
 
 // ---------------------------------------------------------------------------
@@ -902,11 +996,11 @@ Store.watch('activeChannel', function (newChannel) {
 // ---------------------------------------------------------------------------
 
 function _sessionsInit() {
-    fetchSessionTemplates();
-    fetchAllActiveSessions();
-    activeSession = null;
-    updateSessionBar();
-    fetchActiveSession();
+  fetchSessionTemplates();
+  fetchAllActiveSessions();
+  activeSession = null;
+  updateSessionBar();
+  fetchActiveSession();
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/launcher_helpers.test.cjs
+++ b/tests/launcher_helpers.test.cjs
@@ -1,0 +1,76 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  buildRestoreLaunchBody,
+  normalizeAgentLogEvent,
+  normalizeManagedAgentsPayload,
+  normalizeRestoreAgentsPayload,
+} = require("../static/launcher.js");
+
+test("normalizeManagedAgentsPayload reads backend data shape", () => {
+  assert.deepEqual(normalizeManagedAgentsPayload({ data: [{ name: "bot" }] }), [
+    { name: "bot" },
+  ]);
+  assert.deepEqual(
+    normalizeManagedAgentsPayload({ processes: [{ name: "bot-2" }] }),
+    [{ name: "bot-2" }],
+  );
+});
+
+test("normalizeRestoreAgentsPayload accepts raw arrays and wrapped arrays", () => {
+  assert.deepEqual(normalizeRestoreAgentsPayload([{ base: "bot" }]), [
+    { base: "bot" },
+  ]);
+  assert.deepEqual(normalizeRestoreAgentsPayload({ data: [{ base: "bot" }] }), [
+    { base: "bot" },
+  ]);
+  assert.deepEqual(
+    normalizeRestoreAgentsPayload({ agents: [{ base: "review-bot" }] }),
+    [{ base: "review-bot" }],
+  );
+});
+
+test("normalizeAgentLogEvent unwraps websocket payload nesting", () => {
+  assert.deepEqual(
+    normalizeAgentLogEvent({ data: { name: "bot", line: "crashed" } }),
+    { name: "bot", line: "crashed", lines: [] },
+  );
+  assert.deepEqual(
+    normalizeAgentLogEvent({ name: "bot", lines: ["a", "b"] }),
+    { name: "bot", line: "", lines: ["a", "b"] },
+  );
+});
+
+test("buildRestoreLaunchBody preserves relaunch config", () => {
+  assert.deepEqual(
+    buildRestoreLaunchBody({
+      base: "bot",
+      name: "review-bot",
+      cwd: "C:/repo",
+      flags: [],
+      extra_args: ["--dangerously-skip-permissions", "--json"],
+      instance_label: "review-bot",
+    }),
+    {
+      cwd: "C:/repo",
+      flags: [],
+      extra_args: ["--dangerously-skip-permissions", "--json"],
+      instance_label: "review-bot",
+    },
+  );
+
+  assert.deepEqual(
+    buildRestoreLaunchBody({
+      base: "bot",
+      name: "bot-2",
+      flags: [],
+      extra_args: [],
+    }),
+    {
+      flags: [],
+      extra_args: [],
+      instance_label: "bot-2",
+    },
+  );
+});

--- a/tests/launcher_helpers.test.cjs
+++ b/tests/launcher_helpers.test.cjs
@@ -6,6 +6,7 @@ const {
   normalizeAgentLogEvent,
   normalizeManagedAgentsPayload,
   normalizeRestoreAgentsPayload,
+  partitionLauncherInstances,
 } = require("../static/launcher.js");
 
 test("normalizeManagedAgentsPayload reads backend data shape", () => {
@@ -72,5 +73,22 @@ test("buildRestoreLaunchBody preserves relaunch config", () => {
       extra_args: [],
       instance_label: "bot-2",
     },
+  );
+});
+
+test("partitionLauncherInstances keeps starting agents in the active bucket", () => {
+  const partitions = partitionLauncherInstances([
+    { name: "booting-bot", state: "starting" },
+    { name: "live-bot", state: "running" },
+    { name: "dead-bot", state: "crashed" },
+  ]);
+
+  assert.deepEqual(
+    partitions.active.map((item) => item.name),
+    ["booting-bot", "live-bot"],
+  );
+  assert.deepEqual(
+    partitions.crashed.map((item) => item.name),
+    ["dead-bot"],
   );
 });

--- a/tests/test_agent_definitions.py
+++ b/tests/test_agent_definitions.py
@@ -1,4 +1,3 @@
-# tests/test_agent_definitions.py
 import json
 import sys
 from pathlib import Path
@@ -6,7 +5,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
-from config_loader import load_agent_definitions, save_agent_definition, delete_agent_definition
+from config_loader import (
+    delete_agent_definition,
+    load_agent_definitions,
+    load_config,
+    save_agent_definition,
+)
 
 
 def test_load_definitions_merges_with_config(tmp_path):
@@ -32,3 +36,32 @@ def test_save_and_delete_definition(tmp_path):
     delete_agent_definition(data_dir, "newbot")
     defs = load_agent_definitions(data_dir, {})
     assert "newbot" not in defs
+
+
+def test_load_config_includes_user_defined_agents_from_data_dir(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (tmp_path / "config.toml").write_text(
+        '[server]\ndata_dir = "./data"\n\n'
+        '[agents.claude]\ncommand = "claude"\ncolor = "#da7756"\nlabel = "Claude"\n',
+        encoding="utf-8",
+    )
+    (data_dir / "agent_definitions.json").write_text(
+        json.dumps(
+            {
+                "mybot": {
+                    "command": "python",
+                    "color": "#ff0000",
+                    "label": "MyBot",
+                    "cwd": "..",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(root=tmp_path)
+
+    assert "claude" in cfg["agents"]
+    assert "mybot" in cfg["agents"]
+    assert cfg["agents"]["mybot"]["command"] == "python"

--- a/tests/test_agent_definitions.py
+++ b/tests/test_agent_definitions.py
@@ -1,0 +1,34 @@
+# tests/test_agent_definitions.py
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from config_loader import load_agent_definitions, save_agent_definition, delete_agent_definition
+
+
+def test_load_definitions_merges_with_config(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "agent_definitions.json").write_text(json.dumps({
+        "mybot": {"command": "mybot", "color": "#ff0000", "label": "MyBot"}
+    }))
+    config_agents = {"claude": {"command": "claude", "color": "#da7756", "label": "Claude"}}
+    defs = load_agent_definitions(data_dir, config_agents)
+    assert "claude" in defs
+    assert "mybot" in defs
+    assert defs["mybot"]["color"] == "#ff0000"
+
+
+def test_save_and_delete_definition(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    save_agent_definition(data_dir, "newbot", {"command": "newbot", "color": "#00ff00", "label": "NewBot"})
+    defs = load_agent_definitions(data_dir, {})
+    assert "newbot" in defs
+
+    delete_agent_definition(data_dir, "newbot")
+    defs = load_agent_definitions(data_dir, {})
+    assert "newbot" not in defs

--- a/tests/test_launcher_api.py
+++ b/tests/test_launcher_api.py
@@ -1,5 +1,6 @@
 """Integration tests for the Agent Launcher REST API endpoints."""
 
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -17,6 +18,30 @@ _tmpdir: str = ""
 client: TestClient
 
 COOKIES = {"session": "test-token"}
+
+
+class CaptureProcessManager:
+    def __init__(self):
+        self.launch_calls = []
+
+    def launch(self, **kwargs):
+        self.launch_calls.append(kwargs)
+        return {"ok": True, "name": kwargs["base"], "pid": 4242}
+
+    def list_managed(self):
+        return []
+
+    def get_restore_state(self):
+        return []
+
+    def clear_restore_state(self):
+        return None
+
+    def stop(self, name: str):
+        return {"ok": True, "name": name}
+
+    def get_logs(self, name: str):
+        return []
 
 
 def setup_module():
@@ -110,3 +135,64 @@ def test_list_managed_empty():
     resp = client.get("/api/agents/managed", cookies=COOKIES)
     assert resp.status_code == 200
     assert resp.json() == {"data": []}
+
+
+def test_launch_endpoint_keeps_agent_flags_after_wrapper_and_tokenizes_extra_args():
+    original_pm = app_module.process_manager
+    capture_pm = CaptureProcessManager()
+    app_module.process_manager = capture_pm
+
+    try:
+        resp = client.post(
+            "/api/agents/testbot/launch",
+            json={
+                "cwd": ".",
+                "flags": ["--dangerously-skip-permissions"],
+                "extra_args": '--model "claude sonnet" --json',
+                "instance_label": "review-bot",
+            },
+            cookies=COOKIES,
+        )
+    finally:
+        app_module.process_manager = original_pm
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert len(capture_pm.launch_calls) == 1
+
+    call = capture_pm.launch_calls[0]
+    wrapper_path = str(ROOT / "wrapper.py")
+    assert call["command"] == sys.executable
+    assert call["flags"] == []
+    assert call["extra_args"] == [
+        wrapper_path,
+        "testbot",
+        "--no-restart",
+        "--label",
+        "review-bot",
+        "--",
+        "--dangerously-skip-permissions",
+        "--model",
+        "claude sonnet",
+        "--json",
+    ]
+
+
+def test_websocket_continue_resumes_requested_channel():
+    app_module.router._get_ch("planning")["paused"] = True
+    app_module.router._get_ch("planning")["hop_count"] = 99
+
+    with client.websocket_connect("/ws", cookies=COOKIES) as ws:
+        ws.send_text(
+            json.dumps(
+                {
+                    "type": "message",
+                    "sender": "user",
+                    "text": "/continue",
+                    "channel": "planning",
+                }
+            )
+        )
+
+    assert app_module.router.is_paused("planning") is False
+    assert app_module.router._get_ch("planning")["hop_count"] == 0

--- a/tests/test_launcher_api.py
+++ b/tests/test_launcher_api.py
@@ -194,6 +194,7 @@ def test_launch_endpoint_keeps_agent_flags_after_wrapper_and_tokenizes_extra_arg
     assert call["command"] == sys.executable
     assert call["flags"] == []
     assert call["extra_args"] == [
+        "-u",
         wrapper_path,
         "testbot",
         "--no-restart",

--- a/tests/test_launcher_api.py
+++ b/tests/test_launcher_api.py
@@ -13,6 +13,7 @@ from app import app, configure
 import app as app_module
 from process_manager import ProcessManager
 from starlette.testclient import TestClient
+from wrapper import _normalize_passthrough_args
 
 _tmpdir: str = ""
 client: TestClient
@@ -130,6 +131,34 @@ def test_add_and_delete_definition():
     assert "mybot" not in defs
 
 
+def test_custom_definition_updates_runtime_registry():
+    new_agent = {
+        "name": "regbot",
+        "command": "python",
+        "label": "RegBot",
+        "color": "#00ff00",
+    }
+
+    resp = client.post("/api/agent-definitions", json=new_agent, cookies=COOKIES)
+    assert resp.status_code == 200
+    runtime_cfg = app_module.registry.get_base_config("regbot")
+    assert runtime_cfg is not None
+    assert runtime_cfg["command"] == "python"
+
+    app_module.registry.register("regbot")
+
+    delete_resp = client.delete("/api/agent-definitions/regbot", cookies=COOKIES)
+    assert delete_resp.status_code == 409
+    assert delete_resp.json()["error"] == "cannot delete running agent definition: regbot"
+
+    app_module.registry.deregister("regbot")
+
+    delete_resp = client.delete("/api/agent-definitions/regbot", cookies=COOKIES)
+    assert delete_resp.status_code == 200
+
+    assert app_module.registry.get_base_config("regbot") is None
+
+
 def test_list_managed_empty():
     """GET /api/agents/managed returns empty list when no agents are launched."""
     resp = client.get("/api/agents/managed", cookies=COOKIES)
@@ -196,3 +225,16 @@ def test_websocket_continue_resumes_requested_channel():
 
     assert app_module.router.is_paused("planning") is False
     assert app_module.router._get_ch("planning")["hop_count"] == 0
+
+
+def test_wrapper_passthrough_args_strip_argparse_separator():
+    assert _normalize_passthrough_args(["--", "-u", "-c", "print('ok')"]) == [
+        "-u",
+        "-c",
+        "print('ok')",
+    ]
+    assert _normalize_passthrough_args(["--model", "claude sonnet", "--json"]) == [
+        "--model",
+        "claude sonnet",
+        "--json",
+    ]

--- a/tests/test_launcher_api.py
+++ b/tests/test_launcher_api.py
@@ -1,0 +1,112 @@
+"""Integration tests for the Agent Launcher REST API endpoints."""
+
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from config_loader import load_config
+from app import app, configure
+import app as app_module
+from process_manager import ProcessManager
+from starlette.testclient import TestClient
+
+_tmpdir: str = ""
+client: TestClient
+
+COOKIES = {"session": "test-token"}
+
+
+def setup_module():
+    """Create a temp config dir, load config, configure the app, and wire ProcessManager."""
+    global _tmpdir, client
+
+    _tmpdir = tempfile.mkdtemp()
+    tmp = Path(_tmpdir)
+
+    # Write minimal config.toml
+    (tmp / "config.toml").write_text(
+        '[server]\nport = 8399\ndata_dir = "./data"\n\n'
+        '[agents.testbot]\ncommand = "echo"\ncolor = "#888"\nlabel = "TestBot"\n',
+        encoding="utf-8",
+    )
+
+    # Ensure data dir exists
+    (tmp / "data").mkdir(exist_ok=True)
+
+    cfg = load_config(root=tmp)
+    configure(cfg, session_token="test-token")
+
+    # Wire up a real ProcessManager so /api/agents/managed works
+    app_module.process_manager = ProcessManager(
+        data_dir=tmp / "data",
+        server_port=8399,
+    )
+
+    client = TestClient(app)
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+def test_list_definitions():
+    """GET /api/agent-definitions returns definitions dict and flag_presets dict."""
+    resp = client.get("/api/agent-definitions", cookies=COOKIES)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert "definitions" in body
+    assert "flag_presets" in body
+    assert isinstance(body["definitions"], dict)
+    assert isinstance(body["flag_presets"], dict)
+
+    # The testbot from config.toml must appear
+    assert "testbot" in body["definitions"]
+    assert body["definitions"]["testbot"]["command"] == "echo"
+    assert body["definitions"]["testbot"]["label"] == "TestBot"
+
+
+def test_add_and_delete_definition():
+    """POST a new definition, verify it shows up in GET, then DELETE it."""
+    new_agent = {
+        "name": "mybot",
+        "command": "python",
+        "label": "MyBot",
+        "color": "#ff0000",
+    }
+
+    # Add
+    resp = client.post("/api/agent-definitions", json=new_agent, cookies=COOKIES)
+    assert resp.status_code == 200
+    assert resp.json().get("ok") is True
+
+    # Verify it appears in GET
+    resp = client.get("/api/agent-definitions", cookies=COOKIES)
+    assert resp.status_code == 200
+    defs = resp.json()["definitions"]
+    assert "mybot" in defs
+    assert defs["mybot"]["command"] == "python"
+    assert defs["mybot"]["label"] == "MyBot"
+    assert defs["mybot"]["color"] == "#ff0000"
+
+    # Delete
+    resp = client.delete("/api/agent-definitions/mybot", cookies=COOKIES)
+    assert resp.status_code == 200
+    assert resp.json().get("ok") is True
+
+    # Verify it is gone
+    resp = client.get("/api/agent-definitions", cookies=COOKIES)
+    assert resp.status_code == 200
+    defs = resp.json()["definitions"]
+    assert "mybot" not in defs
+
+
+def test_list_managed_empty():
+    """GET /api/agents/managed returns empty list when no agents are launched."""
+    resp = client.get("/api/agents/managed", cookies=COOKIES)
+    assert resp.status_code == 200
+    assert resp.json() == {"data": []}

--- a/tests/test_launcher_api.py
+++ b/tests/test_launcher_api.py
@@ -3,6 +3,7 @@
 import json
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -87,13 +88,16 @@ def test_list_definitions():
     body = resp.json()
     assert "definitions" in body
     assert "flag_presets" in body
+    assert "builtin_names" in body
     assert isinstance(body["definitions"], dict)
     assert isinstance(body["flag_presets"], dict)
+    assert isinstance(body["builtin_names"], list)
 
     # The testbot from config.toml must appear
     assert "testbot" in body["definitions"]
     assert body["definitions"]["testbot"]["command"] == "echo"
     assert body["definitions"]["testbot"]["label"] == "TestBot"
+    assert "testbot" in body["builtin_names"]
 
 
 def test_add_and_delete_definition():
@@ -113,11 +117,13 @@ def test_add_and_delete_definition():
     # Verify it appears in GET
     resp = client.get("/api/agent-definitions", cookies=COOKIES)
     assert resp.status_code == 200
-    defs = resp.json()["definitions"]
+    body = resp.json()
+    defs = body["definitions"]
     assert "mybot" in defs
     assert defs["mybot"]["command"] == "python"
     assert defs["mybot"]["label"] == "MyBot"
     assert defs["mybot"]["color"] == "#ff0000"
+    assert "mybot" not in body["builtin_names"]
 
     # Delete
     resp = client.delete("/api/agent-definitions/mybot", cookies=COOKIES)
@@ -157,6 +163,36 @@ def test_custom_definition_updates_runtime_registry():
     assert delete_resp.status_code == 200
 
     assert app_module.registry.get_base_config("regbot") is None
+
+
+def test_stop_endpoint_deregisters_runtime_instance_for_followup_delete():
+    new_agent = {
+        "name": "stopbot",
+        "command": "python",
+        "label": "StopBot",
+        "color": "#ffaa00",
+    }
+
+    resp = client.post("/api/agent-definitions", json=new_agent, cookies=COOKIES)
+    assert resp.status_code == 200
+
+    app_module.registry.register("stopbot")
+
+    original_pm = app_module.process_manager
+    capture_pm = CaptureProcessManager()
+    app_module.process_manager = capture_pm
+
+    try:
+        stop_resp = client.post("/api/agents/stopbot/stop", cookies=COOKIES)
+    finally:
+        app_module.process_manager = original_pm
+
+    assert stop_resp.status_code == 200
+    assert stop_resp.json()["ok"] is True
+
+    delete_resp = client.delete("/api/agent-definitions/stopbot", cookies=COOKIES)
+    assert delete_resp.status_code == 200
+    assert app_module.registry.get_base_config("stopbot") is None
 
 
 def test_list_managed_empty():
@@ -223,6 +259,9 @@ def test_websocket_continue_resumes_requested_channel():
                 }
             )
         )
+        deadline = time.time() + 1.0
+        while time.time() < deadline and app_module.router.is_paused("planning"):
+            time.sleep(0.05)
 
     assert app_module.router.is_paused("planning") is False
     assert app_module.router._get_ch("planning")["hop_count"] == 0

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -51,3 +51,83 @@ def test_launch_duplicate_base_gets_suffix():
     pm.shutdown()
     import shutil
     shutil.rmtree("./test_data", ignore_errors=True)
+
+
+def test_managed_and_restore_state_include_base_metadata():
+    """Managed agents and restore state preserve the originating base name."""
+    pm = ProcessManager(data_dir=Path("./test_data"), server_port=8300)
+    pm.launch(
+        base="bot",
+        command=sys.executable,
+        flags=[],
+        extra_args=["-c", "import time; time.sleep(2)"],
+        cwd=".",
+    )
+    pm.launch(
+        base="bot",
+        command=sys.executable,
+        flags=[],
+        extra_args=["-c", "import time; time.sleep(2)"],
+        cwd=".",
+        instance_label="review-bot",
+    )
+
+    managed = sorted(pm.list_managed(), key=lambda item: item["name"])
+    assert managed[0]["base"] == "bot"
+    assert managed[1]["base"] == "bot"
+    assert managed[0]["started_at"] > 0
+    assert managed[1]["started_at"] > 0
+
+    restore = sorted(pm.get_restore_state(), key=lambda item: item["name"])
+    assert restore[0]["base"] == "bot"
+    assert restore[1]["base"] == "bot"
+    assert restore[0]["started_at"] > 0
+    assert restore[1]["started_at"] > 0
+
+    pm.stop("bot")
+    pm.stop("review-bot")
+    pm.shutdown()
+    import shutil
+    shutil.rmtree("./test_data", ignore_errors=True)
+
+
+def test_restore_state_keeps_relaunchable_user_args_from_wrapper_invocation():
+    """Restore state should keep the user-facing args, not the raw wrapper invocation."""
+    pm = ProcessManager(data_dir=Path("./test_data"), server_port=8300)
+    wrapper_path = str(ROOT / "wrapper.py")
+    pm.launch(
+        base="bot",
+        command=sys.executable,
+        flags=[],
+        extra_args=[
+            wrapper_path,
+            "bot",
+            "--no-restart",
+            "--label",
+            "review-bot",
+            "--",
+            "--dangerously-skip-permissions",
+            "--model",
+            "claude sonnet",
+            "--json",
+        ],
+        cwd=".",
+        instance_label="review-bot",
+    )
+
+    restore = pm.get_restore_state()
+    assert len(restore) == 1
+    assert restore[0]["base"] == "bot"
+    assert restore[0]["instance_label"] == "review-bot"
+    assert restore[0]["flags"] == []
+    assert restore[0]["extra_args"] == [
+        "--dangerously-skip-permissions",
+        "--model",
+        "claude sonnet",
+        "--json",
+    ]
+
+    pm.stop("review-bot")
+    pm.shutdown()
+    import shutil
+    shutil.rmtree("./test_data", ignore_errors=True)

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -1,0 +1,53 @@
+import time
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from process_manager import ProcessManager
+
+
+def test_launch_tracks_state():
+    """Launching an agent creates a tracked entry with correct state."""
+    pm = ProcessManager(data_dir=Path("./test_data"), server_port=8300)
+    result = pm.launch(
+        base="testbot",
+        command=sys.executable,
+        flags=[],
+        extra_args=["-c", "import time; time.sleep(0.5); print('hello')"],
+        cwd=".",
+    )
+    assert result["ok"] is True
+    assert result["name"] == "testbot"
+    assert result["pid"] > 0
+
+    managed = pm.list_managed()
+    assert len(managed) == 1
+    assert managed[0]["name"] == "testbot"
+    assert managed[0]["state"] in ("starting", "running")
+
+    time.sleep(1.5)
+    managed = pm.list_managed()
+    assert managed[0]["state"] in ("crashed", "stopped")
+
+    pm.shutdown()
+    import shutil
+    shutil.rmtree("./test_data", ignore_errors=True)
+
+
+def test_launch_duplicate_base_gets_suffix():
+    """Launching the same base twice assigns different names."""
+    pm = ProcessManager(data_dir=Path("./test_data"), server_port=8300)
+    r1 = pm.launch(base="bot", command=sys.executable,
+                   flags=[], extra_args=["-c", "import time; time.sleep(2)"], cwd=".")
+    r2 = pm.launch(base="bot", command=sys.executable,
+                   flags=[], extra_args=["-c", "import time; time.sleep(2)"], cwd=".")
+    assert r1["name"] == "bot"
+    assert r2["name"] == "bot-2"
+    assert len(pm.list_managed()) == 2
+    pm.stop("bot")
+    pm.stop("bot-2")
+    pm.shutdown()
+    import shutil
+    shutil.rmtree("./test_data", ignore_errors=True)

--- a/wrapper.py
+++ b/wrapper.py
@@ -350,6 +350,13 @@ def _build_provider_launch(
     return launch_args, launch_env, inject_env, settings_path
 
 
+def _normalize_passthrough_args(extra: list[str]) -> list[str]:
+    """Strip the argparse ``--`` separator before forwarding child args."""
+    if extra and extra[0] == "--":
+        return extra[1:]
+    return list(extra)
+
+
 def _register_instance(server_port: int, base: str, label: str | None = None) -> dict:
     import urllib.request
 
@@ -555,6 +562,7 @@ def main():
     parser.add_argument("--no-restart", action="store_true", help="Do not restart on exit")
     parser.add_argument("--label", type=str, default=None, help="Custom display label")
     args, extra = parser.parse_known_args()
+    extra = _normalize_passthrough_args(extra)
 
     agent = args.agent
     agent_cfg = config.get("agents", {}).get(agent, {})


### PR DESCRIPTION
## Summary
- add Electron browser commands that agents can use to open URLs either docked in-app or in a pop-out window
- add browser-pane, browser-window, tray, notification, and desktop-command tests plus updated launcher smoke coverage
- record the current desktop QA, release-readiness, and launcher follow-up status in repo docs

## Verification
- npm --prefix electron test
- .venv\Scripts\python -m pytest tests -q
- node --check static/launcher.js
- node --check electron/main.js
- node --check electron/renderer/renderer.js
- npm --prefix electron run smoke:launcher
- npm --prefix electron run smoke:desktop