### PR TITLE
feat: mobile/narrow-viewport layout via @media (max-width: 700px)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -4473,3 +4473,78 @@ footer {
     50% { box-shadow: 0 0 8px 2px var(--accent); }
 }
 .help-pulse { animation: helpPulse 1s ease 3; }
+
+/* --- Mobile layout (phone / narrow viewport) --- */
+@media (max-width: 700px) {
+    header {
+        padding: 10px 12px;
+        gap: 8px;
+    }
+
+    .header-left {
+        gap: 8px;
+    }
+
+    header h1 {
+        font-size: 15px;
+    }
+
+    .discord-pill,
+    .subtitle,
+    .sender-label,
+    .input-hint {
+        display: none;
+    }
+
+    #agent-status {
+        gap: 8px;
+        max-width: 42vw;
+    }
+
+    .status-pill {
+        padding: 4px 8px;
+        font-size: 11px;
+    }
+
+    .settings-btn {
+        padding: 5px 6px;
+    }
+
+    main#timeline {
+        padding: 12px 8px;
+    }
+
+    .message {
+        padding-left: 4px;
+        padding-right: 4px;
+        gap: 6px;
+    }
+
+    .chat-bubble {
+        max-width: calc(100vw - 76px);
+        padding: 8px 12px;
+    }
+
+    footer {
+        padding: 10px 12px;
+    }
+
+    #input-row {
+        gap: 6px;
+    }
+
+    #input {
+        padding-left: 12px;
+        padding-right: 12px;
+    }
+
+    #mic {
+        padding-left: 8px;
+        padding-right: 8px;
+    }
+
+    #send {
+        padding-left: 14px;
+        padding-right: 14px;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a single `@media (max-width: 700px)` block at the end of `static/style.css` so phones and narrow tabs get a usable layout without introducing a JS breakpoint framework. No behavior change above 700px.

## Motivation

The desktop layout is great but falls apart on a phone: decorative labels push the input off-screen, agent-status can cover the settings button when there are a lot of agents, and chat bubbles run edge-to-edge with no breathing room. I've been using this block against a Tailscale-exposed instance from my phone and it's the minimum that makes the app feel right on mobile.

## What changed

`static/style.css` — one new `@media (max-width: 700px)` block, 75 lines, appended at the end. Adjustments:

- Tighter header/footer padding, h1 → 15px
- Hide decorative labels (`.discord-pill`, `.subtitle`, `.sender-label`, `.input-hint`) that waste horizontal space
- `#agent-status` capped at `42vw` so a long agent list can't push the settings button off-screen
- `.status-pill` / `.settings-btn` shrunk a notch
- `main#timeline` / `.message` padding reduced for more bubble width
- `.chat-bubble` constrained to `100vw - 76px` (leaves room for avatar + gutter)
- Input row: `gap: 6px`, smaller mic/send horizontal padding

## Test plan

- [x] Selectors verified against the current tree (`static/index.html` + `static/chat.js` + `static/style.css`) — all targets exist
- [x] Live-tested against a running instance exposed via Tailscale, accessed from an Android phone over several weeks
- [x] No change to layout at >700px (all rules scoped inside the media query)
- [ ] Maintainer: quick desktop smoke-test to confirm nothing regressed above 700px would be appreciated