### PR TITLE
[codex] Implement project runner and operations UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ build/
 .idea/
 .gemini/
 .claude/
-tests/
 agents_lineup.svg
 docs/
 goals.py

--- a/DEV-JOURNAL.md
+++ b/DEV-JOURNAL.md
@@ -1,0 +1,119 @@
+# DEV-JOURNAL
+
+**Append-only. New entries go at the END of this file.**
+
+This journal records project sessions, decisions, implementation milestones,
+commits, open questions, and recommended next steps.
+
+## Entry Template
+
+```markdown
+---
+
+## YYYY-MM-DD HH:MM TZ - Session Title
+
+**Branch:** `branch-name`
+**Base Commit:** `short-sha`
+**Commits:** none
+
+### Summary
+
+### Decisions
+
+### Changes
+
+### Verification
+
+### Open Questions
+
+### Next Steps
+```
+
+---
+
+## 2026-05-04 16:33 EDT - Team Runner And Multi-Project Workflow
+
+**Branch:** `main`
+**Base Commit:** `0440f5d`
+**Commits:** none
+
+### Summary
+
+Set up this fork for project-specific experimentation and built the first pass
+of a repeatable team runner workflow. The main outcome is a repo-local `./ac`
+script that can start, inspect, attach to, and stop project-specific
+agentchattr teams from TOML files.
+
+### Decisions
+
+- Keep normal pushes pointed at `the-sarge/agentchattr`; disable accidental
+  pushes to upstream by setting `upstream` push URL to `DISABLED`.
+- Use `./ac` as the near-term runner instead of Task or an installed CLI.
+- Keep orchestration in Python for now; consider a Go runner only after the
+  command shape stabilizes.
+- Keep the default runtime host/tmux based for now.
+- Treat Docker as a later optional mode, likely one container per project with
+  server and wrappers together plus mounted persistent data.
+- Use predictable tmux names:
+  - `{tmux_prefix}-server`
+  - `{tmux_prefix}-<agent>`
+  - `{tmux_prefix}-wrap-<agent>`
+- Use project/team TOML files as the source of truth for agent rosters.
+- Add a project-local `DEV-JOURNAL.md` for timestamped session handoffs.
+
+### Changes
+
+- Changed loop guard limits from `50` to `100` in the settings UI and backend
+  validation.
+- Changed default `routing.max_agent_hops` in `config.toml` to `100`.
+- Added project config overlay support through `AGENTCHATTR_PROJECT_CONFIG`.
+- Added provider aliases so custom handles can use built-in provider behavior,
+  for example `provider = "claude"` with `[agents.architect]`.
+- Added config-seeded roles so team TOML `role = "Planner"` is reflected in
+  runtime role state.
+- Added detached/namespaced tmux support to wrapper startup.
+- Added executable `./ac` with:
+  - `up`
+  - `status`
+  - `attach`
+  - `down`
+- Added example team file at `teams/project-a.toml.example`.
+- Added `TEAM_RUNNER_GUIDE.md` as the operator reference.
+- Added `PROJECT_PLAN.md` with phases, risks, testing strategy, and a
+  parallel subagent handoff plan.
+- Updated README references for the project team workflow, guide, and roadmap.
+
+### Verification
+
+- Ran syntax checks for touched Python files, including `ac`.
+- Ran dependency-light unit tests locally; latest relevant run passed `29`
+  tests.
+- Ran full tests inside Docker after installing dependencies; Docker run passed
+  `46` tests.
+- Ran Docker smoke test with fake `claude`, `codex`, and `gemini` commands for
+  one project.
+- Ran Docker smoke test with two simultaneous projects on separate ports,
+  overlapping agent handles, separate roles/colors/labels, and independent
+  shutdown.
+
+### Open Questions
+
+- Whether to add `restart`, `logs`, `list`, and `up --dry-run` to `./ac` next.
+- What exact backend API shape the Agent Operations UI should consume.
+- Whether team TOML validation should live entirely in `config_loader.py` or in
+  a dedicated helper module.
+- Whether Docker mode should be implemented as `./ac <project> up --docker`
+  after the host/tmux workflow stabilizes.
+- Whether the runner should eventually become an installed CLI or remain a
+  repo-local script.
+
+### Next Steps
+
+1. Add `./ac <project> restart <agent>` and `./ac <project> logs <target>`.
+2. Add team TOML validation and `./ac <project> up --dry-run`.
+3. Add an Agent Operations panel in the frontend with attach commands and
+   configured-vs-running warnings.
+4. Add project awareness to the UI header so simultaneous project tabs are easy
+   to distinguish.
+5. Use the `PROJECT_PLAN.md` parallel subagent handoff section to split work
+   across workers in the next session.

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,0 +1,493 @@
+# agentchattr Project Plan
+
+This plan covers the project/team runner workflow, multi-project operations,
+frontend improvements, and follow-on hardening work.
+
+## Goals
+
+- Make repeatable project-specific agent rosters easy to define and launch.
+- Support multiple agentchattr projects running at the same time.
+- Make agent operations visible enough that hung agents are easy to identify
+  and recover.
+- Keep the existing FastAPI/MCP/static-frontend architecture intact while the
+  workflow is still evolving.
+
+## Non-Goals
+
+- Rewriting the core server in another language.
+- Replacing the browser UI with a frontend framework.
+- Making Docker the default runtime before the host/tmux workflow stabilizes.
+- Solving every agent CLI authentication model in containers.
+
+## Current Baseline
+
+Implemented:
+
+- `./ac <project> up/status/attach/down`
+- team TOML config overlays via `AGENTCHATTR_PROJECT_CONFIG`
+- project-specific tmux prefixes via `AGENTCHATTR_TMUX_PREFIX`
+- provider aliases such as `provider = "claude"` for custom handles
+- config-seeded roles
+- detached wrapper startup for multi-agent launches
+- loop guard max/default increased to `100`
+- example team file at `teams/project-a.toml.example`
+- operating guide at `TEAM_RUNNER_GUIDE.md`
+
+Validated:
+
+- single-project Docker smoke test with fake agents
+- two simultaneous Docker project smoke test on separate ports
+- project isolation for roles, labels, colors, tmux sessions, and shutdown
+
+## Phase 1: Stabilize Team Runner
+
+Objective: make `./ac` reliable enough for daily use.
+
+Deliverables:
+
+- Add `./ac <project> restart <agent>` for a one-agent reset.
+- Add `./ac <project> logs <target>` for server/wrapper/agent pane capture.
+- Add `./ac <project> list` or top-level `./ac list` to show known team files.
+- Improve `up` preflight checks:
+  - duplicate ports across team files
+  - missing commands on `PATH`
+  - duplicate agent names in a team file
+  - missing or reused `tmux_prefix`
+- Add clearer failure messages when server startup fails.
+- Add a dry-run mode:
+  ```bash
+  ./ac project-a up --dry-run
+  ```
+
+Acceptance criteria:
+
+- A stopped agent can be restarted without stopping the project.
+- `status` clearly identifies server, wrapper, and live agent sessions.
+- `up --dry-run` shows exact tmux sessions, ports, commands, and data paths.
+- Project A can be stopped or restarted without affecting Project B.
+
+## Phase 2: Team Config Polish
+
+Objective: make team TOML files expressive but predictable.
+
+Deliverables:
+
+- Define and document a stable team TOML schema.
+- Add schema validation with actionable errors.
+- Add support for shared defaults:
+  ```toml
+  [agent_defaults.claude]
+  cwd = ".."
+  color = "#da7756"
+  ```
+- Add per-agent pass-through args:
+  ```toml
+  args = ["--dangerously-skip-permissions"]
+  ```
+- Add optional project title seeding so browser tabs are distinguishable.
+- Add team file examples:
+  - small two-agent project
+  - larger Claude/Codex/Gemini team
+  - API-agent project
+
+Acceptance criteria:
+
+- Invalid team files fail before starting any tmux sessions.
+- Repeated provider config is minimized.
+- Examples can be copied and started with only port/path changes.
+
+## Phase 3: Agent Operations UI
+
+Objective: surface the operational state that currently requires tmux/manual
+inspection.
+
+Deliverables:
+
+- Add an Agent Operations panel in the UI.
+- Show for each configured agent:
+  - handle
+  - label
+  - provider
+  - role
+  - color
+  - online/offline/busy state
+  - last heartbeat age
+  - tmux session name
+  - attach command
+- Show configured-vs-running mismatches:
+  - configured but not registered
+  - registered but not in team file
+  - wrapper active but no live agent heartbeat
+- Add copy buttons for attach commands.
+- Add status badges for server, MCP HTTP, MCP SSE, and loop guard.
+
+Acceptance criteria:
+
+- From the browser, a user can identify the correct tmux session for a hung
+  agent without reading docs.
+- The UI distinguishes live agent sessions from wrapper supervisor sessions.
+- Missing agents are visible as warnings, not silent absence.
+
+## Phase 4: Project Awareness In The UI
+
+Objective: make simultaneous browser tabs for Project A/B/C hard to confuse.
+
+Deliverables:
+
+- Show project name in the header.
+- Show port and data directory in a Project settings view.
+- Show team file path when launched with `AGENTCHATTR_PROJECT_CONFIG`.
+- Add project accent color or short project badge.
+- Add browser document title format:
+  ```text
+  project-a - agentchattr
+  ```
+
+Acceptance criteria:
+
+- Multiple browser tabs are visually distinguishable.
+- A user can confirm which project/server they are looking at from the UI.
+
+## Phase 5: Frontend Maintainability
+
+Objective: reduce risk when adding UI features.
+
+Deliverables:
+
+- Continue extracting large `static/chat.js` sections into modules:
+  - settings
+  - schedules
+  - pins/todos
+  - attachments/images
+  - message rendering
+  - help tour
+- Keep `Hub` and `Store` as transition helpers until the module boundary is
+  cleaner.
+- Avoid adding new major features directly to `chat.js`.
+
+Acceptance criteria:
+
+- New Agent Operations UI lives outside `chat.js`.
+- Existing behavior is preserved after each extraction.
+- Frontend modules have clear ownership boundaries.
+
+## Phase 6: Search And Navigation
+
+Objective: make long-running project chats easier to operate.
+
+Deliverables:
+
+- Add message search.
+- Add filters:
+  - sender
+  - channel
+  - pinned/todo/done
+  - jobs/session messages
+- Add a command palette:
+  - switch channel
+  - open jobs
+  - open rules
+  - open Agent Operations
+  - copy attach command
+  - continue loop guard
+
+Acceptance criteria:
+
+- Users can find an old decision or agent output without scrolling.
+- Common operations are accessible from keyboard-driven navigation.
+
+## Phase 7: Docker Option
+
+Objective: evaluate containerized project instances after the host workflow is
+stable.
+
+Recommended model:
+
+- one container per project
+- server and wrappers in the same container
+- persistent mounts for:
+  - project source repo
+  - `data_dir`
+  - `upload_dir`
+  - agent credentials, where needed
+
+Deliverables:
+
+- Add optional Dockerfile.
+- Add `./ac <project> up --docker` prototype.
+- Add documented volume layout.
+- Add fake-agent Docker CI smoke test for:
+  - single project
+  - multiple projects
+  - shutdown cleanup
+
+Acceptance criteria:
+
+- Container removal does not delete project data when volumes are mounted.
+- Docker mode does not become required for normal host/tmux usage.
+- Credentials and project source mounts are explicit.
+
+## Phase 8: Packaging Later
+
+Objective: make installation cleaner after command shape stabilizes.
+
+Options:
+
+- keep `./ac` as the repo-local script
+- add a Taskfile as a thin wrapper around `./ac`
+- later add a Python console entry point or Go binary
+
+Recommendation:
+
+- Keep `./ac` for now.
+- Reconsider packaging once the command set has settled.
+- Consider a Go rewrite only for the runner if the Python script becomes a
+  stable, widely used CLI.
+
+## Testing Strategy
+
+Unit tests:
+
+- config overlay behavior
+- provider alias defaults
+- team schema validation
+- command planning/dry-run output
+
+Smoke tests:
+
+- fake agents in Docker
+- one project up/down
+- two projects simultaneously
+- project A down while project B remains running
+- seeded roles visible through API
+- status output contains expected tmux sessions
+
+Manual tests:
+
+- real Claude/Codex/Gemini launch
+- attach/detach behavior
+- hung-agent recovery
+- browser UI operations panel
+
+## Risks
+
+- Agent CLIs have different auth and MCP configuration expectations.
+- tmux session cleanup can be too broad if prefixes are poorly chosen.
+- UI settings stored under `data_dir` can override team-file defaults.
+- Running many agents can make port/session/name collisions more likely.
+- Dockerizing real agent CLIs may require significant credential and toolchain
+  setup.
+
+## Near-Term Recommended Sequence
+
+1. Add `restart` and `logs` to `./ac`.
+2. Add team TOML validation and `up --dry-run`.
+3. Add Agent Operations UI with attach commands.
+4. Add project name/team file awareness to the UI.
+5. Extract settings/schedules from `chat.js` before adding larger UI features.
+6. Revisit Docker once the host-based team runner feels stable.
+
+## Parallel Subagent Handoff
+
+Use this section after restarting context. The tasks below are intentionally
+split by ownership boundary so several subagents can work at the same time
+with minimal file conflicts.
+
+### Coordination Rules
+
+- Keep each subagent on a disjoint write set.
+- Tell worker subagents they are not alone in the codebase and must not revert
+  edits made by others.
+- Avoid multiple workers editing `ac` at the same time.
+- Avoid editing `static/chat.js` unless the task explicitly requires a tiny
+  integration hook.
+- Prefer new focused modules for frontend work.
+- Main thread should own final integration and conflict resolution.
+
+### Parallel Batch 1
+
+Recommended first batch after context restart:
+
+1. Runner commands worker
+2. Team TOML validation worker
+3. Agent Operations UI explorer/worker
+4. Docs/examples worker
+
+The main thread should define/confirm any API contract needed by the UI while
+the workers handle their bounded slices.
+
+### Worker A: Runner Commands
+
+Ownership:
+
+- `ac`
+- new or existing runner-focused tests
+- small README/guide updates only for commands this worker adds
+
+Task:
+
+- Add `./ac <project> restart <agent>`.
+- Add `./ac <project> logs <target>`.
+- Add `./ac <project> list` or top-level listing if practical.
+- Add `./ac <project> up --dry-run`.
+- Keep session naming consistent:
+  - `{tmux_prefix}-server`
+  - `{tmux_prefix}-<agent>`
+  - `{tmux_prefix}-wrap-<agent>`
+
+Acceptance criteria:
+
+- Restart one agent without stopping the whole project.
+- Logs command can capture server, wrapper, or live agent panes.
+- Dry run prints planned ports, data paths, team file, server session, wrapper
+  sessions, live agent sessions, and commands without starting tmux sessions.
+- Existing `up/status/attach/down` behavior remains intact.
+
+Suggested subagent prompt:
+
+```text
+You are Worker A for agentchattr. Implement runner command enhancements in `ac`.
+You are not alone in the codebase; do not revert edits made by others. Own only
+`ac` plus runner-specific tests/docs needed for your commands. Add
+`restart <agent>`, `logs <target>`, `list` if practical, and `up --dry-run`.
+Preserve the tmux naming convention and existing behavior. Run syntax checks
+and relevant tests. In your final response, list files changed and verification.
+```
+
+### Worker B: Team TOML Validation
+
+Ownership:
+
+- `config_loader.py`
+- validation helper module if needed
+- config/team tests
+- team example files only if validation requires a schema adjustment
+
+Task:
+
+- Define validation for team/project config overlays.
+- Validate before startup where possible.
+- Catch:
+  - no agents
+  - duplicate or missing ports
+  - missing `tmux_prefix`
+  - invalid agent names
+  - missing provider/command
+  - unknown providers
+  - invalid color strings
+  - role strings over the UI-supported length
+- Produce actionable error messages.
+
+Acceptance criteria:
+
+- Invalid team files fail before starting tmux sessions.
+- Valid existing examples still load.
+- Tests cover valid config, missing agents, bad ports, bad provider, bad color,
+  and provider alias command inference.
+
+Suggested subagent prompt:
+
+```text
+You are Worker B for agentchattr. Implement team TOML validation. You are not
+alone in the codebase; do not revert edits made by others. Own
+`config_loader.py`, optional validation helpers, and config tests. Invalid team
+configs should fail with actionable errors before orchestration starts where
+possible. Preserve existing config.toml/config.local.toml behavior. Run relevant
+tests. In your final response, list files changed and verification.
+```
+
+### Worker C: Agent Operations UI
+
+Ownership:
+
+- new `static/agent-ops.js`
+- optional new `static/agent-ops.css`
+- minimal `static/index.html` hook
+- avoid large edits to `static/chat.js`
+
+Task:
+
+- Add an Agent Operations panel.
+- Show each configured/running agent with:
+  - handle
+  - label
+  - provider if available
+  - role
+  - color
+  - online/offline/busy state
+  - tmux session name or attach command if available
+- Add copy buttons for attach commands.
+- Show warnings for configured but not running and running but not configured
+  if the backend data is available.
+
+Acceptance criteria:
+
+- UI can be opened from the header.
+- Agent rows render from current available status data.
+- Attach commands follow `./ac <project> attach <agent>`.
+- No major feature code is added to `static/chat.js`.
+
+Suggested subagent prompt:
+
+```text
+You are Worker C for agentchattr. Add an Agent Operations frontend panel. You
+are not alone in the codebase; do not revert edits made by others. Own new
+`static/agent-ops.js`, optional CSS, and minimal `static/index.html` integration.
+Avoid large edits to `static/chat.js`. Use current status/role/agent data where
+available, and structure the module so richer backend project metadata can be
+added later. In your final response, list files changed and verification.
+```
+
+### Worker D: Docs And Examples
+
+Ownership:
+
+- `TEAM_RUNNER_GUIDE.md`
+- `PROJECT_PLAN.md`
+- `README.md`
+- `teams/*.toml.example`
+
+Task:
+
+- Add more team examples:
+  - small two-agent project
+  - large Claude/Codex/Gemini roster
+  - API-agent project
+- Tighten troubleshooting docs.
+- Add command examples for any new runner commands implemented by Worker A.
+- Keep docs aligned with actual command behavior.
+
+Acceptance criteria:
+
+- A new user can copy an example team file and understand which ports/paths to
+  change.
+- Docs clearly distinguish live agent sessions from wrapper sessions.
+- Docs do not describe unimplemented commands unless marked as planned.
+
+Suggested subagent prompt:
+
+```text
+You are Worker D for agentchattr. Improve docs and examples for the team runner.
+You are not alone in the codebase; do not revert edits made by others. Own
+`TEAM_RUNNER_GUIDE.md`, `PROJECT_PLAN.md`, `README.md`, and `teams/*.toml.example`.
+Add practical examples and troubleshooting. Do not document commands as
+available unless they are implemented. In your final response, list files
+changed and verification.
+```
+
+### Main Thread Integration Tasks
+
+Main thread should own:
+
+- Choosing final API shape for project/team metadata.
+- Reviewing `ac` command behavior for compatibility.
+- Running full local tests and Docker smoke tests.
+- Resolving conflicts if workers touch shared docs.
+- Deciding whether Agent Operations needs a backend API before merging.
+
+### Avoid Parallelizing
+
+- Multiple workers editing `ac` concurrently.
+- Frontend extraction from `static/chat.js` while Agent Operations UI is being
+  added.
+- Core MCP/routing changes unless scoped to a small bug fix.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Agents wake each other up, coordinate, and report back.
 
 <p align="center">
   <img src="gang.gif" alt="agentchattr gang" width="600"><br>
-  <sub>the gang after <code>/hatmaking</code></sub>
+  <sub>the gang in a multi-agent room</sub>
 </p>
 
 ## Features
@@ -122,6 +122,12 @@ Agents interact with channels via MCP: `chat_send(channel="debug")`, `chat_read(
 
 When agents are triggered by an @mention, the wrapper injects `use mcp to read #channel-name - you're mentioned, take appropriate action and respond` so the agent reads the right channel automatically. Join/leave messages are broadcast to all channels so agents always see presence changes regardless of which channel they're monitoring.
 
+### Search and command palette
+Open search from the header or press `Cmd/Ctrl+K`. Search recent messages across channels, filter by sender/channel/pinned/todo/done/jobs/session/system messages, switch channels, open Jobs/Rules/Agent Operations, copy tmux attach commands, or send `/continue` from one palette.
+
+### Agent Operations
+The header operations button opens a right-side panel with project metadata, ports, data/upload paths, configured agents, registered agents, heartbeat age, busy/available state, tmux session names, and attach-command copy buttons. It flags common mismatches such as configured agents that never registered or wrappers running without a live heartbeat.
+
 ### Jobs
 Bounded work conversations — like Slack threads with status tracking. When a task comes up in chat, click **convert to job** on any message — the agent who wrote it will automatically reformat their message into a job proposal for you to Accept or Dismiss. You can also create jobs manually from the jobs panel. Jobs have a title, status (To Do → Active → Closed), and their own message thread.
 
@@ -132,7 +138,7 @@ Agents can also propose jobs directly via `chat_propose_job` — a proposal card
 ### Agent roles
 Assign roles to agents to steer their behavior — Planner, Builder, Reviewer, Researcher, or any custom role. Roles aren't a hard constraint — they're a persistent nudge. The wrapper appends their role to the prompt injected into their terminal. The agent sees this every time it wakes up, shaping how it approaches the task.
 
-Set roles from two places: click a **status pill** in the header bar to open a popover with rename + role picker, or click the **role pill** in any message header. Choose from presets or type a custom role (max 20 characters). Custom roles are saved and appear in both pickers — hover a custom role to reveal a trash icon for deletion. Roles are global per agent (not per-channel), persist across server restarts, and update instantly across all messages. Clear a role by selecting "None".
+Set roles from two places: click a **status pill** in the right-side Agents rail to open a popover with rename + role picker, or click the **role pill** in any message header. Choose from presets or type a custom role (max 20 characters). Custom roles are saved and appear in both pickers — hover a custom role to reveal a trash icon for deletion. Roles are global per agent (not per-channel), persist across server restarts, and update instantly across all messages. Clear a role by selecting "None".
 
 ### Rules
 Rules set the working style for your agents. Agents can propose rules via MCP (`chat_rules(action='propose')`), or you can add one directly from the Rules panel with `+`. Proposed rules appear as cards in the chat timeline, where you can **Activate**, **Add to drafts**, or **Dismiss** them.
@@ -231,23 +237,14 @@ Type `/` in the input to open a Slack-style autocomplete menu:
 - `/summary @agent` — ask an agent to summarize recent messages in the current channel
 - `/continue` — resume after the loop guard pauses an agent-to-agent chain
 - `/clear` — clear messages in the current channel
-
-### Fun stuff
-Slash commands for when you want to see what your agents are made of:
-
-- `/hatmaking` — all agents design an SVG hat for their avatar (see the gang above)
-- `/artchallenge` — SVG art challenge with optional theme — agents create artwork and share it in chat
 - `/roastreview` — all agents review and roast each other's recent work
-- `/poetry haiku` — agents write a haiku about the codebase
-- `/poetry limerick` — agents write a limerick about the codebase
-- `/poetry sonnet` — agents write a sonnet about the codebase
 
 Hats are SVG overlays (viewBox `0 0 32 16`, max 5KB) that sit above agent avatars in chat. They persist across page reloads. Drag a hat to the trash icon to remove it.
 
 ### Web chat UI
 Dark-themed chat at `localhost:8300` with real-time updates:
 
-- @mention autocomplete with live agent list — type `@` to search online agents, "all agents", and the human user. Arrow keys to navigate, Enter/Tab to insert
+- @mention autocomplete with live agent list — type `@` to search online agents and `@all`. Arrow keys to navigate, Enter/Tab to insert
 - Pre-@ mention toggles to "lock on" to specific agents
 - Reply threading with inline quotes that link back to the parent message
 - GitHub-flavored markdown with code blocks, tables, and copy buttons
@@ -482,9 +479,13 @@ Server and wrappers share the same `AGENTCHATTR_*` env vars and the same flag na
 For repeatable per-project rosters, create a team file in `teams/<project>.toml` and start it with:
 
 ```bash
+./ac list
+./ac project-a up --dry-run
 ./ac project-a up
 ./ac project-a status
 ./ac project-a attach architect
+./ac project-a logs architect
+./ac project-a restart architect
 ./ac project-a down
 ```
 
@@ -509,7 +510,13 @@ Example `teams/project-a.toml`:
 ```toml
 [project]
 name = "project-a"
+title = "Project A"
+accent_color = "#7c3aed"
 tmux_prefix = "agentchattr-project-a"
+# repo_url = "https://github.com/owner/repo"
+# board_url = "https://github.com/orgs/owner/projects/1"  # replaces Support pill with "Project Board"
+# link_label = "Project Board"  # optional override for the pill label
+# link_url = "https://github.com/orgs/owner/projects/1/views/1"  # optional override for the pill URL
 
 [server]
 port = 8301
@@ -527,16 +534,21 @@ upload_dir = "./uploads/project-a"
 default = "none"
 max_agent_hops = 100
 
+[agent_defaults.claude]
+cwd = ".."
+
+[agent_defaults.codex]
+cwd = ".."
+args = ["--ask-for-approval", "never"]
+
 [agents.architect]
 provider = "claude"
-cwd = ".."
 color = "#da7756"
 label = "Architect"
 role = "Planner"
 
 [agents.builder]
 provider = "codex"
-cwd = ".."
 color = "#10a37f"
 label = "Builder"
 role = "Builder"
@@ -549,9 +561,11 @@ label = "Research"
 role = "Researcher"
 ```
 
-`provider` selects the built-in wrapper behavior for aliases, so `provider = "claude"` works even when the handle is `architect`. If `command` is omitted, it defaults to the provider name. The team file's `[agents]` section replaces the default roster for that project.
+`provider` selects the built-in wrapper behavior for aliases, so `provider = "claude"` works even when the handle is `architect`. If `command` is omitted, it defaults to the provider name. The team file's `[agents]` section replaces the default roster for that project. `[agent_defaults.<provider>]` applies shared fields to matching agents, and per-agent values override those defaults. `args = [...]` adds provider CLI arguments after agentchattr's MCP/config arguments. Optional `repo_url` and `board_url` fields show up in Agent Operations; `board_url` also replaces the Support link with a `Project Board` pill. Use `link_label` and `link_url` only when you want that pill to point somewhere else.
 
 Under the hood, `ac` sets `AGENTCHATTR_PROJECT_CONFIG` and `AGENTCHATTR_TMUX_PREFIX`. You can use `AGENTCHATTR_PROJECT_CONFIG=/path/to/team.toml python run.py` directly if you want to start the server by hand.
+
+The web UI also exposes an Agent Operations panel from the header. It shows project ports/paths, configured and registered agents, tmux session names, heartbeat state, and copyable attach commands.
 
 See [`TEAM_RUNNER_GUIDE.md`](TEAM_RUNNER_GUIDE.md) for the full operating guide and
 [`PROJECT_PLAN.md`](PROJECT_PLAN.md) for the roadmap.

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ temperature = 1.0
 
 [routing]
 default = "none"            # "none" = only @mentions trigger agents
-max_agent_hops = 4          # pause after N agent-to-agent messages
+max_agent_hops = 100        # pause after N agent-to-agent messages
 
 [mcp]
 http_port = 8200            # MCP streamable-http (Claude Code, Codex)
@@ -476,6 +476,85 @@ python wrapper.py claude \
 Relative paths resolve against the shell's current directory (not agentchattr's install location), so `./.agentchattr` ends up inside your project folder.
 
 Server and wrappers share the same `AGENTCHATTR_*` env vars and the same flag names, so a launcher/profile can run multiple isolated instances by passing matching values to each process. If no flags or env vars are set, `config.toml` is used exactly as before — zero change for existing setups.
+
+### Project teams
+
+For repeatable per-project rosters, create a team file in `teams/<project>.toml` and start it with:
+
+```bash
+./ac project-a up
+./ac project-a status
+./ac project-a attach architect
+./ac project-a down
+```
+
+`ac project-a up` starts the server in a project-specific tmux session, then starts one wrapper per configured agent. CLI agents run in their own tmux sessions using the configured names, roles, labels, colors, ports, and data directory.
+
+Tmux sessions use a predictable naming convention:
+
+- `{tmux_prefix}-server` — the FastAPI/MCP server
+- `{tmux_prefix}-<agent>` — the live agent CLI session to attach to
+- `{tmux_prefix}-wrap-<agent>` — the wrapper supervisor for that agent
+
+For normal manual intervention, attach to the live agent session:
+
+```bash
+./ac project-a attach architect
+```
+
+Use `./ac project-a attach wrapper:architect` only when debugging the wrapper process itself.
+
+Example `teams/project-a.toml`:
+
+```toml
+[project]
+name = "project-a"
+tmux_prefix = "agentchattr-project-a"
+
+[server]
+port = 8301
+host = "127.0.0.1"
+data_dir = "./data/project-a"
+
+[mcp]
+http_port = 8211
+sse_port = 8212
+
+[images]
+upload_dir = "./uploads/project-a"
+
+[routing]
+default = "none"
+max_agent_hops = 100
+
+[agents.architect]
+provider = "claude"
+cwd = ".."
+color = "#da7756"
+label = "Architect"
+role = "Planner"
+
+[agents.builder]
+provider = "codex"
+cwd = ".."
+color = "#10a37f"
+label = "Builder"
+role = "Builder"
+
+[agents.research]
+provider = "gemini"
+cwd = ".."
+color = "#4285f4"
+label = "Research"
+role = "Researcher"
+```
+
+`provider` selects the built-in wrapper behavior for aliases, so `provider = "claude"` works even when the handle is `architect`. If `command` is omitted, it defaults to the provider name. The team file's `[agents]` section replaces the default roster for that project.
+
+Under the hood, `ac` sets `AGENTCHATTR_PROJECT_CONFIG` and `AGENTCHATTR_TMUX_PREFIX`. You can use `AGENTCHATTR_PROJECT_CONFIG=/path/to/team.toml python run.py` directly if you want to start the server by hand.
+
+See [`TEAM_RUNNER_GUIDE.md`](TEAM_RUNNER_GUIDE.md) for the full operating guide and
+[`PROJECT_PLAN.md`](PROJECT_PLAN.md) for the roadmap.
 
 ### API agents (local models)
 

--- a/TEAM_RUNNER_GUIDE.md
+++ b/TEAM_RUNNER_GUIDE.md
@@ -1,0 +1,324 @@
+# agentchattr Team Runner Guide
+
+This guide covers the project/team workflow driven by `./ac`.
+
+The goal is to define a repeatable roster per project, then start, inspect,
+attach to, and stop that project without manually renaming agents in the UI.
+
+## Concepts
+
+A **team file** is a TOML file that defines one project-specific agentchattr
+instance:
+
+- web server port
+- MCP ports
+- data and upload directories
+- tmux session prefix
+- agent roster
+- names, labels, colors, and roles
+
+`./ac` reads the team file, starts the server in tmux, then starts one wrapper
+per configured agent. Each wrapper starts the actual agent CLI in its own tmux
+session.
+
+## Quick Start
+
+Create a project team file:
+
+```bash
+cp teams/project-a.toml.example teams/project-a.toml
+```
+
+Edit ports, paths, and agents as needed, then start it:
+
+```bash
+./ac project-a up
+```
+
+Check status:
+
+```bash
+./ac project-a status
+```
+
+Attach to an agent:
+
+```bash
+./ac project-a attach claude-planner
+```
+
+Stop the project:
+
+```bash
+./ac project-a down
+```
+
+## Team File Location
+
+By default, `./ac project-a up` looks for:
+
+```text
+teams/project-a.toml
+projects/project-a.toml
+project-a.toml
+```
+
+You can also pass an explicit file:
+
+```bash
+./ac project-a up -f /path/to/project-a.toml
+```
+
+## Team File Example
+
+```toml
+[project]
+name = "project-a"
+tmux_prefix = "agentchattr-project-a"
+
+[server]
+port = 8301
+host = "127.0.0.1"
+data_dir = "./data/project-a"
+
+[mcp]
+http_port = 8211
+sse_port = 8212
+
+[images]
+upload_dir = "./uploads/project-a"
+
+[routing]
+default = "none"
+max_agent_hops = 100
+
+[agents.claude-planner]
+provider = "claude"
+cwd = ".."
+color = "#da7756"
+label = "Claude Planner"
+role = "Planner"
+
+[agents.codex-builder]
+provider = "codex"
+cwd = ".."
+color = "#10a37f"
+label = "Codex Builder"
+role = "Builder"
+
+[agents.gemini-research]
+provider = "gemini"
+cwd = ".."
+color = "#4285f4"
+label = "Gemini Research"
+role = "Researcher"
+```
+
+## Agent Fields
+
+Each `[agents.<name>]` entry defines a handle. The handle is what you mention
+in chat, for example `@claude-planner`.
+
+Common fields:
+
+- `provider`: built-in provider behavior to use: `claude`, `codex`, `gemini`,
+  `kimi`, `qwen`, `kilo`, `codebuddy`, or `copilot`
+- `command`: optional executable path. If omitted, defaults to `provider`
+- `cwd`: working directory for the agent CLI
+- `color`: status pill and mention color
+- `label`: display label in the UI
+- `role`: role text injected into the agent when it is triggered
+
+For normal aliases, prefer `provider` and omit `command`:
+
+```toml
+[agents.architect]
+provider = "claude"
+```
+
+Use `command` when testing or when the executable is not on `PATH`:
+
+```toml
+[agents.architect]
+provider = "claude"
+command = "/opt/bin/claude"
+```
+
+## Multiple Projects
+
+Each project must use unique ports and a unique tmux prefix:
+
+```toml
+[project]
+tmux_prefix = "agentchattr-project-b"
+
+[server]
+port = 8302
+
+[mcp]
+http_port = 8221
+sse_port = 8222
+```
+
+Then run projects side by side:
+
+```bash
+./ac project-a up
+./ac project-b up
+./ac project-c up
+```
+
+Each project has isolated runtime state if its `data_dir` and `upload_dir` are
+different.
+
+## Tmux Naming Convention
+
+For a project with:
+
+```toml
+[project]
+tmux_prefix = "agentchattr-project-a"
+
+[agents.claude-planner]
+provider = "claude"
+```
+
+tmux sessions are named:
+
+```text
+agentchattr-project-a-server
+agentchattr-project-a-wrap-claude-planner
+agentchattr-project-a-claude-planner
+```
+
+Use these targets:
+
+- `server`: the FastAPI/MCP server
+- `<agent>`: the live agent CLI session
+- `wrapper:<agent>`: the wrapper supervisor for that agent
+
+Examples:
+
+```bash
+./ac project-a attach server
+./ac project-a attach claude-planner
+./ac project-a attach wrapper:claude-planner
+```
+
+For a hung or confused agent, attach to the live agent session, not the wrapper:
+
+```bash
+./ac project-a attach claude-planner
+```
+
+Detach from tmux without stopping the agent:
+
+```text
+Ctrl+B, then D
+```
+
+## Restarting One Agent
+
+There is not yet a dedicated `./ac project-a restart <agent>` command. For now:
+
+1. Kill the live agent tmux session.
+2. Wait a few seconds for its wrapper to exit.
+3. Run `./ac project-a up` again. Existing sessions are left alone; stopped
+   wrappers are started again.
+
+Example:
+
+```bash
+tmux kill-session -t agentchattr-project-a-claude-planner
+sleep 5
+./ac project-a up
+```
+
+If the wrapper session is still present and stuck, kill it too:
+
+```bash
+tmux kill-session -t agentchattr-project-a-wrap-claude-planner
+./ac project-a up
+```
+
+## Stopping A Project
+
+Stop one project:
+
+```bash
+./ac project-a down
+```
+
+This kills tmux sessions whose names start with that project’s `tmux_prefix`.
+It should not stop other projects with different prefixes.
+
+## Data Persistence
+
+Project data is stored where the team file says:
+
+```toml
+[server]
+data_dir = "./data/project-a"
+
+[images]
+upload_dir = "./uploads/project-a"
+```
+
+Important files in `data_dir` include chat history, jobs, rules, roles,
+settings, summaries, session runs, and agent queue files.
+
+If you change settings in the UI, those runtime settings are saved under the
+project `data_dir` and can override defaults from the team file on the next
+startup.
+
+## Troubleshooting
+
+List project sessions:
+
+```bash
+tmux list-sessions | grep agentchattr-project-a
+```
+
+View server output:
+
+```bash
+./ac project-a attach server
+```
+
+View wrapper output:
+
+```bash
+./ac project-a attach wrapper:claude-planner
+```
+
+View live agent:
+
+```bash
+./ac project-a attach claude-planner
+```
+
+Check if ports are already taken:
+
+```bash
+lsof -i :8301
+lsof -i :8211
+lsof -i :8212
+```
+
+If `./ac project-a up` says a port is already listening, either stop the other
+process or change the project’s ports.
+
+## Docker Notes
+
+The current `./ac` workflow is host/tmux based. Docker can work later, but if
+you put server and agents in a container, mount persistent directories for:
+
+```text
+data_dir
+upload_dir
+project source repo
+agent credentials, if needed
+```
+
+Without mounted volumes or bind mounts, container-local state should be treated
+as disposable.

--- a/TEAM_RUNNER_GUIDE.md
+++ b/TEAM_RUNNER_GUIDE.md
@@ -26,31 +26,33 @@ session.
 Create a project team file:
 
 ```bash
-cp teams/project-a.toml.example teams/project-a.toml
+cp teams/two-agent.toml.example teams/two-agent.toml
 ```
 
 Edit ports, paths, and agents as needed, then start it:
 
 ```bash
-./ac project-a up
+./ac list
+./ac two-agent up --dry-run
+./ac two-agent up
 ```
 
 Check status:
 
 ```bash
-./ac project-a status
+./ac two-agent status
 ```
 
 Attach to an agent:
 
 ```bash
-./ac project-a attach claude-planner
+./ac two-agent attach architect
 ```
 
 Stop the project:
 
 ```bash
-./ac project-a down
+./ac two-agent down
 ```
 
 ## Team File Location
@@ -74,7 +76,13 @@ You can also pass an explicit file:
 ```toml
 [project]
 name = "project-a"
+title = "Project A"
+accent_color = "#7c3aed"
 tmux_prefix = "agentchattr-project-a"
+# repo_url = "https://github.com/owner/repo"
+# board_url = "https://github.com/orgs/owner/projects/1"  # replaces Support pill with "Project Board"
+# link_label = "Project Board"  # optional override for the pill label
+# link_url = "https://github.com/orgs/owner/projects/1/views/1"  # optional override for the pill URL
 
 [server]
 port = 8301
@@ -92,9 +100,11 @@ upload_dir = "./uploads/project-a"
 default = "none"
 max_agent_hops = 100
 
+[agent_defaults.claude]
+cwd = ".."
+
 [agents.claude-planner]
 provider = "claude"
-cwd = ".."
 color = "#da7756"
 label = "Claude Planner"
 role = "Planner"
@@ -114,6 +124,12 @@ label = "Gemini Research"
 role = "Researcher"
 ```
 
+Additional examples are available under `teams/`:
+
+- `teams/two-agent.toml.example`
+- `teams/large-roster.toml.example`
+- `teams/api-agent.toml.example`
+
 ## Agent Fields
 
 Each `[agents.<name>]` entry defines a handle. The handle is what you mention
@@ -128,6 +144,8 @@ Common fields:
 - `color`: status pill and mention color
 - `label`: display label in the UI
 - `role`: role text injected into the agent when it is triggered
+- `args`: extra provider CLI arguments appended after agentchattr-owned MCP
+  arguments and before ad hoc wrapper pass-through arguments
 
 For normal aliases, prefer `provider` and omit `command`:
 
@@ -143,6 +161,20 @@ Use `command` when testing or when the executable is not on `PATH`:
 provider = "claude"
 command = "/opt/bin/claude"
 ```
+
+Shared defaults reduce repeated fields:
+
+```toml
+[agent_defaults.codex]
+cwd = ".."
+args = ["--ask-for-approval", "never"]
+
+[agents.codex-builder]
+provider = "codex"
+label = "Codex Builder"
+```
+
+Per-agent values override matching `[agent_defaults.<provider>]` values.
 
 ## Multiple Projects
 
@@ -219,27 +251,34 @@ Ctrl+B, then D
 
 ## Restarting One Agent
 
-There is not yet a dedicated `./ac project-a restart <agent>` command. For now:
-
-1. Kill the live agent tmux session.
-2. Wait a few seconds for its wrapper to exit.
-3. Run `./ac project-a up` again. Existing sessions are left alone; stopped
-   wrappers are started again.
-
-Example:
+Restart one wrapper/live agent pair without touching the server or other
+agents:
 
 ```bash
-tmux kill-session -t agentchattr-project-a-claude-planner
-sleep 5
-./ac project-a up
+./ac project-a restart claude-planner
 ```
 
-If the wrapper session is still present and stuck, kill it too:
+This kills:
+
+```text
+agentchattr-project-a-claude-planner
+agentchattr-project-a-wrap-claude-planner
+```
+
+Then it starts the wrapper again. The wrapper creates the live agent tmux
+session.
+
+## Logs
+
+Capture recent tmux pane output without attaching:
 
 ```bash
-tmux kill-session -t agentchattr-project-a-wrap-claude-planner
-./ac project-a up
+./ac project-a logs server
+./ac project-a logs claude-planner --lines 300
+./ac project-a logs wrapper:claude-planner
 ```
+
+The default is `--lines 200`. A raw tmux session name also works as the target.
 
 ## Stopping A Project
 
@@ -282,13 +321,13 @@ tmux list-sessions | grep agentchattr-project-a
 View server output:
 
 ```bash
-./ac project-a attach server
+./ac project-a logs server
 ```
 
 View wrapper output:
 
 ```bash
-./ac project-a attach wrapper:claude-planner
+./ac project-a logs wrapper:claude-planner
 ```
 
 View live agent:

--- a/TEMP_TEST_CHECKLIST.md
+++ b/TEMP_TEST_CHECKLIST.md
@@ -1,0 +1,141 @@
+# Temporary Test Checklist
+
+Use this to manually test the runner, metadata APIs, Agent Operations panel, and search/command palette before we package or PR the work.
+
+## Setup
+
+- From the repo root for this checkout:
+  ```bash
+  cd /Users/josh/code/github.com/the-sarge/agentchattr
+  ```
+
+- Make sure the venv has app and test dependencies:
+  ```bash
+  .venv/bin/python -m pip install -q -r requirements.txt pytest
+  ```
+
+- Run the Python suite:
+  ```bash
+  .venv/bin/python -m pytest -q
+  ```
+- Confirm these pass before manual QA:
+  ```bash
+  node --check static/agent-ops.js
+  node --check static/search-nav.js
+  ```
+
+## Runner Smoke
+
+- List known projects:
+  ```bash
+  ./ac list
+  ```
+  Expected: examples are ignored unless copied to `.toml`; no crash if no real team files exist.
+
+- Dry-run a team example:
+  ```bash
+  ./ac two-agent up --dry-run -f teams/two-agent.toml.example
+  ```
+  Expected: prints team file, web/MCP ports, data/upload dirs, tmux prefix, server/wrapper/live session names, and exact commands. It should not create tmux sessions or start servers.
+
+- Optional real tmux smoke, only if you have the configured commands on `PATH`:
+  ```bash
+  cp teams/two-agent.toml.example teams/two-agent.toml
+  ./ac two-agent up
+  ./ac two-agent status
+  ./ac two-agent logs server --lines 80
+  ./ac two-agent restart builder
+  ./ac two-agent down
+  ```
+  Expected: restart affects only `builder` live/wrapper sessions; server and `architect` stay untouched.
+
+## Server/API Smoke
+
+- Start the app:
+  ```bash
+  .venv/bin/python run.py
+  ```
+- Copy the printed session token.
+- In another terminal, verify:
+  ```bash
+  curl -fsS -H 'X-Session-Token: TOKEN_HERE' http://127.0.0.1:8300/api/project
+  curl -fsS -H 'X-Session-Token: TOKEN_HERE' http://127.0.0.1:8300/api/agent-ops
+  ```
+  Expected: `/api/project` includes name/title/accent/team file/tmux prefix/ports/paths. `/api/agent-ops` includes service badges, configured agents, registered agents, tmux sessions, attach commands, and mismatch lists.
+
+## Browser UI
+
+- Open `http://127.0.0.1:8300`.
+- Header:
+  - Project badge appears next to the title.
+  - Browser tab title is `<project> - agentchattr`, except the default project should stay exactly `agentchattr`.
+  - Existing header buttons still work: Jobs, Rules, Pins, Settings, Help.
+  - Agent/status pills appear in the right-side Agents rail by default, not in the header.
+  - Opening Jobs, Rules, or Agent Operations hides the Agents rail so the active panel has enough room.
+
+- Agent Operations:
+  - Click the operations/sliders button in the header.
+  - Panel opens wider on the right without breaking timeline layout.
+  - Project section shows tmux prefix, data dir, upload dir, team/default config, and repo/board links when configured.
+  - Long data/upload/team paths wrap cleanly and do not collide with labels.
+  - Services section owns the web/MCP port rows; Project should not repeat them.
+  - Configured agents show label, handle, provider/type, configured role even when the agent is offline/missing, heartbeat age, live/wrapper attach commands.
+  - Warning rows appear for configured agents that are not registered.
+  - Copy buttons place attach commands on the clipboard.
+  - Closing and reopening refreshes the data.
+
+- Search and command palette:
+  - Press `Cmd+K` on macOS or `Ctrl+K` elsewhere.
+  - Palette opens and focuses the input.
+  - Type text from an existing message and confirm matching message rows appear.
+  - Type `general`. Expected: `Switch to #general` is the first match, and message rows only appear if their message body contains `general`.
+  - Type any other channel name. Expected: a `Switch to #channel` command appears before message-content matches, and Enter switches channels.
+  - Type `@sendername`. Expected: message rows from that sender appear; typing the bare sender name should not match every message by that sender unless the body contains it.
+  - Type `jobs`. Expected: `Open Jobs` appears without needing a `>` prefix.
+  - Type a command-like query without `>`. Expected: command rows still match.
+  - Optional: type `>` to restrict results to commands only.
+  - Try filters: sender, channel, pinned, todo, done, jobs, sessions, system.
+  - Press Enter on a message result. Expected: switches to the message channel if needed and scrolls/highlights the message.
+  - Run commands for channel switching, Jobs, Rules, Agent Operations, and pinned items.
+  - Verify attach-copy commands appear when `/api/agent-ops` has configured agents.
+  - Escape closes the palette.
+
+- Channels and layout defaults:
+  - Reload in a clean browser profile or clear local storage. Expected: Agents rail opens on the left and Channels sidebar opens on the right by default.
+  - Open Settings and set `Sidebars` to `Agents left`. Expected: Agents rail moves left and Channels sidebar moves right.
+  - Set `Sidebars` to `Channels left`. Expected: Channels sidebar moves left and Agents rail moves right.
+  - Create and rename a 24-character channel, e.g. `abcdefghijklmnopqrstuvwx`.
+  - Confirm a 25-character channel is rejected.
+  - Resize the channel sidebar and confirm longer names remain usable.
+
+- Settings and command cleanup:
+  - Open Settings. Expected: loop guard default is `100` and History includes `1000`.
+  - Type `/` in the message box. Expected: `/roastreview` remains, but `/artchallenge`, `/hatmaking`, and `/poetry ...` commands are gone.
+  - Type `@all`. Expected: the mention remains `@all`, not `@all agents`.
+
+- Project links:
+  - Add `repo_url` and `board_url` under `[project]` in a team file and restart.
+  - Expected: `/api/project` returns both URLs, Agent Operations shows them, and the old Support link becomes `Project Board`.
+  - Optional: set `link_label` and `link_url` under `[project]`. Expected: those override the pill label and URL.
+
+## Regression Checks
+
+- Send a normal chat message.
+- Reload. Expected: your own existing message bubbles stay right-aligned.
+- Press `Cmd+.` on macOS or `Ctrl+.` elsewhere. Expected: cursor moves to the main message field without using the mouse.
+- Create/switch channels.
+- Open and close Jobs and Rules panels.
+- Pin/unpin a message.
+- Change Settings and reload the page.
+- Confirm WebSocket reconnect still loads history without duplicate visible UI.
+
+## Notes To Capture
+
+Record:
+
+- Browser/OS.
+- Exact command used to start the server.
+- Whether testing default `config.toml` or a team file.
+- Any console errors from browser devtools.
+- Any server traceback.
+- Screenshots for layout problems, especially narrow/mobile widths.

--- a/ac
+++ b/ac
@@ -21,11 +21,18 @@ import socket
 import subprocess
 import sys
 import time
-import tomllib
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from config_loader import (  # noqa: E402
+    ConfigError,
+    discover_team_files,
+    load_project_config_file,
+    validate_known_team_files,
+)
 
 
 def _slug(value: str) -> str:
@@ -58,11 +65,6 @@ def _find_team_file(project: str, explicit: str | None = None) -> Path:
     raise SystemExit(f"Team file not found. Searched:\n  {searched}")
 
 
-def _load_toml(path: Path) -> dict:
-    with open(path, "rb") as f:
-        return tomllib.load(f)
-
-
 def _project_name(project_arg: str, team: dict, path: Path) -> str:
     project = team.get("project", {})
     return str(project.get("name") or project_arg or path.stem)
@@ -78,6 +80,19 @@ def _tmux_prefix(project_arg: str, team: dict, path: Path) -> str:
 
 def _server_port(team: dict) -> int:
     return int(team.get("server", {}).get("port", 8300))
+
+
+def _mcp_ports(team: dict) -> tuple[int, int]:
+    mcp = team.get("mcp", {})
+    return int(mcp.get("http_port", 8200)), int(mcp.get("sse_port", 8201))
+
+
+def _data_dir(team: dict) -> str:
+    return str(team.get("server", {}).get("data_dir", "./data"))
+
+
+def _upload_dir(team: dict) -> str:
+    return str(team.get("images", {}).get("upload_dir", "./uploads"))
 
 
 def _agent_names(team: dict) -> list[str]:
@@ -165,9 +180,127 @@ def _shell_command(env: dict[str, str], args: list[str]) -> str:
     return "env " + " ".join(env_parts + [shlex.quote(str(arg)) for arg in args])
 
 
+def _wrapper_script(team: dict, agent: str) -> str:
+    return "wrapper_api.py" if _agent_is_api(team, agent) else "wrapper.py"
+
+
+def _wrapper_cmd_args(python: Path | str, team: dict, agent: str, prefix: str) -> list[str]:
+    wrapper = _wrapper_script(team, agent)
+    cmd_args = [str(python), wrapper, agent]
+    if wrapper == "wrapper.py":
+        cmd_args.extend(["--detach", "--tmux-prefix", prefix])
+    return cmd_args
+
+
+def _agent_sessions(prefix: str, agent: str) -> tuple[str, str]:
+    return f"{prefix}-{agent}", f"{prefix}-wrap-{_slug(agent)}"
+
+
+def _resolve_target_session(prefix: str, agents: list[str], target: str) -> str:
+    target = (target or "").strip()
+    if target == "server":
+        return f"{prefix}-server"
+    if target.startswith(("wrapper:", "wrap:")):
+        agent = target.split(":", 1)[1]
+        return f"{prefix}-wrap-{_slug(agent)}"
+    if target in agents:
+        return f"{prefix}-{target}"
+    return target
+
+
+def _command_missing(team: dict, agent: str) -> str | None:
+    cfg = team.get("agents", {}).get(agent, {})
+    if str(cfg.get("type", "")).lower() == "api":
+        return None
+    command = str(cfg.get("command", "")).strip()
+    if not command:
+        return f"{agent}: missing command"
+    if os.sep in command or (os.altsep and os.altsep in command):
+        path = Path(command).expanduser()
+        if path.exists() and os.access(path, os.X_OK):
+            return None
+    elif shutil.which(command):
+        return None
+    return f"{agent}: command not found on PATH: {command}"
+
+
+def _preflight_project(
+    team: dict,
+    prefix: str,
+    *,
+    require_tmux: bool = True,
+    check_ports: bool = True,
+    check_commands: bool = True,
+) -> None:
+    errors: list[str] = []
+    if require_tmux and not shutil.which("tmux"):
+        errors.append("tmux is required. Install it first, then retry.")
+
+    try:
+        validate_known_team_files(ROOT)
+    except ConfigError as exc:
+        errors.append(str(exc))
+
+    if check_commands:
+        for agent in _agent_names(team):
+            missing = _command_missing(team, agent)
+            if missing:
+                errors.append(missing)
+
+    if check_ports:
+        server_session = f"{prefix}-server"
+        server_already_running = shutil.which("tmux") and _tmux_session_exists(server_session)
+        if not server_already_running:
+            port_items = [
+                ("server", _server_port(team)),
+                ("MCP HTTP", _mcp_ports(team)[0]),
+                ("MCP SSE", _mcp_ports(team)[1]),
+            ]
+            for label, port in port_items:
+                if _port_open(port):
+                    errors.append(f"{label} port {port} is already in use")
+
+    if errors:
+        raise SystemExit("Preflight failed:\n  - " + "\n  - ".join(errors))
+
+
+def _print_dry_run(team_file: Path, team: dict, name: str, prefix: str, port: int, agents: list[str]) -> None:
+    env = _env_for_project(team_file, prefix)
+    http_port, sse_port = _mcp_ports(team)
+    print(f"{name} dry run")
+    print(f"Team file: {team_file}")
+    print(f"Web UI: http://127.0.0.1:{port}")
+    print(f"MCP HTTP: http://127.0.0.1:{http_port}/mcp")
+    print(f"MCP SSE: http://127.0.0.1:{sse_port}/sse")
+    print(f"Data dir: {_data_dir(team)}")
+    print(f"Upload dir: {_upload_dir(team)}")
+    print(f"Tmux prefix: {prefix}")
+    print("Tmux sessions:")
+    print(f"  server            {prefix}-server")
+    for agent in agents:
+        live_session, wrapper_session = _agent_sessions(prefix, agent)
+        print(f"  {agent:<16} {live_session}")
+        print(f"  {'wrapper:' + agent:<16} {wrapper_session}")
+    print("Commands:")
+    print(f"  server            {_shell_command(env, ['.venv/bin/python', 'run.py'])}")
+    for agent in agents:
+        cmd_args = _wrapper_cmd_args(".venv/bin/python", team, agent, prefix)
+        print(f"  {agent:<16} {_shell_command(env, cmd_args)}")
+
+
+def _start_wrapper(team_file: Path, team: dict, prefix: str, agent: str, python: Path) -> None:
+    _live_session, wrapper_session = _agent_sessions(prefix, agent)
+    env = _env_for_project(team_file, prefix)
+    command = _shell_command(env, _wrapper_cmd_args(python, team, agent, prefix))
+    _start_tmux_session(wrapper_session, command)
+
+
 def _project_context(args) -> tuple[Path, dict, str, str, int, list[str]]:
     team_file = _find_team_file(args.project, args.file)
-    team = _load_toml(team_file)
+    try:
+        team = load_project_config_file(team_file, ROOT)
+    except ConfigError as exc:
+        raise SystemExit(f"Config error: {exc}") from exc
     name = _project_name(args.project, team, team_file)
     prefix = _tmux_prefix(args.project, team, team_file)
     port = _server_port(team)
@@ -179,16 +312,24 @@ def up(args) -> None:
     if sys.platform == "win32":
         raise SystemExit("ac project up currently supports tmux-based Mac/Linux launches.")
 
-    _check_tmux()
     team_file, team, name, prefix, port, agents = _project_context(args)
+    _preflight_project(
+        team,
+        prefix,
+        require_tmux=not args.dry_run,
+        check_ports=not args.dry_run,
+        check_commands=not args.dry_run,
+    )
+    if args.dry_run:
+        _print_dry_run(team_file, team, name, prefix, port, agents)
+        return
+
     python = _ensure_venv()
     env = _env_for_project(team_file, prefix)
 
     server_session = f"{prefix}-server"
     if _tmux_session_exists(server_session):
         print(f"Server already running: {server_session}")
-    elif _port_open(port):
-        print(f"Port {port} is already listening; leaving server tmux session stopped.")
     else:
         command = _shell_command(env, [python, "run.py"])
         _start_tmux_session(server_session, command)
@@ -197,17 +338,12 @@ def up(args) -> None:
             raise SystemExit(f"Server did not start on port {port}. Check: tmux attach -t {server_session}")
 
     for agent in agents:
-        wrapper_session = f"{prefix}-wrap-{_slug(agent)}"
+        _live_session, wrapper_session = _agent_sessions(prefix, agent)
         if _tmux_session_exists(wrapper_session):
             print(f"Agent wrapper already running: {wrapper_session}")
             continue
 
-        wrapper = "wrapper_api.py" if _agent_is_api(team, agent) else "wrapper.py"
-        cmd_args = [python, wrapper, agent]
-        if wrapper == "wrapper.py":
-            cmd_args.extend(["--detach", "--tmux-prefix", prefix])
-        command = _shell_command(env, cmd_args)
-        _start_tmux_session(wrapper_session, command)
+        _start_wrapper(team_file, team, prefix, agent, python)
         print(f"Started {agent}: wrapper={wrapper_session}, agent={prefix}-{agent}")
 
     print(f"\n{name} is up: http://127.0.0.1:{port}")
@@ -225,6 +361,67 @@ def down(args) -> None:
     for session in sorted(matches, reverse=True):
         _kill_tmux_session(session)
         print(f"Stopped {session}")
+
+
+def restart(args) -> None:
+    _check_tmux()
+    team_file, team, _name, prefix, port, agents = _project_context(args)
+    target = (args.target or "").strip()
+    if target not in agents:
+        print(f"Unknown agent: {target or '<missing>'}")
+        print()
+        _print_attach_help(prefix, agents)
+        raise SystemExit(2)
+    _preflight_project(team, prefix, require_tmux=True, check_ports=False)
+    if not _port_open(port):
+        raise SystemExit(f"Server is not listening on port {port}; start the project before restarting an agent.")
+
+    live_session, wrapper_session = _agent_sessions(prefix, target)
+    for session in (live_session, wrapper_session):
+        if _tmux_session_exists(session):
+            _kill_tmux_session(session)
+            print(f"Stopped {session}")
+    python = _ensure_venv()
+    _start_wrapper(team_file, team, prefix, target, python)
+    print(f"Restarted {target}: wrapper={wrapper_session}, agent={live_session}")
+
+
+def logs(args) -> None:
+    _check_tmux()
+    _team_file, _team, _name, prefix, _port, agents = _project_context(args)
+    target = (args.target or "").strip()
+    if not target:
+        print("logs requires a target: server, <agent>, wrapper:<agent>, or raw tmux session")
+        raise SystemExit(2)
+    session = _resolve_target_session(prefix, agents, target)
+    if not _tmux_session_exists(session):
+        raise SystemExit(f"tmux session not found: {session}")
+    lines = max(1, int(args.lines or 200))
+    result = subprocess.run(
+        ["tmux", "capture-pane", "-p", "-t", session, "-S", f"-{lines}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip() or f"failed to capture logs from {session}")
+    print(result.stdout.rstrip())
+
+
+def list_projects(_args) -> None:
+    paths = discover_team_files(ROOT)
+    if not paths:
+        print("No team files found under teams/*.toml or projects/*.toml.")
+        return
+    print(f"{'Project':<22} {'Port':<7} {'Tmux prefix':<28} Team file")
+    for path in paths:
+        try:
+            team = load_project_config_file(path, ROOT)
+            name = _project_name(path.stem, team, path)
+            port = _server_port(team)
+            prefix = _tmux_prefix(path.stem, team, path)
+            print(f"{name:<22} {port:<7} {prefix:<28} {path}")
+        except ConfigError as exc:
+            print(f"{path.stem:<22} {'error':<7} {'invalid':<28} {path} ({exc})")
 
 
 def _print_attach_help(prefix: str, agents: list[str]) -> None:
@@ -247,8 +444,7 @@ def status(args) -> None:
     print(f"Server: {'running' if server_session in sessions else 'stopped'} ({server_session})")
     print("Agent sessions:")
     for agent in agents:
-        agent_session = f"{prefix}-{agent}"
-        wrapper_session = f"{prefix}-wrap-{_slug(agent)}"
+        agent_session, wrapper_session = _agent_sessions(prefix, agent)
         agent_state = "running" if agent_session in sessions else "stopped"
         wrapper_state = "wrapper running" if wrapper_session in sessions else "wrapper stopped"
         print(f"  {agent:<16} {agent_state:<8} {agent_session}  ({wrapper_state})")
@@ -274,15 +470,7 @@ def attach(args) -> None:
         _print_attach_help(prefix, agents)
         raise SystemExit(2)
 
-    if target == "server":
-        session = f"{prefix}-server"
-    elif target.startswith(("wrapper:", "wrap:")):
-        agent = target.split(":", 1)[1]
-        session = f"{prefix}-wrap-{_slug(agent)}"
-    elif target in agents:
-        session = f"{prefix}-{target}"
-    else:
-        session = target
+    session = _resolve_target_session(prefix, agents, target)
 
     if not _tmux_session_exists(session):
         print(f"tmux session not found: {session}")
@@ -295,11 +483,20 @@ def attach(args) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Start/stop project-specific agentchattr teams.")
-    parser.add_argument("project", help="Project name or path to a team TOML file")
-    parser.add_argument("action", choices=("up", "down", "status", "attach"))
-    parser.add_argument("target", nargs="?", help="Attach target: agent name, server, or wrapper:<agent>")
+    parser.add_argument("project", nargs="?", help="Project name or path to a team TOML file, or 'list'")
+    parser.add_argument("action", nargs="?", choices=("up", "down", "status", "attach", "restart", "logs"))
+    parser.add_argument("target", nargs="?", help="Target: agent name, server, wrapper:<agent>, or raw tmux session")
     parser.add_argument("-f", "--file", help="Explicit team TOML file")
+    parser.add_argument("--dry-run", action="store_true", help="For up: print sessions, ports, paths, and commands without starting anything")
+    parser.add_argument("--lines", type=int, default=200, help="For logs: number of pane lines to capture")
     args = parser.parse_args()
+
+    if args.project == "list" and args.action is None:
+        list_projects(args)
+        return
+    if not args.project or not args.action:
+        parser.print_help()
+        raise SystemExit(2)
 
     if args.action == "up":
         up(args)
@@ -307,6 +504,10 @@ def main() -> None:
         down(args)
     elif args.action == "attach":
         attach(args)
+    elif args.action == "restart":
+        restart(args)
+    elif args.action == "logs":
+        logs(args)
     else:
         status(args)
 

--- a/ac
+++ b/ac
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""agentchattr project/team runner.
+
+Usage:
+    ./ac project-a up
+    ./ac project-a status
+    ./ac project-a attach architect
+    ./ac project-a down
+
+By default, project-a resolves to teams/project-a.toml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_.-]+", "-", value.strip()).strip("-")
+    return slug or "default"
+
+
+def _find_team_file(project: str, explicit: str | None = None) -> Path:
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit))
+    else:
+        raw = Path(project)
+        if raw.suffix == ".toml" or raw.exists():
+            candidates.append(raw)
+        candidates.extend([
+            ROOT / "teams" / f"{project}.toml",
+            ROOT / "projects" / f"{project}.toml",
+            ROOT / f"{project}.toml",
+        ])
+
+    for candidate in candidates:
+        candidate = candidate.expanduser()
+        if not candidate.is_absolute():
+            candidate = (Path.cwd() / candidate).resolve()
+        if candidate.exists():
+            return candidate
+
+    searched = "\n  ".join(str(c) for c in candidates)
+    raise SystemExit(f"Team file not found. Searched:\n  {searched}")
+
+
+def _load_toml(path: Path) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _project_name(project_arg: str, team: dict, path: Path) -> str:
+    project = team.get("project", {})
+    return str(project.get("name") or project_arg or path.stem)
+
+
+def _tmux_prefix(project_arg: str, team: dict, path: Path) -> str:
+    project = team.get("project", {})
+    explicit = project.get("tmux_prefix")
+    if explicit:
+        return _slug(str(explicit))
+    return f"agentchattr-{_slug(_project_name(project_arg, team, path))}"
+
+
+def _server_port(team: dict) -> int:
+    return int(team.get("server", {}).get("port", 8300))
+
+
+def _agent_names(team: dict) -> list[str]:
+    agents = team.get("agents", {})
+    if not isinstance(agents, dict) or not agents:
+        raise SystemExit("Team file must define at least one [agents.<name>] entry.")
+    return list(agents.keys())
+
+
+def _agent_is_api(team: dict, agent: str) -> bool:
+    cfg = team.get("agents", {}).get(agent, {})
+    return str(cfg.get("type", "")).lower() == "api"
+
+
+def _check_tmux() -> None:
+    if shutil.which("tmux"):
+        return
+    raise SystemExit("tmux is required. Install it first, then retry.")
+
+
+def _tmux_session_exists(name: str) -> bool:
+    result = subprocess.run(["tmux", "has-session", "-t", name], capture_output=True)
+    return result.returncode == 0
+
+
+def _tmux_sessions() -> list[str]:
+    result = subprocess.run(
+        ["tmux", "list-sessions", "-F", "#{session_name}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _start_tmux_session(name: str, command: str) -> None:
+    subprocess.check_call([
+        "tmux", "new-session", "-d", "-s", name, "-c", str(ROOT), command,
+    ])
+
+
+def _kill_tmux_session(name: str) -> None:
+    subprocess.run(["tmux", "kill-session", "-t", name], capture_output=True)
+
+
+def _port_open(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.2)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _wait_for_port(port: int, timeout: float = 30.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _port_open(port):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def _ensure_venv() -> Path:
+    venv_python = ROOT / ".venv" / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+    if venv_python.exists():
+        return venv_python
+
+    print("Creating .venv and installing dependencies...")
+    subprocess.check_call([sys.executable, "-m", "venv", str(ROOT / ".venv")])
+    subprocess.check_call([
+        str(venv_python), "-m", "pip", "install", "-q", "-r", str(ROOT / "requirements.txt"),
+    ])
+    return venv_python
+
+
+def _env_for_project(team_file: Path, prefix: str) -> dict[str, str]:
+    env = dict(os.environ)
+    env["AGENTCHATTR_PROJECT_CONFIG"] = str(team_file)
+    env["AGENTCHATTR_TMUX_PREFIX"] = prefix
+    return env
+
+
+def _shell_command(env: dict[str, str], args: list[str]) -> str:
+    env_keys = ["AGENTCHATTR_PROJECT_CONFIG", "AGENTCHATTR_TMUX_PREFIX"]
+    env_parts = [f"{key}={shlex.quote(env[key])}" for key in env_keys if key in env]
+    return "env " + " ".join(env_parts + [shlex.quote(str(arg)) for arg in args])
+
+
+def _project_context(args) -> tuple[Path, dict, str, str, int, list[str]]:
+    team_file = _find_team_file(args.project, args.file)
+    team = _load_toml(team_file)
+    name = _project_name(args.project, team, team_file)
+    prefix = _tmux_prefix(args.project, team, team_file)
+    port = _server_port(team)
+    agents = _agent_names(team)
+    return team_file, team, name, prefix, port, agents
+
+
+def up(args) -> None:
+    if sys.platform == "win32":
+        raise SystemExit("ac project up currently supports tmux-based Mac/Linux launches.")
+
+    _check_tmux()
+    team_file, team, name, prefix, port, agents = _project_context(args)
+    python = _ensure_venv()
+    env = _env_for_project(team_file, prefix)
+
+    server_session = f"{prefix}-server"
+    if _tmux_session_exists(server_session):
+        print(f"Server already running: {server_session}")
+    elif _port_open(port):
+        print(f"Port {port} is already listening; leaving server tmux session stopped.")
+    else:
+        command = _shell_command(env, [python, "run.py"])
+        _start_tmux_session(server_session, command)
+        print(f"Started server: {server_session}")
+        if not _wait_for_port(port):
+            raise SystemExit(f"Server did not start on port {port}. Check: tmux attach -t {server_session}")
+
+    for agent in agents:
+        wrapper_session = f"{prefix}-wrap-{_slug(agent)}"
+        if _tmux_session_exists(wrapper_session):
+            print(f"Agent wrapper already running: {wrapper_session}")
+            continue
+
+        wrapper = "wrapper_api.py" if _agent_is_api(team, agent) else "wrapper.py"
+        cmd_args = [python, wrapper, agent]
+        if wrapper == "wrapper.py":
+            cmd_args.extend(["--detach", "--tmux-prefix", prefix])
+        command = _shell_command(env, cmd_args)
+        _start_tmux_session(wrapper_session, command)
+        print(f"Started {agent}: wrapper={wrapper_session}, agent={prefix}-{agent}")
+
+    print(f"\n{name} is up: http://127.0.0.1:{port}")
+    print(f"Team file: {team_file}")
+    print(f"Sessions: tmux list-sessions | grep {shlex.quote(prefix)}")
+
+
+def down(args) -> None:
+    _check_tmux()
+    team_file, team, name, prefix, _port, _agents = _project_context(args)
+    matches = [s for s in _tmux_sessions() if s == prefix or s.startswith(prefix + "-")]
+    if not matches:
+        print(f"No tmux sessions found for {name} ({prefix}).")
+        return
+    for session in sorted(matches, reverse=True):
+        _kill_tmux_session(session)
+        print(f"Stopped {session}")
+
+
+def _print_attach_help(prefix: str, agents: list[str]) -> None:
+    print("Attach targets:")
+    print(f"  server            tmux attach -t {prefix}-server")
+    for agent in agents:
+        print(f"  {agent:<16} tmux attach -t {prefix}-{agent}")
+    print()
+    print("Wrapper supervisor sessions are available as wrapper:<agent> when debugging orchestration.")
+
+
+def status(args) -> None:
+    _check_tmux()
+    team_file, team, name, prefix, port, agents = _project_context(args)
+    sessions = [s for s in _tmux_sessions() if s == prefix or s.startswith(prefix + "-")]
+    print(f"{name}")
+    print(f"Team file: {team_file}")
+    print(f"Web UI: http://127.0.0.1:{port} ({'listening' if _port_open(port) else 'not listening'})")
+    server_session = f"{prefix}-server"
+    print(f"Server: {'running' if server_session in sessions else 'stopped'} ({server_session})")
+    print("Agent sessions:")
+    for agent in agents:
+        agent_session = f"{prefix}-{agent}"
+        wrapper_session = f"{prefix}-wrap-{_slug(agent)}"
+        agent_state = "running" if agent_session in sessions else "stopped"
+        wrapper_state = "wrapper running" if wrapper_session in sessions else "wrapper stopped"
+        print(f"  {agent:<16} {agent_state:<8} {agent_session}  ({wrapper_state})")
+    extra = sorted(
+        s for s in sessions
+        if s != server_session
+        and not any(s == f"{prefix}-{agent}" or s == f"{prefix}-wrap-{_slug(agent)}" for agent in agents)
+    )
+    if extra:
+        print("Other sessions:")
+        for session in extra:
+            print(f"  {session}")
+    print()
+    print(f"Attach: ./ac {args.project} attach <agent>")
+
+
+def attach(args) -> None:
+    _check_tmux()
+    _team_file, _team, name, prefix, _port, agents = _project_context(args)
+    target = (args.target or "").strip()
+    if not target:
+        print(f"{name}")
+        _print_attach_help(prefix, agents)
+        raise SystemExit(2)
+
+    if target == "server":
+        session = f"{prefix}-server"
+    elif target.startswith(("wrapper:", "wrap:")):
+        agent = target.split(":", 1)[1]
+        session = f"{prefix}-wrap-{_slug(agent)}"
+    elif target in agents:
+        session = f"{prefix}-{target}"
+    else:
+        session = target
+
+    if not _tmux_session_exists(session):
+        print(f"tmux session not found: {session}")
+        print()
+        _print_attach_help(prefix, agents)
+        raise SystemExit(1)
+
+    subprocess.call(["tmux", "attach-session", "-t", session])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Start/stop project-specific agentchattr teams.")
+    parser.add_argument("project", help="Project name or path to a team TOML file")
+    parser.add_argument("action", choices=("up", "down", "status", "attach"))
+    parser.add_argument("target", nargs="?", help="Attach target: agent name, server, or wrapper:<agent>")
+    parser.add_argument("-f", "--file", help="Explicit team TOML file")
+    args = parser.parse_args()
+
+    if args.action == "up":
+        up(args)
+    elif args.action == "down":
+        down(args)
+    elif args.action == "attach":
+        attach(args)
+    else:
+        status(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/app.py
+++ b/app.py
@@ -1244,7 +1244,7 @@ async def websocket_endpoint(websocket: WebSocket):
                 if "max_agent_hops" in new:
                     try:
                         hops = int(new["max_agent_hops"])
-                        hops = max(1, min(hops, 50))
+                        hops = max(1, min(hops, 100))
                         room_settings["max_agent_hops"] = hops
                         router.max_hops = hops
                     except (ValueError, TypeError):
@@ -2093,6 +2093,9 @@ async def register_agent(request: Request):
         return JSONResponse({"error": f"unknown base: {base}"}, status_code=400)
     # Touch presence so the instance doesn't immediately time out
     import mcp_bridge
+    seeded_role = str(config.get("agents", {}).get(base, {}).get("role", "")).strip()[:20]
+    if seeded_role:
+        mcp_bridge.set_role(result["name"], seeded_role)
     with mcp_bridge._presence_lock:
         mcp_bridge._presence[result["name"]] = __import__("time").time()
     # If slot 1 was renamed (e.g. "claude" → "claude-1"), migrate state

--- a/app.py
+++ b/app.py
@@ -2,9 +2,14 @@
 
 import asyncio
 import json
+import os
 import re as _re
+import shlex
+import shutil
+import subprocess
 import sys
 import threading
+import time
 import uuid
 import logging
 from pathlib import Path
@@ -24,6 +29,7 @@ from agents import AgentTrigger
 from registry import RuntimeRegistry
 from session_store import SessionStore, validate_session_template
 from session_engine import SessionEngine
+from config_loader import PROJECT_CONFIG_ENV, TMUX_PREFIX_ENV
 
 log = logging.getLogger(__name__)
 
@@ -54,11 +60,12 @@ room_settings: dict = {
     "channels": ["general"],
     "history_limit": "all",
     "contrast": "normal",
+    "max_agent_hops": 100,
     "custom_roles": [],
 }
 
 # Channel validation
-_CHANNEL_NAME_RE = _re.compile(r'^[a-z0-9][a-z0-9\-]{0,19}$')
+_CHANNEL_NAME_RE = _re.compile(r'^[a-z0-9][a-z0-9\-]{0,23}$')
 MAX_CHANNELS = 8
 
 # Agent hats (persisted to data/hats.json)
@@ -133,11 +140,15 @@ def _load_settings():
             room_settings.update(saved)
         except Exception:
             pass
+    if room_settings.get("settings_version") is None and room_settings.get("max_agent_hops") == 4:
+        room_settings["max_agent_hops"] = 100
+    room_settings["settings_version"] = 2
     # Ensure "general" always exists and is first
     if "channels" not in room_settings or not room_settings["channels"]:
         room_settings["channels"] = ["general"]
     elif "general" not in room_settings["channels"]:
         room_settings["channels"].insert(0, "general")
+    room_settings.setdefault("max_agent_hops", 100)
 
 
 def _save_settings():
@@ -271,7 +282,7 @@ def configure(cfg: dict, session_token: str = ""):
     schedules = ScheduleStore(str(Path(data_dir) / "schedules.json"))
     schedules.on_change(_on_schedule_change)
 
-    max_hops = cfg.get("routing", {}).get("max_agent_hops", 4)
+    max_hops = cfg.get("routing", {}).get("max_agent_hops", 100)
 
     # Registry: single source of truth for all live agent state
     registry = RuntimeRegistry(data_dir=data_dir)
@@ -650,9 +661,9 @@ async def _handle_new_message(msg: dict):
     global _last_active_channel
     if msg_type not in ("system", "leave", "join"):
         _last_active_channel = channel
-    # Strip @mentions to find the slash command (e.g. "@claude @codex /hatmaking")
+    # Strip @mentions to find the slash command (e.g. "@claude @codex /roastreview")
     stripped = _re.sub(r"@[\w-]+\s*", "", text).strip().lower()
-    _broadcast_cmds = ("/hatmaking", "/artchallenge", "/roastreview", "/poetry")
+    _broadcast_cmds = ("/roastreview",)
     cmd_word = stripped.split()[0] if stripped else ""
     is_broadcast_cmd = cmd_word in _broadcast_cmds
     known_agents = set(registry.get_all_names()) if registry else set()
@@ -696,56 +707,6 @@ async def _handle_new_message(msg: dict):
         agent_names = registry.get_all_names() if registry else list(config.get("agents", {}).keys())
         mentions = " ".join(f"@{a}" for a in agent_names)
         store.add(sender, f"{mentions} Time for a roast review! Inspect each other's work and constructively roast it.", channel=channel)
-        return
-
-    if stripped.startswith("/artchallenge"):
-        parts = stripped.split(None, 1)
-        theme = parts[1] if len(parts) > 1 else "anything you like"
-        agent_names = registry.get_all_names() if registry else list(config.get("agents", {}).keys())
-        mentions = " ".join(f"@{a}" for a in agent_names)
-        store.add(
-            sender,
-            f"{mentions} Art challenge! Create an SVG artwork with the theme: **{theme}**. "
-            "Write your SVG code to a .svg file, then attach it using chat_send(image_path=...). "
-            "Make it creative, keep it under 5KB. Let's see what you've got!",
-            channel=channel,
-        )
-        return
-
-    if stripped == "/hatmaking":
-        agent_names = registry.get_all_names() if registry else list(config.get("agents", {}).keys())
-        mentions = " ".join(f"@{a}" for a in agent_names)
-        all_instances = registry.get_all() if registry else {}
-        agents_cfg = config.get("agents", {})
-        color_parts = ", ".join(
-            f"{a}={all_instances[a]['color']}" if a in all_instances
-            else f"{a}={agents_cfg.get(a, {}).get('color', '#888')}"
-            for a in agent_names
-        )
-        store.add(
-            sender,
-            f"{mentions} Hat making time! Design a new hat for your avatar using SVG. "
-            "Use viewBox=\"0 0 32 16\" so it fits on top of a 32px avatar circle. "
-            f"Background is dark (#0f0f17). Avatar colors: {color_parts}. Design for good contrast! "
-            "Call chat_set_hat(sender=your_name, svg='<svg ...>...</svg>') to wear it. "
-            "Be creative — top hats, party hats, crowns, propeller beanies, whatever you want!",
-            channel=channel,
-        )
-        return
-
-    if stripped.startswith("/poetry"):
-        parts = stripped.split(None, 1)
-        form = parts[1] if len(parts) > 1 else "haiku"
-        if form not in ("haiku", "limerick", "sonnet"):
-            form = "haiku"
-        agent_names = registry.get_all_names() if registry else list(config.get("agents", {}).keys())
-        mentions = " ".join(f"@{a}" for a in agent_names)
-        prompts = {
-            "haiku": "Write a haiku about the current state of this codebase.",
-            "limerick": "Write a limerick about the current state of this codebase.",
-            "sonnet": "Write a sonnet about the current state of this codebase.",
-        }
-        store.add(sender, f"{mentions} {prompts[form]}", channel=channel)
         return
 
     # Detect session draft blocks from agents only.
@@ -1008,6 +969,206 @@ def _on_registry_change():
         asyncio.run_coroutine_threadsafe(broadcast_status(), _event_loop)
 
 
+def _slug(value: str) -> str:
+    value = _re.sub(r"[^a-zA-Z0-9_.-]+", "-", value.strip()).strip("-")
+    return value or "default"
+
+
+def _runtime_path(raw: str) -> str:
+    path = Path(str(raw)).expanduser()
+    if not path.is_absolute():
+        path = (Path(__file__).parent / path).resolve()
+    return str(path)
+
+
+def _project_name_from_config() -> str:
+    project = config.get("project", {}) if isinstance(config.get("project", {}), dict) else {}
+    return str(project.get("name") or project.get("title") or "agentchattr")
+
+
+def _tmux_prefix_from_config() -> str:
+    env_prefix = os.environ.get(TMUX_PREFIX_ENV, "").strip()
+    if env_prefix:
+        return env_prefix
+    project = config.get("project", {}) if isinstance(config.get("project", {}), dict) else {}
+    explicit = str(project.get("tmux_prefix", "")).strip()
+    if explicit:
+        return explicit
+    return f"agentchattr-{_slug(_project_name_from_config())}"
+
+
+def _project_payload() -> dict:
+    project = config.get("project", {}) if isinstance(config.get("project", {}), dict) else {}
+    server = config.get("server", {}) if isinstance(config.get("server", {}), dict) else {}
+    mcp = config.get("mcp", {}) if isinstance(config.get("mcp", {}), dict) else {}
+    images = config.get("images", {}) if isinstance(config.get("images", {}), dict) else {}
+    team_file = config.get("_meta", {}).get("project_config_path") or os.environ.get(PROJECT_CONFIG_ENV) or None
+    name = _project_name_from_config()
+    title = str(project.get("title") or name)
+    theme = config.get("theme", {}) if isinstance(config.get("theme", {}), dict) else {}
+    return {
+        "name": name,
+        "title": title,
+        "accent_color": project.get("accent_color") or theme.get("accent_color") or "#7c3aed",
+        "repo_url": project.get("repo_url") or project.get("github_url") or "",
+        "board_url": project.get("board_url") or project.get("github_project_url") or "",
+        "link_label": project.get("link_label") or "",
+        "link_url": project.get("link_url") or "",
+        "team_file": str(team_file) if team_file else None,
+        "tmux_prefix": _tmux_prefix_from_config(),
+        "server": {
+            "host": server.get("host", "127.0.0.1"),
+            "port": int(server.get("port", 8300)),
+        },
+        "mcp": {
+            "http_port": int(mcp.get("http_port", 8200)),
+            "sse_port": int(mcp.get("sse_port", 8201)),
+        },
+        "data_dir": _runtime_path(server.get("data_dir", "./data")),
+        "upload_dir": _runtime_path(images.get("upload_dir", "./uploads")),
+    }
+
+
+def _tmux_sessions() -> set[str]:
+    if not shutil.which("tmux"):
+        return set()
+    result = subprocess.run(
+        ["tmux", "list-sessions", "-F", "#{session_name}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return set()
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def _agent_ops_payload() -> dict:
+    import mcp_bridge
+
+    now = time.time()
+    project = _project_payload()
+    prefix = project["tmux_prefix"]
+    sessions = _tmux_sessions()
+    configured_cfg = config.get("agents", {}) if isinstance(config.get("agents", {}), dict) else {}
+    registered = registry.get_all() if registry else {}
+    status = agents.get_status() if agents else {}
+    registered_by_base: dict[str, list[str]] = {}
+    for name, info in registered.items():
+        registered_by_base.setdefault(info.get("base", name), []).append(name)
+
+    with mcp_bridge._presence_lock:
+        presence = dict(mcp_bridge._presence)
+        activity = dict(mcp_bridge._activity)
+
+    configured = []
+    for name, cfg in configured_cfg.items():
+        live_session = f"{prefix}-{name}"
+        wrapper_session = f"{prefix}-wrap-{_slug(name)}"
+        registered_names = registered_by_base.get(name, [])
+        heartbeat_ages = [
+            now - presence[n]
+            for n in registered_names
+            if n in presence
+        ]
+        heartbeat_age = min(heartbeat_ages) if heartbeat_ages else None
+        online = any(status.get(n, {}).get("available") for n in registered_names)
+        busy = any(status.get(n, {}).get("busy") for n in registered_names)
+        wrapper_running = wrapper_session in sessions
+        configured.append({
+            "name": name,
+            "label": cfg.get("label", name),
+            "provider": cfg.get("provider") or ("api" if cfg.get("type") == "api" else cfg.get("command", "")),
+            "command": cfg.get("command", ""),
+            "type": cfg.get("type", "cli"),
+            "role": cfg.get("role", ""),
+            "color": cfg.get("color", "#888"),
+            "registered_names": registered_names,
+            "online": bool(online),
+            "busy": bool(busy),
+            "heartbeat_age": heartbeat_age,
+            "tmux": {
+                "live_session": live_session,
+                "wrapper_session": wrapper_session,
+                "live_running": live_session in sessions,
+                "wrapper_running": wrapper_running,
+            },
+            "attach": {
+                "live": f"tmux attach -t {shlex.quote(live_session)}",
+                "wrapper": f"tmux attach -t {shlex.quote(wrapper_session)}",
+            },
+            "mismatches": {
+                "configured_not_registered": not registered_names,
+                "wrapper_running_without_live_heartbeat": wrapper_running and not online,
+            },
+        })
+
+    registered_rows = []
+    for name, info in registered.items():
+        base = info.get("base", name)
+        live_session = f"{prefix}-{name}"
+        state = status.get(name, {})
+        heartbeat_age = now - presence[name] if name in presence else None
+        registered_rows.append({
+            "name": name,
+            "base": base,
+            "label": info.get("label", state.get("label", name)),
+            "role": state.get("role", ""),
+            "color": info.get("color", state.get("color", "#888")),
+            "state": info.get("state", ""),
+            "online": bool(state.get("available")),
+            "busy": bool(state.get("busy") or activity.get(name)),
+            "heartbeat_age": heartbeat_age,
+            "tmux": {
+                "live_session": live_session,
+                "live_running": live_session in sessions,
+            },
+            "attach": {
+                "live": f"tmux attach -t {shlex.quote(live_session)}",
+            },
+            "mismatches": {
+                "registered_not_configured": base not in configured_cfg,
+            },
+        })
+
+    service_badges = [
+        {
+            "name": "server",
+            "label": "Server",
+            "status": "running",
+            "detail": f"{project['server']['host']}:{project['server']['port']}",
+            "tmux_session": f"{prefix}-server",
+            "tmux_running": f"{prefix}-server" in sessions,
+        },
+        {
+            "name": "mcp-http",
+            "label": "MCP HTTP",
+            "status": "configured",
+            "detail": str(project["mcp"]["http_port"]),
+        },
+        {
+            "name": "mcp-sse",
+            "label": "MCP SSE",
+            "status": "configured",
+            "detail": str(project["mcp"]["sse_port"]),
+        },
+    ]
+    return {
+        "project": project,
+        "service_badges": service_badges,
+        "configured_agents": configured,
+        "registered_agents": registered_rows,
+        "tmux_sessions": sorted(s for s in sessions if s == prefix or s.startswith(prefix + "-")),
+        "mismatches": {
+            "configured_not_registered": [row["name"] for row in configured if row["mismatches"]["configured_not_registered"]],
+            "registered_not_configured": [row["name"] for row in registered_rows if row["mismatches"]["registered_not_configured"]],
+            "wrapper_running_without_live_heartbeat": [
+                row["name"] for row in configured
+                if row["mismatches"]["wrapper_running_without_live_heartbeat"]
+            ],
+        },
+    }
+
+
 # --- WebSocket ---
 
 @app.websocket("/ws")
@@ -1110,7 +1271,7 @@ async def websocket_endpoint(websocket: WebSocket):
                         continue
                     # Broadcast slash commands — expand without storing the raw command.
                     # _handle_new_message will store the expanded version.
-                    if cmd in ("/hatmaking", "/artchallenge", "/roastreview", "/poetry"):
+                    if cmd == "/roastreview":
                         await _handle_new_message({"sender": sender, "text": text, "channel": channel})
                         continue
 
@@ -1537,6 +1698,16 @@ async def get_status():
     status = agents.get_status()
     status["paused"] = any(router.is_paused(ch) for ch in room_settings.get("channels", ["general"]))
     return status
+
+
+@app.get("/api/project")
+async def get_project():
+    return _project_payload()
+
+
+@app.get("/api/agent-ops")
+async def get_agent_ops():
+    return _agent_ops_payload()
 
 
 @app.get("/api/settings")

--- a/config.toml
+++ b/config.toml
@@ -80,7 +80,7 @@ temperature = 1.0
 [routing]
 # "none" = only route on explicit @mention. "all" = route to all agents by default.
 default = "none"
-max_agent_hops = 4
+max_agent_hops = 100
 
 [mcp]
 http_port = 8200

--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,10 @@
+[project]
+name = "agentchattr"
+title = "agentchattr"
+accent_color = "#7c3aed"
+repo_url = "https://github.com/the-sarge/agentchattr"
+board_url = "https://github.com/orgs/the-sarge/projects/1"
+
 [server]
 port = 8300
 host = "127.0.0.1"

--- a/config_loader.py
+++ b/config_loader.py
@@ -20,12 +20,19 @@ install directory.
 """
 
 import os
+import re
 import sys
 import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).parent
 PROJECT_CONFIG_ENV = "AGENTCHATTR_PROJECT_CONFIG"
+TMUX_PREFIX_ENV = "AGENTCHATTR_TMUX_PREFIX"
+MAX_ROLE_LEN = 20
+
+
+class ConfigError(ValueError):
+    """Raised when a config or team file is structurally invalid."""
 
 _PROVIDER_COMMANDS = {
     "claude": "claude",
@@ -37,6 +44,9 @@ _PROVIDER_COMMANDS = {
     "codebuddy": "codebuddy",
     "copilot": "copilot",
 }
+_KNOWN_PROVIDERS = set(_PROVIDER_COMMANDS)
+_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+_AGENT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 
 
 # Mapping: env var name → (config section, key, is_int)
@@ -130,17 +140,256 @@ def _merge_project_config(config: dict, project_config: dict) -> None:
             config[section] = value
 
 
+def _resolve_project_config_path(raw: str) -> Path:
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    return path
+
+
 def _load_project_config(config: dict) -> None:
     raw = os.environ.get(PROJECT_CONFIG_ENV, "").strip()
     if not raw:
         return
 
-    path = Path(raw).expanduser()
-    if not path.is_absolute():
-        path = (Path.cwd() / path).resolve()
+    path = _resolve_project_config_path(raw)
     with open(path, "rb") as f:
         project_config = tomllib.load(f)
+    validate_config(project_config, source=path, require_project=False, check_known_files=False)
     _merge_project_config(config, project_config)
+    config.setdefault("_meta", {})["project_config_path"] = str(path)
+
+
+def _apply_agent_defaults(config: dict) -> None:
+    """Merge [agent_defaults.<provider>] into matching agents."""
+    defaults = config.get("agent_defaults", {})
+    agents = config.get("agents", {})
+    if not isinstance(defaults, dict) or not isinstance(agents, dict):
+        return
+
+    for name, cfg in list(agents.items()):
+        if not isinstance(cfg, dict):
+            continue
+        provider = str(cfg.get("provider", "")).strip().lower()
+        if not provider and str(cfg.get("type", "")).strip().lower() == "api":
+            provider = "api"
+        provider_defaults = defaults.get(provider)
+        if isinstance(provider_defaults, dict):
+            agents[name] = {**provider_defaults, **cfg}
+
+
+def discover_team_files(root: Path | None = None) -> list[Path]:
+    """Return known project/team TOML files under teams/ and projects/."""
+    root = root or ROOT
+    paths: list[Path] = []
+    for dirname in ("teams", "projects"):
+        directory = root / dirname
+        if directory.exists():
+            paths.extend(sorted(directory.glob("*.toml")))
+    return paths
+
+
+def _port_value(section: dict, key: str, label: str, errors: list[str]) -> int | None:
+    value = section.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        errors.append(f"{label} must be an integer")
+        return None
+    if not (1 <= value <= 65535):
+        errors.append(f"{label} must be between 1 and 65535")
+        return None
+    return value
+
+
+def _validate_color(value, label: str, errors: list[str]) -> None:
+    if value is None:
+        return
+    if not isinstance(value, str) or not _HEX_COLOR_RE.match(value):
+        errors.append(f"{label} must be a #RRGGBB hex color")
+
+
+def _validate_agent(name: str, cfg, errors: list[str]) -> None:
+    if not _AGENT_NAME_RE.match(str(name)):
+        errors.append(f"[agents.{name}] has an invalid handle; use letters, numbers, _ or -")
+    if not isinstance(cfg, dict):
+        errors.append(f"[agents.{name}] must be a table")
+        return
+
+    agent_type = str(cfg.get("type", "")).strip().lower()
+    provider = str(cfg.get("provider", "")).strip().lower()
+    command = cfg.get("command")
+    if agent_type and agent_type != "api":
+        errors.append(f"[agents.{name}].type must be \"api\" when set")
+    if provider and provider not in _KNOWN_PROVIDERS:
+        errors.append(f"[agents.{name}].provider has unknown provider {provider!r}")
+    if command is not None and (not isinstance(command, str) or not command.strip()):
+        errors.append(f"[agents.{name}].command must be a non-empty string")
+    if agent_type != "api" and not provider and command is None:
+        errors.append(f"[agents.{name}] must define provider or command")
+    if agent_type == "api":
+        if not isinstance(cfg.get("base_url"), str) or not cfg.get("base_url", "").strip():
+            errors.append(f"[agents.{name}].base_url is required for API agents")
+
+    _validate_color(cfg.get("color"), f"[agents.{name}].color", errors)
+
+    role = cfg.get("role")
+    if role is not None:
+        if not isinstance(role, str):
+            errors.append(f"[agents.{name}].role must be a string")
+        elif len(role.strip()) > MAX_ROLE_LEN:
+            errors.append(f"[agents.{name}].role must be {MAX_ROLE_LEN} characters or fewer")
+
+    args = cfg.get("args")
+    if args is not None:
+        if not isinstance(args, list) or any(not isinstance(arg, str) for arg in args):
+            errors.append(f"[agents.{name}].args must be a list of strings")
+
+
+def _validate_agent_defaults(config: dict, errors: list[str]) -> None:
+    defaults = config.get("agent_defaults", {})
+    if defaults is None:
+        return
+    if not isinstance(defaults, dict):
+        errors.append("[agent_defaults] must be a table")
+        return
+    for provider, cfg in defaults.items():
+        provider_name = str(provider).strip().lower()
+        if provider_name != "api" and provider_name not in _KNOWN_PROVIDERS:
+            errors.append(f"[agent_defaults.{provider}] has unknown provider")
+        if not isinstance(cfg, dict):
+            errors.append(f"[agent_defaults.{provider}] must be a table")
+            continue
+        command = cfg.get("command")
+        if command is not None and (not isinstance(command, str) or not command.strip()):
+            errors.append(f"[agent_defaults.{provider}].command must be a non-empty string")
+        _validate_color(cfg.get("color"), f"[agent_defaults.{provider}].color", errors)
+        role = cfg.get("role")
+        if role is not None:
+            if not isinstance(role, str):
+                errors.append(f"[agent_defaults.{provider}].role must be a string")
+            elif len(role.strip()) > MAX_ROLE_LEN:
+                errors.append(f"[agent_defaults.{provider}].role must be {MAX_ROLE_LEN} characters or fewer")
+        args = cfg.get("args")
+        if args is not None and (not isinstance(args, list) or any(not isinstance(arg, str) for arg in args)):
+            errors.append(f"[agent_defaults.{provider}].args must be a list of strings")
+
+
+def validate_config(
+    config: dict,
+    *,
+    source: Path | str = "config",
+    require_project: bool = False,
+    check_known_files: bool = False,
+    root: Path | None = None,
+) -> None:
+    """Validate the shared config shape."""
+    errors: list[str] = []
+    label = str(source)
+
+    if not isinstance(config, dict):
+        raise ConfigError(f"{label}: config must be a table")
+
+    project = config.get("project", {})
+    if project is None:
+        project = {}
+    if not isinstance(project, dict):
+        errors.append("[project] must be a table")
+        project = {}
+    if require_project and not str(project.get("tmux_prefix", "")).strip():
+        errors.append("[project].tmux_prefix is required in team files")
+    _validate_color(project.get("accent_color"), "[project].accent_color", errors)
+    for key in ("repo_url", "github_url", "board_url", "github_project_url", "link_label", "link_url"):
+        value = project.get(key)
+        if value is not None and not isinstance(value, str):
+            errors.append(f"[project].{key} must be a string")
+
+    server = config.get("server", {})
+    if not isinstance(server, dict):
+        errors.append("[server] must be a table")
+        server = {}
+    _port_value(server, "port", "[server].port", errors)
+
+    mcp = config.get("mcp", {})
+    if not isinstance(mcp, dict):
+        errors.append("[mcp] must be a table")
+        mcp = {}
+    _port_value(mcp, "http_port", "[mcp].http_port", errors)
+    _port_value(mcp, "sse_port", "[mcp].sse_port", errors)
+
+    agents = config.get("agents", {})
+    if not isinstance(agents, dict) or not agents:
+        errors.append("config must define at least one [agents.<name>] entry")
+    else:
+        for name, cfg in agents.items():
+            _validate_agent(str(name), cfg, errors)
+
+    _validate_agent_defaults(config, errors)
+
+    if errors:
+        joined = "\n  - ".join(errors)
+        raise ConfigError(f"{label} is invalid:\n  - {joined}")
+    if check_known_files:
+        validate_known_team_files(root=root or ROOT)
+
+
+def validate_known_team_files(root: Path | None = None) -> None:
+    """Validate known teams/projects for duplicate tmux prefixes and ports."""
+    root = root or ROOT
+    errors: list[str] = []
+    prefixes: dict[str, Path] = {}
+    ports: dict[int, tuple[Path, str]] = {}
+
+    for path in discover_team_files(root):
+        try:
+            with open(path, "rb") as f:
+                team = tomllib.load(f)
+            validate_config(team, source=path, require_project=True, check_known_files=False, root=root)
+        except (OSError, tomllib.TOMLDecodeError, ConfigError) as exc:
+            errors.append(str(exc))
+            continue
+
+        project = team.get("project", {}) if isinstance(team.get("project", {}), dict) else {}
+        prefix = str(project.get("tmux_prefix", "")).strip()
+        if prefix:
+            if prefix in prefixes:
+                errors.append(f"{path}: duplicate tmux_prefix {prefix!r} also used by {prefixes[prefix]}")
+            else:
+                prefixes[prefix] = path
+
+        for section, key, port in (
+            ("server", "port", team.get("server", {}).get("port") if isinstance(team.get("server"), dict) else None),
+            ("mcp", "http_port", team.get("mcp", {}).get("http_port") if isinstance(team.get("mcp"), dict) else None),
+            ("mcp", "sse_port", team.get("mcp", {}).get("sse_port") if isinstance(team.get("mcp"), dict) else None),
+        ):
+            if isinstance(port, int) and not isinstance(port, bool):
+                existing = ports.get(port)
+                port_label = f"[{section}].{key}"
+                if existing:
+                    errors.append(
+                        f"{path}: duplicate port {port} for {port_label}; "
+                        f"also used by {existing[0]} {existing[1]}"
+                    )
+                else:
+                    ports[port] = (path, port_label)
+
+    if errors:
+        joined = "\n  - ".join(errors)
+        raise ConfigError(f"Known team files are invalid:\n  - {joined}")
+
+
+def load_project_config_file(path: Path, root: Path | None = None) -> dict:
+    """Load the full config as if AGENTCHATTR_PROJECT_CONFIG pointed at path."""
+    root = root or ROOT
+    previous = os.environ.get(PROJECT_CONFIG_ENV)
+    os.environ[PROJECT_CONFIG_ENV] = str(path)
+    try:
+        return load_config(root)
+    finally:
+        if previous is None:
+            os.environ.pop(PROJECT_CONFIG_ENV, None)
+        else:
+            os.environ[PROJECT_CONFIG_ENV] = previous
 
 
 def _normalize_agent_defaults(config: dict) -> None:
@@ -191,7 +440,11 @@ def load_config(root: Path | None = None) -> dict:
                 print(f"  Warning: Ignoring local agent '{name}' (already defined in config.toml)")
 
     _load_project_config(config)
+    _apply_agent_defaults(config)
     _normalize_agent_defaults(config)
     _apply_env_overrides(config)
+    validate_config(config, source=config.get("_meta", {}).get("project_config_path", config_path))
+    if config.get("_meta", {}).get("project_config_path"):
+        validate_known_team_files(root)
 
     return config

--- a/config_loader.py
+++ b/config_loader.py
@@ -12,6 +12,7 @@ isolated instances per project without editing the repo's config file.
   AGENTCHATTR_MCP_HTTP_PORT   → mcp.http_port         (int)
   AGENTCHATTR_MCP_SSE_PORT    → mcp.sse_port          (int)
   AGENTCHATTR_UPLOAD_DIR      → images.upload_dir
+  AGENTCHATTR_PROJECT_CONFIG  → extra TOML config overlay for one project/team
 
 Relative paths in env var overrides resolve against the current working
 directory (where the user invoked the command from), not agentchattr's
@@ -24,6 +25,18 @@ import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).parent
+PROJECT_CONFIG_ENV = "AGENTCHATTR_PROJECT_CONFIG"
+
+_PROVIDER_COMMANDS = {
+    "claude": "claude",
+    "codex": "codex",
+    "gemini": "gemini",
+    "kimi": "kimi",
+    "qwen": "qwen",
+    "kilo": "kilo",
+    "codebuddy": "codebuddy",
+    "copilot": "copilot",
+}
 
 
 # Mapping: env var name → (config section, key, is_int)
@@ -100,6 +113,51 @@ def _apply_env_overrides(config: dict) -> None:
         config.setdefault(section, {})[key] = value
 
 
+def _merge_project_config(config: dict, project_config: dict) -> None:
+    """Merge a project/team config overlay into the base config.
+
+    Project configs intentionally replace the agent roster when they define
+    [agents.*]. That lets a team file be authoritative for "which agents should
+    exist for this project" instead of inheriting the default roster.
+    """
+    for section, value in project_config.items():
+        if section == "agents":
+            config["agents"] = dict(value)
+            continue
+        if isinstance(value, dict) and isinstance(config.get(section), dict):
+            config[section].update(value)
+        else:
+            config[section] = value
+
+
+def _load_project_config(config: dict) -> None:
+    raw = os.environ.get(PROJECT_CONFIG_ENV, "").strip()
+    if not raw:
+        return
+
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    with open(path, "rb") as f:
+        project_config = tomllib.load(f)
+    _merge_project_config(config, project_config)
+
+
+def _normalize_agent_defaults(config: dict) -> None:
+    """Fill implied fields for provider-based agent aliases.
+
+    Team configs commonly use a stable handle such as [agents.architect] with
+    provider = "claude". The wrapper still needs a concrete command, so infer
+    command = "claude" when it is not specified.
+    """
+    for cfg in config.get("agents", {}).values():
+        if not isinstance(cfg, dict):
+            continue
+        provider = str(cfg.get("provider", "")).strip().lower()
+        if provider and "command" not in cfg and provider in _PROVIDER_COMMANDS:
+            cfg["command"] = _PROVIDER_COMMANDS[provider]
+
+
 def load_config(root: Path | None = None) -> dict:
     """Load config.toml and merge config.local.toml if it exists.
 
@@ -132,6 +190,8 @@ def load_config(root: Path | None = None) -> dict:
             else:
                 print(f"  Warning: Ignoring local agent '{name}' (already defined in config.toml)")
 
+    _load_project_config(config)
+    _normalize_agent_defaults(config)
     _apply_env_overrides(config)
 
     return config

--- a/run.py
+++ b/run.py
@@ -44,7 +44,7 @@ def main():
     # wrappers use identical extraction logic.
     _parse_args()
 
-    from config_loader import apply_cli_overrides, load_config
+    from config_loader import ConfigError, apply_cli_overrides, load_config
     apply_cli_overrides()
 
     config_path = ROOT / "config.toml"
@@ -52,7 +52,11 @@ def main():
         print(f"Error: {config_path} not found")
         sys.exit(1)
 
-    config = load_config(ROOT)
+    try:
+        config = load_config(ROOT)
+    except ConfigError as exc:
+        print(f"Config error: {exc}")
+        sys.exit(1)
 
     # --- Security: generate a random session token (in-memory only) ---
     session_token = secrets.token_hex(32)

--- a/run.py
+++ b/run.py
@@ -80,6 +80,10 @@ def main():
     mcp_bridge._load_cursors()
     mcp_bridge._ROLES_FILE = data_dir / "roles.json"
     mcp_bridge._load_roles()
+    for name, agent_cfg in config.get("agents", {}).items():
+        role = str(agent_cfg.get("role", "")).strip()[:20]
+        if role:
+            mcp_bridge.set_role(name, role)
 
     # Start MCP servers in background threads
     http_port = config.get("mcp", {}).get("http_port", 8200)
@@ -164,4 +168,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/static/agent-ops.css
+++ b/static/agent-ops.css
@@ -1,0 +1,255 @@
+#agent-ops-panel {
+    --panel-w: 520px;
+    width: var(--panel-w);
+    min-width: 360px;
+    max-width: 62vw;
+    flex-shrink: 0;
+    background: var(--bg-header);
+    border-left: 1px solid var(--border-subtle);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    margin-right: 0;
+    transition: margin-right 0.25s ease, opacity 0.2s ease;
+}
+
+#agent-ops-panel.hidden {
+    margin-right: calc(-1 * var(--panel-w));
+    opacity: 0;
+    pointer-events: none;
+}
+
+.project-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 22px;
+    max-width: 220px;
+    padding: 3px 8px;
+    border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+    border-radius: var(--radius-md);
+    color: var(--text);
+    background: var(--accent-soft);
+    font-size: 12px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.project-badge.hidden { display: none; }
+
+.agent-ops-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border-subtle);
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.agent-ops-close {
+    border: 0;
+    background: transparent;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 20px;
+    line-height: 1;
+}
+
+.agent-ops-close:hover { color: var(--text); }
+
+.agent-ops-body {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 12px;
+    overflow-y: auto;
+}
+
+.agent-ops-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.agent-ops-section-title {
+    color: var(--text-dim);
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.agent-ops-services,
+.agent-ops-settings {
+    display: grid;
+    gap: 6px;
+}
+
+.agent-ops-service,
+.agent-ops-setting,
+.agent-ops-row {
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--white-03);
+}
+
+.agent-ops-service,
+.agent-ops-setting {
+    display: grid;
+    grid-template-columns: 86px minmax(0, 1fr);
+    gap: 10px;
+    padding: 8px 10px;
+    min-width: 0;
+}
+
+.agent-ops-name {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+}
+
+.agent-ops-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: var(--radius-full);
+    background: var(--text-dim);
+    flex-shrink: 0;
+}
+
+.agent-ops-dot.online { background: var(--online); }
+.agent-ops-dot.busy { background: var(--warning); }
+.agent-ops-dot.warn { background: var(--pending); }
+
+.agent-ops-label {
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.agent-ops-meta,
+.agent-ops-value {
+    color: var(--text-dim);
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.agent-ops-setting .agent-ops-meta {
+    font-weight: 650;
+}
+
+.agent-ops-setting .agent-ops-value {
+    color: var(--text-muted);
+    font-family: 'Cascadia Code', 'JetBrains Mono', monospace;
+    min-width: 0;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+}
+
+.agent-ops-setting.wide {
+    grid-template-columns: 86px minmax(0, 1fr) auto;
+}
+
+.agent-ops-link {
+    color: var(--accent);
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+
+.agent-ops-link:hover {
+    text-decoration: underline;
+}
+
+.agent-ops-row {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+}
+
+.agent-ops-row.warn {
+    border-color: color-mix(in srgb, var(--pending) 45%, var(--border));
+    background: rgba(218, 119, 86, 0.08);
+}
+
+.agent-ops-row-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-width: 0;
+}
+
+.agent-ops-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.agent-ops-tag {
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    color: var(--text-dim);
+    background: var(--white-06);
+    font-size: 11px;
+}
+
+.agent-ops-copy-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 6px;
+    align-items: center;
+}
+
+.agent-ops-command {
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-input);
+    color: var(--text-muted);
+    font-family: 'Cascadia Code', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.agent-ops-copy {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--white-06);
+    color: var(--text-dim);
+    cursor: pointer;
+    padding: 5px 7px;
+}
+
+.agent-ops-copy:hover {
+    color: var(--text);
+    border-color: var(--accent);
+}
+
+.agent-ops-empty {
+    color: var(--text-dim);
+    font-size: 12px;
+    padding: 8px 0;
+}
+
+@media (max-width: 780px) {
+    #agent-ops-panel {
+        --panel-w: 100vw;
+        max-width: 100vw;
+    }
+
+    .project-badge {
+        max-width: 140px;
+    }
+}

--- a/static/agent-ops.js
+++ b/static/agent-ops.js
@@ -1,0 +1,285 @@
+(function() {
+    let agentOpsOpen = false;
+    let agentOpsTimer = null;
+    let lastProject = null;
+
+    function authHeaders() {
+        const token = window.__SESSION_TOKEN__ || window.SESSION_TOKEN || '';
+        return token ? { 'X-Session-Token': token } : {};
+    }
+
+    function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, ch => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+        }[ch]));
+    }
+
+    function fmtAge(seconds) {
+        if (seconds === null || seconds === undefined) return 'no heartbeat';
+        if (seconds < 1) return 'now';
+        if (seconds < 60) return `${Math.round(seconds)}s ago`;
+        return `${Math.round(seconds / 60)}m ago`;
+    }
+
+    function validHex(color) {
+        return /^#[0-9a-fA-F]{6}$/.test(String(color || ''));
+    }
+
+    async function loadJson(path) {
+        const resp = await fetch(path, { headers: authHeaders() });
+        if (!resp.ok) throw new Error(`${path} ${resp.status}`);
+        return resp.json();
+    }
+
+    async function loadProject() {
+        try {
+            const project = await loadJson('/api/project');
+            lastProject = project;
+            applyProject(project);
+        } catch (err) {
+            console.warn('agent operations project load failed', err);
+        }
+    }
+
+    function applyProject(project) {
+        const name = project.title || project.name || 'agentchattr';
+        window.agentchattrProjectTitle = name;
+        document.title = name.toLowerCase() === 'agentchattr' ? 'agentchattr' : `${name} - agentchattr`;
+        if (validHex(project.accent_color)) {
+            document.documentElement.style.setProperty('--accent', project.accent_color);
+            document.documentElement.style.setProperty('--accent-soft', `${project.accent_color}24`);
+        }
+        const badge = document.getElementById('project-badge');
+        if (badge) {
+            badge.textContent = name;
+            badge.title = project.team_file || name;
+            badge.classList.remove('hidden');
+        }
+        applyProjectLinks(project);
+    }
+
+    function applyProjectLinks(project) {
+        const link = document.querySelector('.channel-support');
+        if (!link) return;
+        const url = project.link_url || project.board_url || project.repo_url || '';
+        const rawLabel = project.link_label || (project.board_url || project.link_url ? 'Project Board' : project.repo_url ? 'Repository' : 'Support development');
+        const label = ` ${rawLabel}`;
+        if (url) {
+            link.href = url;
+            link.title = rawLabel;
+            link.dataset.projectLabel = label;
+            const labelEl = link.querySelector('.support-label');
+            if (labelEl) labelEl.textContent = label;
+        }
+    }
+
+    async function refreshAgentOps() {
+        const body = document.getElementById('agent-ops-body');
+        if (!body) return;
+        try {
+            const ops = await loadJson('/api/agent-ops');
+            lastProject = ops.project || lastProject;
+            if (lastProject) applyProject(lastProject);
+            body.innerHTML = renderAgentOps(ops);
+            wireCopyButtons(body);
+        } catch (err) {
+            body.innerHTML = `<div class="agent-ops-empty">Unable to load operations data.</div>`;
+            console.warn('agent operations load failed', err);
+        }
+    }
+
+    function renderAgentOps(ops) {
+        return [
+            renderServices(ops.service_badges || []),
+            renderProjectSettings(ops.project || lastProject || {}),
+            renderConfiguredAgents(ops.configured_agents || []),
+            renderRegisteredAgents(ops.registered_agents || []),
+            renderWarnings(ops.mismatches || {}),
+        ].join('');
+    }
+
+    function renderServices(services) {
+        const rows = services.map(s => `
+            <div class="agent-ops-service">
+                <div class="agent-ops-name">
+                    <span class="agent-ops-dot ${s.tmux_running === false ? 'warn' : 'online'}"></span>
+                    <span class="agent-ops-label">${escapeHtml(s.label || s.name)}</span>
+                </div>
+                <span class="agent-ops-meta">${escapeHtml(s.detail || s.status || '')}</span>
+            </div>
+        `).join('');
+        return section('Services', `<div class="agent-ops-services">${rows}</div>`);
+    }
+
+    function renderProjectSettings(project) {
+        const rows = [
+            ['Tmux', project.tmux_prefix || ''],
+            ['Data', project.data_dir || ''],
+            ['Uploads', project.upload_dir || ''],
+            ['Team', project.team_file || 'default config'],
+            ['Repo', project.repo_url || ''],
+            ['Project Board', project.board_url || ''],
+            ['Link', project.link_url || ''],
+        ].filter(([, value]) => value).map(([label, value]) => `
+            <div class="agent-ops-setting">
+                <span class="agent-ops-meta">${escapeHtml(label)}</span>
+                ${renderProjectValue(label, value)}
+            </div>
+        `).join('');
+        return section('Project', `<div class="agent-ops-settings">${rows}</div>`);
+    }
+
+    function renderProjectValue(label, value) {
+        if ((label === 'Repo' || label === 'Project Board' || label === 'Link') && value) {
+            return `<a class="agent-ops-link" href="${escapeHtml(value)}" target="_blank" rel="noopener" title="${escapeHtml(value)}">${escapeHtml(value)}</a>`;
+        }
+        return `<span class="agent-ops-value" title="${escapeHtml(value)}">${escapeHtml(value)}</span>`;
+    }
+
+    function renderConfiguredAgents(rows) {
+        if (!rows.length) return section('Configured Agents', '<div class="agent-ops-empty">No configured agents.</div>');
+        return section('Configured Agents', rows.map(renderConfiguredAgent).join(''));
+    }
+
+    function renderConfiguredAgent(row) {
+        const mismatch = row.mismatches || {};
+        const warn = mismatch.configured_not_registered || mismatch.wrapper_running_without_live_heartbeat;
+        const state = row.busy ? 'busy' : row.online ? 'online' : warn ? 'warn' : '';
+        const provider = row.provider || row.type || 'agent';
+        const role = row.role ? `<span class="agent-ops-tag">role ${escapeHtml(row.role)}</span>` : '<span class="agent-ops-tag">no role</span>';
+        const registered = (row.registered_names || []).length
+            ? `<span class="agent-ops-tag">@${escapeHtml(row.registered_names.join(', @'))}</span>`
+            : '<span class="agent-ops-tag">not registered</span>';
+        const liveCommand = row.attach?.live || '';
+        const wrapperCommand = row.attach?.wrapper || '';
+        return `
+            <div class="agent-ops-row ${warn ? 'warn' : ''}">
+                <div class="agent-ops-row-top">
+                    <div class="agent-ops-name">
+                        <span class="agent-ops-dot ${state}" style="background:${escapeHtml(row.color || '')}"></span>
+                        <span class="agent-ops-label">${escapeHtml(row.label || row.name)}</span>
+                    </div>
+                    <span class="agent-ops-meta">${fmtAge(row.heartbeat_age)}</span>
+                </div>
+                <div class="agent-ops-tags">
+                    <span class="agent-ops-tag">@${escapeHtml(row.name)}</span>
+                    <span class="agent-ops-tag">${escapeHtml(provider)}</span>
+                    ${role}
+                    ${registered}
+                </div>
+                ${copyRow('Live', liveCommand)}
+                ${copyRow('Wrapper', wrapperCommand)}
+            </div>
+        `;
+    }
+
+    function renderRegisteredAgents(rows) {
+        if (!rows.length) return section('Running Agents', '<div class="agent-ops-empty">No registered agents.</div>');
+        return section('Running Agents', rows.map(row => {
+            const warn = row.mismatches?.registered_not_configured;
+            const state = row.busy ? 'busy' : row.online ? 'online' : warn ? 'warn' : '';
+            return `
+                <div class="agent-ops-row ${warn ? 'warn' : ''}">
+                    <div class="agent-ops-row-top">
+                        <div class="agent-ops-name">
+                            <span class="agent-ops-dot ${state}" style="background:${escapeHtml(row.color || '')}"></span>
+                            <span class="agent-ops-label">${escapeHtml(row.label || row.name)}</span>
+                        </div>
+                        <span class="agent-ops-meta">${fmtAge(row.heartbeat_age)}</span>
+                    </div>
+                    <div class="agent-ops-tags">
+                        <span class="agent-ops-tag">@${escapeHtml(row.name)}</span>
+                        <span class="agent-ops-tag">base ${escapeHtml(row.base)}</span>
+                        <span class="agent-ops-tag">${escapeHtml(row.state || 'active')}</span>
+                    </div>
+                    ${copyRow('Live', row.attach?.live || '')}
+                </div>
+            `;
+        }).join(''));
+    }
+
+    function renderWarnings(mismatches) {
+        const items = [];
+        if ((mismatches.configured_not_registered || []).length) {
+            items.push(`Configured but not registered: ${mismatches.configured_not_registered.map(escapeHtml).join(', ')}`);
+        }
+        if ((mismatches.registered_not_configured || []).length) {
+            items.push(`Registered but not configured: ${mismatches.registered_not_configured.map(escapeHtml).join(', ')}`);
+        }
+        if ((mismatches.wrapper_running_without_live_heartbeat || []).length) {
+            items.push(`Wrapper running without live heartbeat: ${mismatches.wrapper_running_without_live_heartbeat.map(escapeHtml).join(', ')}`);
+        }
+        if (!items.length) return '';
+        return section('Warnings', items.map(text => `
+            <div class="agent-ops-row warn">
+                <div class="agent-ops-meta">${text}</div>
+            </div>
+        `).join(''));
+    }
+
+    function section(title, body) {
+        return `
+            <div class="agent-ops-section">
+                <div class="agent-ops-section-title">${escapeHtml(title)}</div>
+                ${body}
+            </div>
+        `;
+    }
+
+    function copyRow(label, command) {
+        if (!command) return '';
+        return `
+            <div class="agent-ops-copy-row">
+                <div class="agent-ops-command" title="${escapeHtml(command)}">${escapeHtml(label)}: ${escapeHtml(command)}</div>
+                <button class="agent-ops-copy" data-copy="${escapeHtml(command)}" title="Copy attach command">Copy</button>
+            </div>
+        `;
+    }
+
+    function wireCopyButtons(root) {
+        root.querySelectorAll('.agent-ops-copy').forEach(btn => {
+            btn.addEventListener('click', async () => {
+                const text = btn.dataset.copy || '';
+                try {
+                    await navigator.clipboard.writeText(text);
+                } catch (_err) {
+                    const ta = document.createElement('textarea');
+                    ta.value = text;
+                    document.body.appendChild(ta);
+                    ta.select();
+                    document.execCommand('copy');
+                    ta.remove();
+                }
+                const old = btn.textContent;
+                btn.textContent = 'Copied';
+                setTimeout(() => { btn.textContent = old; }, 900);
+            });
+        });
+    }
+
+    window.toggleAgentOpsPanel = function(force) {
+        const panel = document.getElementById('agent-ops-panel');
+        const toggle = document.getElementById('agent-ops-toggle');
+        if (!panel) return;
+        agentOpsOpen = typeof force === 'boolean' ? force : panel.classList.contains('hidden');
+        panel.classList.toggle('hidden', !agentOpsOpen);
+        document.body.classList.toggle('agent-ops-open', agentOpsOpen);
+        if (toggle) toggle.classList.toggle('active', agentOpsOpen);
+        if (agentOpsOpen) {
+            refreshAgentOps();
+            clearInterval(agentOpsTimer);
+            agentOpsTimer = setInterval(refreshAgentOps, 5000);
+        } else {
+            clearInterval(agentOpsTimer);
+            agentOpsTimer = null;
+        }
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        loadProject();
+    });
+})();

--- a/static/channels.js
+++ b/static/channels.js
@@ -189,7 +189,7 @@ function _showSidebarRenameDialog(oldName) {
 
     const input = document.createElement('input');
     input.type = 'text';
-    input.maxLength = 20;
+    input.maxLength = 24;
     input.value = oldName;
     wrapper.appendChild(input);
 
@@ -201,7 +201,7 @@ function _showSidebarRenameDialog(oldName) {
     confirm.title = 'Rename';
     confirm.onclick = () => {
         const newName = input.value.trim().toLowerCase();
-        if (!newName || !/^[a-z0-9][a-z0-9\-]{0,19}$/.test(newName)) return;
+        if (!newName || !/^[a-z0-9][a-z0-9\-]{0,23}$/.test(newName)) return;
         if (newName !== oldName) {
             window.ws.send(JSON.stringify({ type: 'channel_rename', old_name: oldName, new_name: newName }));
             if (window.activeChannel === oldName) {
@@ -351,7 +351,7 @@ function showChannelCreateDialog() {
 
     const input = document.createElement('input');
     input.type = 'text';
-    input.maxLength = 20;
+    input.maxLength = 24;
     input.placeholder = 'channel-name';
     wrapper.appendChild(input);
 
@@ -385,7 +385,7 @@ function showChannelCreateDialog() {
 
 function _submitInlineCreate(input, wrapper) {
     const name = input.value.trim().toLowerCase();
-    if (!name || !/^[a-z0-9][a-z0-9\-]{0,19}$/.test(name)) return;
+    if (!name || !/^[a-z0-9][a-z0-9\-]{0,23}$/.test(name)) return;
     if (window.channelList.includes(name)) { input.focus(); return; }
     window._setPendingChannelSwitch(name);
     window.ws.send(JSON.stringify({ type: 'channel_create', name }));
@@ -413,7 +413,7 @@ function showChannelRenameDialog(oldName) {
 
     const input = document.createElement('input');
     input.type = 'text';
-    input.maxLength = 20;
+    input.maxLength = 24;
     input.value = oldName;
     wrapper.appendChild(input);
 
@@ -428,7 +428,7 @@ function showChannelRenameDialog(oldName) {
     confirm.title = 'Rename';
     confirm.onclick = () => {
         const newName = input.value.trim().toLowerCase();
-        if (!newName || !/^[a-z0-9][a-z0-9\-]{0,19}$/.test(newName)) return;
+        if (!newName || !/^[a-z0-9][a-z0-9\-]{0,23}$/.test(newName)) return;
         if (newName !== oldName) {
             window.ws.send(JSON.stringify({ type: 'channel_rename', old_name: oldName, new_name: newName }));
             if (window.activeChannel === oldName) {
@@ -537,6 +537,8 @@ function deleteChannel(name) {
 
 const SIDEBAR_MODE_KEY = 'agentchattr-channel-sidebar-mode';
 const SIDEBAR_WIDTH_KEY = 'agentchattr-channel-sidebar-w';
+const SIDEBAR_DEFAULT_VERSION_KEY = 'agentchattr-channel-sidebar-default-v2';
+const SIDEBAR_LAYOUT_KEY = 'agentchattr-sidebar-layout';
 
 function setChannelSidebarMode(mode, persist = true) {
     const sidebar = document.getElementById('channel-sidebar');
@@ -569,12 +571,26 @@ function setChannelSidebarMode(mode, persist = true) {
     _updateSupportLabel();
 }
 
+function setSidebarLayout(layout, persist = true) {
+    const normalized = layout === 'channels-left' ? 'channels-left' : 'agents-left';
+    document.body.classList.toggle('sidebars-agents-left', normalized === 'agents-left');
+    document.body.classList.toggle('sidebars-channels-left', normalized === 'channels-left');
+    if (persist) localStorage.setItem(SIDEBAR_LAYOUT_KEY, normalized);
+    const setting = document.getElementById('setting-sidebar-layout');
+    if (setting && setting.value !== normalized) setting.value = normalized;
+}
+
 // Swap "Support development" → "Support" when the sidebar is narrow, so the
 // text doesn't truncate. Width threshold tuned to match the pill's padding
 // plus the heart glyph.
 function _updateSupportLabel() {
     const label = document.querySelector('.channel-support .support-label');
     if (!label) return;
+    const projectLabel = label.closest('.channel-support')?.dataset.projectLabel || '';
+    if (projectLabel) {
+        label.textContent = projectLabel;
+        return;
+    }
     const inSidebar = document.body.classList.contains('channels-in-sidebar');
     if (!inSidebar) {
         label.textContent = ' Support development';
@@ -607,9 +623,9 @@ function setupChannelSidebarGrip() {
 
     document.addEventListener('mousemove', (e) => {
         if (!dragging) return;
-        // Sidebar is on the left, so dragging right grows it (positive delta).
-        const delta = e.clientX - startX;
-        const newWidth = Math.min(Math.max(startWidth + delta, 140), 400);
+        const channelsOnRight = document.body.classList.contains('sidebars-agents-left');
+        const delta = channelsOnRight ? startX - e.clientX : e.clientX - startX;
+        const newWidth = Math.min(Math.max(startWidth + delta, 180), 480);
         panel.style.setProperty('--channel-sidebar-w', newWidth + 'px');
         panel.style.width = newWidth + 'px';
         _updateSupportLabel();
@@ -627,15 +643,23 @@ function setupChannelSidebarGrip() {
 }
 
 function _restoreSidebarState() {
+    const savedLayout = localStorage.getItem(SIDEBAR_LAYOUT_KEY) || 'agents-left';
+    setSidebarLayout(savedLayout, false);
+
     const savedWidth = parseInt(localStorage.getItem(SIDEBAR_WIDTH_KEY) || '', 10);
-    if (savedWidth && savedWidth >= 140 && savedWidth <= 400) {
+    if (savedWidth && savedWidth >= 180 && savedWidth <= 480) {
         const panel = document.getElementById('channel-sidebar');
         if (panel) {
             panel.style.setProperty('--channel-sidebar-w', savedWidth + 'px');
             panel.style.width = savedWidth + 'px';
         }
     }
-    const savedMode = localStorage.getItem(SIDEBAR_MODE_KEY) || 'top';
+    let savedMode = localStorage.getItem(SIDEBAR_MODE_KEY) || 'sidebar';
+    if (!localStorage.getItem(SIDEBAR_DEFAULT_VERSION_KEY) && savedMode === 'top') {
+        savedMode = 'sidebar';
+        localStorage.setItem(SIDEBAR_MODE_KEY, savedMode);
+        localStorage.setItem(SIDEBAR_DEFAULT_VERSION_KEY, '1');
+    }
     setChannelSidebarMode(savedMode, false);
 }
 
@@ -662,6 +686,10 @@ function _channelsInit() {
     if (setting) {
         setting.addEventListener('change', () => setChannelSidebarMode(setting.value));
     }
+    const layoutSetting = document.getElementById('setting-sidebar-layout');
+    if (layoutSetting) {
+        layoutSetting.addEventListener('change', () => setSidebarLayout(layoutSetting.value));
+    }
 
     requestAnimationFrame(_syncClearChatWidth);
     window.addEventListener('resize', _syncClearChatWidth);
@@ -677,6 +705,7 @@ window.filterMessagesByChannel = filterMessagesByChannel;
 window.renderChannelTabs = renderChannelTabs;
 window.deleteChannel = deleteChannel;
 window.showChannelRenameDialog = showChannelRenameDialog;
+window.setSidebarLayout = setSidebarLayout;
 window.renderChannelSidebar = renderChannelSidebar;
 window.setChannelSidebarMode = setChannelSidebarMode;
 window.Channels = { init: _channelsInit };

--- a/static/chat.js
+++ b/static/chat.js
@@ -9,6 +9,7 @@ let pendingAttachments = [];
 let autoScroll = true;
 let reconnectTimer = null;
 let username = 'user';
+let selfNames = new Set(JSON.parse(localStorage.getItem('agentchattr-self-names') || '["user"]').map(n => String(n).toLowerCase()));
 let agentConfig = {};  // { name: { color, label } } — registered instances (used for pills)
 let baseColors = {};   // { name: { color, label } } — base agent colors (for message coloring)
 let todos = {};  // { msg_id: "todo" | "done" }
@@ -38,6 +39,7 @@ window._setPendingChannelSwitch = function(v) { pendingChannelSwitch = v; };
 // scrollToBottom is set after function definition (see below)
 Object.defineProperty(window, 'username', { get() { return username; } });
 Object.defineProperty(window, 'agentConfig', { get() { return agentConfig; } });
+Object.defineProperty(window, 'todos', { get() { return todos; } });
 Object.defineProperty(window, 'ws', { get() { return ws; } });
 Object.defineProperty(window, 'soundEnabled', { get() { return soundEnabled; } });
 Object.defineProperty(window, 'rules', { get() { return rules; }, set(v) { rules = v; } });
@@ -46,6 +48,22 @@ Object.defineProperty(window, '_lastMentionedAgent', {
     get() { return _lastMentionedAgent; },
     set(v) { _lastMentionedAgent = v; },
 });
+
+function rememberSelfName(name) {
+    const normalized = String(name || '').trim().toLowerCase();
+    if (!normalized) return;
+    selfNames.add(normalized);
+    localStorage.setItem('agentchattr-self-names', JSON.stringify([...selfNames]));
+}
+
+function isSelfSender(sender) {
+    const normalized = String(sender || '').trim().toLowerCase();
+    if (!normalized || normalized === 'system') return false;
+    if (selfNames.has(normalized)) return true;
+    if (agentConfig[normalized] || baseColors[normalized] || resolveAgent(normalized)) return false;
+    return true;
+}
+window.isSelfSender = isSelfSender;
 
 // --- Drag-scroll for overflow containers ---
 function enableDragScroll(el) {
@@ -399,7 +417,7 @@ function connectWebSocket() {
             }
         } else if (event.type === 'message') {
             // Play notification sound for new messages from others (not joins, not when focused)
-            if (soundEnabled && !document.hasFocus() && event.data.type !== 'join' && event.data.type !== 'leave' && event.data.type !== 'summary' && event.data.sender && event.data.sender.toLowerCase() !== username.toLowerCase()) {
+            if (soundEnabled && !document.hasFocus() && event.data.type !== 'join' && event.data.type !== 'leave' && event.data.type !== 'summary' && event.data.sender && !isSelfSender(event.data.sender)) {
                 playNotificationSound(event.data.sender);
             }
             appendMessage(event.data);
@@ -746,7 +764,7 @@ function appendMessage(msg) {
         if (isError) el.classList.add('error-msg');
 
         // Update last mentioned agent if message is from user (Ben)
-        if (msg.sender.toLowerCase() === username.toLowerCase()) {
+        if (isSelfSender(msg.sender)) {
             const mentions = msg.text.match(/@(\w[\w-]*)/g);
             if (mentions) {
                 const lastMention = mentions[mentions.length - 1].slice(1).toLowerCase();
@@ -760,7 +778,7 @@ function appendMessage(msg) {
         let textHtml = styleHashtags(renderMarkdown(msg.text));
 
         const senderColor = getColor(msg.sender);
-        const isSelf = msg.sender.toLowerCase() === username.toLowerCase();
+        const isSelf = isSelfSender(msg.sender);
         el.classList.add(isSelf ? 'self' : 'other');
 
         let attachmentsHtml = '';
@@ -826,7 +844,7 @@ function appendMessage(msg) {
             channelUnread[msgChannel] = (channelUnread[msgChannel] || 0) + 1;
             renderChannelTabs();
             // Play soft pluck for cross-channel chat messages from others (only when focused)
-            if (document.hasFocus() && msg.type === 'chat' && msg.sender && msg.sender.toLowerCase() !== username.toLowerCase()) {
+            if (document.hasFocus() && msg.type === 'chat' && msg.sender && !isSelfSender(msg.sender)) {
                 playCrossChannelSound();
             }
         }
@@ -1732,10 +1750,11 @@ let pendingChannelSwitch = null;
 function applySettings(data) {
     if (data.title) {
         document.getElementById('room-title').textContent = data.title;
-        document.title = data.title;
+        if (!window.agentchattrProjectTitle) document.title = data.title;
     }
     if (data.username) {
         username = data.username;
+        rememberSelfName(username);
         document.getElementById('sender-label').textContent = username;
         document.getElementById('setting-username').value = username;
     }
@@ -1870,7 +1889,7 @@ function saveSettings() {
             data: {
                 username: newUsername || 'user',
                 font: newFont,
-                max_agent_hops: parseInt(newHops) || 4,
+                max_agent_hops: parseInt(newHops) || 100,
                 history_limit: newHistory,
                 contrast: newContrast,
                 rules_refresh_interval: parseInt(newRulesRefresh) || 0,
@@ -2001,10 +2020,27 @@ async function importHistory(input) {
 
 // --- Keyboard shortcuts ---
 
+function focusMessageInput() {
+    const input = document.getElementById('input');
+    if (!input) return;
+    window.closeSearchNav?.();
+    input.focus({ preventScroll: true });
+    const pos = input.value.length;
+    input.setSelectionRange(pos, pos);
+}
+
 function setupKeyboardShortcuts() {
     document.addEventListener('keydown', (e) => {
         const modal = document.getElementById('image-modal');
         const modalOpen = modal && !modal.classList.contains('hidden');
+
+        if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === '.') {
+            if (!modalOpen) {
+                e.preventDefault();
+                focusMessageInput();
+            }
+            return;
+        }
 
         if (e.key === 'Escape') {
             const nameModal = document.getElementById('agent-name-modal');
@@ -2037,12 +2073,7 @@ function showSlashHint(text) {
 }
 
 const SLASH_COMMANDS = [
-    { cmd: '/artchallenge', desc: 'SVG art challenge — all agents create artwork (optional theme)', broadcast: true },
-    { cmd: '/hatmaking', desc: 'All agents design a hat to wear on their avatar', broadcast: true },
     { cmd: '/roastreview', desc: 'Get all agents to review and roast each other\'s work', broadcast: true },
-    { cmd: '/poetry haiku', desc: 'Agents write a haiku about the codebase', broadcast: true },
-    { cmd: '/poetry limerick', desc: 'Agents write a limerick about the codebase', broadcast: true },
-    { cmd: '/poetry sonnet', desc: 'Agents write a sonnet about the codebase', broadcast: true },
     { cmd: '/summary', desc: 'Summarize recent messages — tag an agent (e.g. /summary @claude)', broadcast: false, needsMention: true },
     { cmd: '/summarise', desc: 'Summarize recent messages — tag an agent (e.g. /summarise @claude)', broadcast: false, needsMention: true, hidden: true },
     { cmd: '/continue', desc: 'Resume after loop guard pauses', broadcast: false },
@@ -2057,7 +2088,7 @@ let mentionMenuStart = -1;  // cursor position of the '@'
 
 function updateSlashMenu(text) {
     const menu = document.getElementById('slash-menu');
-    if (!text.startsWith('/') || text.includes(' ') && !text.startsWith('/poetry')) {
+    if (!text.startsWith('/') || text.includes(' ')) {
         menu.classList.add('hidden');
         slashMenuVisible = false;
         return;
@@ -2105,13 +2136,13 @@ function selectSlashCommand(cmd) {
 // --- Mention autocomplete ---
 
 function getMentionCandidates() {
-    // Build list: registered agents + "all agents" + username (self) + known humans
+    // Build list: registered agents + @all broadcast.
     const candidates = [];
     for (const [name, cfg] of Object.entries(agentConfig)) {
         if (cfg.state === 'pending') continue;
         candidates.push({ name, label: cfg.label || name, color: cfg.color });
     }
-    candidates.push({ name: 'all agents', label: 'all agents', color: 'var(--accent)' });
+    candidates.push({ name: 'all', label: 'all', color: 'var(--accent)' });
     return candidates;
 }
 
@@ -2132,8 +2163,7 @@ function updateMentionMenu() {
     let atPos = -1;
     for (let i = cursor - 1; i >= 0; i--) {
         if (text[i] === '@') { atPos = i; break; }
-        // Allow spaces if we are still matching a multi-word label like "all agents"
-        if (!/[\w\-\s]/.test(text[i])) break;
+        if (!/[\w\-]/.test(text[i])) break;
         // Optimization: don't look back more than 30 chars
         if (cursor - i > 30) break;
     }
@@ -3652,7 +3682,7 @@ function _helpCardDefs() {
             row: 'top',
             html:
             '<div class="hg-module-title">Agents <span class="hg-loc">header pills</span></div>' +
-            '<p class="hg-module-desc">The status pills in the header show who is here and what they\'re doing.</p>' +
+            '<p class="hg-module-desc">The status pills in the Agents rail show who is here and what they\'re doing.</p>' +
             '<div class="hg-mock-row">' +
                 '<div class="hg-mock-pill hg-pill-available">' +
                     '<span class="hg-mock-dot" style="background:#f97316"></span>' +

--- a/static/index.html
+++ b/static/index.html
@@ -4,17 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>agentchattr</title>
-    <link rel="stylesheet" href="/static/style.css?v=249">
+    <link rel="stylesheet" href="/static/style.css?v=250">
     <link rel="stylesheet" href="/static/sessions.css?v=223">
     <link rel="stylesheet" href="/static/jobs.css?v=223">
+    <link rel="stylesheet" href="/static/agent-ops.css?v=1">
+    <link rel="stylesheet" href="/static/search-nav.css?v=1">
     <link rel="icon" href="/static/favicon.ico">
 </head>
-<body>
+<body class="sidebars-agents-left">
     <div id="app">
         <header>
             <div class="header-left">
                 <img src="/static/logo.png" alt="agentchattr" class="header-logo">
                 <h1 id="room-title">agentchattr</h1>
+                <span class="project-badge hidden" id="project-badge"></span>
                 <a class="discord-pill" href="https://discord.gg/qzfn5YTT9a" target="_blank" rel="noopener" title="Join the Discord">
                     <svg width="14" height="14" viewBox="0 0 71 55" fill="currentColor"><path d="M60.1 4.9A58.5 58.5 0 0045.4.2a.2.2 0 00-.2.1 40.8 40.8 0 00-1.8 3.7 54 54 0 00-16.2 0A37.4 37.4 0 0025.4.3a.2.2 0 00-.2-.1A58.4 58.4 0 0010.5 4.9a.2.2 0 00-.1.1C1.5 18.7-.9 32.2.3 45.5v.2a58.9 58.9 0 0017.7 9a.2.2 0 00.3-.1 42.1 42.1 0 003.6-5.9.2.2 0 00-.1-.3 38.8 38.8 0 01-5.5-2.6.2.2 0 01 0-.4l1.1-.9a.2.2 0 01.2 0 42 42 0 0035.6 0 .2.2 0 01.2 0l1.1.9a.2.2 0 010 .4 36.4 36.4 0 01-5.5 2.6.2.2 0 00-.1.3 47.2 47.2 0 003.6 5.9.2.2 0 00.3.1A58.7 58.7 0 0070.4 45.7v-.2C72 30.1 68 16.7 60.2 5a.2.2 0 00-.1-.1zM23.7 37.3c-3.5 0-6.4-3.2-6.4-7.2s2.8-7.2 6.4-7.2 6.5 3.2 6.4 7.2c0 4-2.8 7.2-6.4 7.2zm23.6 0c-3.5 0-6.4-3.2-6.4-7.2s2.8-7.2 6.4-7.2 6.5 3.2 6.4 7.2c0 4-2.9 7.2-6.4 7.2z"/></svg>
                     Discord
@@ -22,7 +25,20 @@
                 <span class="subtitle" id="room-subtitle"></span>
             </div>
             <div class="header-right">
-                <div id="agent-status"></div>
+                <button class="settings-btn" id="search-nav-toggle" onclick="openSearchNav()" title="Search and Commands">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                        <circle cx="7" cy="7" r="4.2" stroke="currentColor" stroke-width="1.3"/>
+                        <path d="M10.2 10.2L13.5 13.5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+                    </svg>
+                </button>
+                <button class="settings-btn" id="agent-ops-toggle" onclick="toggleAgentOpsPanel()" title="Agent Operations">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                        <path d="M3 4.5h10M3 8h10M3 11.5h10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+                        <circle cx="5" cy="4.5" r="1.4" fill="currentColor"/>
+                        <circle cx="11" cy="8" r="1.4" fill="currentColor"/>
+                        <circle cx="7.5" cy="11.5" r="1.4" fill="currentColor"/>
+                    </svg>
+                </button>
                 <button class="settings-btn" id="jobs-toggle" onclick="toggleJobsPanel()" title="Jobs">
                     <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                         <rect x="3" y="2" width="10" height="12" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
@@ -73,7 +89,7 @@
             <div class="settings-field">
                 <label for="setting-hops">Loop guard</label>
                 <div class="sched-num-wrap">
-                    <input type="number" id="setting-hops" class="sched-pop-num" min="1" max="100" value="4" title="Max agent-to-agent hops before pausing">
+                    <input type="number" id="setting-hops" class="sched-pop-num" min="1" max="100" value="100" title="Max agent-to-agent hops before pausing">
                     <div class="sched-num-btns">
                         <button type="button" onclick="stepNumInput('setting-hops',1)" tabindex="-1">&#9650;</button>
                         <button type="button" onclick="stepNumInput('setting-hops',-1)" tabindex="-1">&#9660;</button>
@@ -89,6 +105,7 @@
                     <option value="100">100</option>
                     <option value="200">200</option>
                     <option value="500">500</option>
+                    <option value="1000">1000</option>
                 </select>
             </div>
             <div class="settings-field">
@@ -101,8 +118,15 @@
             <div class="settings-field">
                 <label for="setting-channel-sidebar">Channels</label>
                 <select id="setting-channel-sidebar" title="Show channels in a sidebar (Discord/Slack-style) instead of a top bar">
-                    <option value="top">Top bar</option>
                     <option value="sidebar">Sidebar</option>
+                    <option value="top">Top bar</option>
+                </select>
+            </div>
+            <div class="settings-field">
+                <label for="setting-sidebar-layout">Sidebars</label>
+                <select id="setting-sidebar-layout" title="Choose which sidebar sits on the left side">
+                    <option value="agents-left">Agents left</option>
+                    <option value="channels-left">Channels left</option>
                 </select>
             </div>
             <div class="settings-field">
@@ -181,6 +205,10 @@
                     <span class="typing-name"></span> is thinking...
                 </div>
             </main>
+            <aside id="presence-sidebar">
+                <div class="presence-sidebar-header">Agents</div>
+                <div id="agent-status"></div>
+            </aside>
             <aside id="jobs-panel" class="hidden">
                 <div class="jobs-grip" id="jobs-grip"></div>
                 <div id="jobs-list-view">
@@ -228,6 +256,13 @@
                     <button class="jobs-create-btn" onclick="showCreateRule()" title="Add Rule">+</button>
                 </div>
                 <div id="rules-list"></div>
+            </aside>
+            <aside id="agent-ops-panel" class="hidden">
+                <div class="agent-ops-header">
+                    <span>Agent Operations</span>
+                    <button class="agent-ops-close" onclick="toggleAgentOpsPanel(false)" title="Close">&times;</button>
+                </div>
+                <div id="agent-ops-body" class="agent-ops-body"></div>
             </aside>
         </div>
 
@@ -342,8 +377,10 @@
     <script src="/static/store.js?v=223"></script>
     <script src="/static/sessions.js?v=223"></script>
     <script src="/static/jobs.js?v=224"></script>
-    <script src="/static/channels.js?v=224"></script>
+    <script src="/static/channels.js?v=225"></script>
     <script src="/static/rules-panel.js?v=223"></script>
+    <script src="/static/agent-ops.js?v=1"></script>
     <script src="/static/chat.js?v=266"></script>
+    <script src="/static/search-nav.js?v=1"></script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -73,7 +73,7 @@
             <div class="settings-field">
                 <label for="setting-hops">Loop guard</label>
                 <div class="sched-num-wrap">
-                    <input type="number" id="setting-hops" class="sched-pop-num" min="1" max="50" value="4" title="Max agent-to-agent hops before pausing">
+                    <input type="number" id="setting-hops" class="sched-pop-num" min="1" max="100" value="4" title="Max agent-to-agent hops before pausing">
                     <div class="sched-num-btns">
                         <button type="button" onclick="stepNumInput('setting-hops',1)" tabindex="-1">&#9650;</button>
                         <button type="button" onclick="stepNumInput('setting-hops',-1)" tabindex="-1">&#9660;</button>

--- a/static/jobs.js
+++ b/static/jobs.js
@@ -278,7 +278,7 @@ function resolveJobDefaultRecipient(job, messages = []) {
     // For active threads with history, infer from last non-self agent sender.
     for (let i = messages.length - 1; i >= 0; i--) {
         const sender = String(messages[i]?.sender || '');
-        if (!sender || sender.toLowerCase() === window.username.toLowerCase()) continue;
+        if (!sender || window.isSelfSender?.(sender) || sender.toLowerCase() === window.username.toLowerCase()) continue;
         const normalized = _normalizeJobRecipient(sender, opts);
         if (normalized) return normalized;
     }
@@ -363,8 +363,10 @@ function toggleJobsPanel() {
     window._preserveScroll(() => {
         const panel = document.getElementById('jobs-panel');
         panel.classList.toggle('hidden');
-        document.getElementById('jobs-toggle').classList.toggle('active', !panel.classList.contains('hidden'));
-        if (!panel.classList.contains('hidden')) {
+        const open = !panel.classList.contains('hidden');
+        document.body.classList.toggle('jobs-panel-open', open);
+        document.getElementById('jobs-toggle').classList.toggle('active', open);
+        if (open) {
             // Return to list view if we were in conversation view
             showJobsListView();
             renderJobsList();
@@ -1400,7 +1402,7 @@ function handleJobEvent(action, data) {
             activeJobId === data.job_id
         );
         const sender = (data.message && data.message.sender) ? String(data.message.sender) : '';
-        const isSelfMessage = sender.toLowerCase() === window.username.toLowerCase();
+        const isSelfMessage = window.isSelfSender?.(sender) || sender.toLowerCase() === window.username.toLowerCase();
         const msgType = data.message.type || 'chat';
         if (!isSelfMessage) {
             const normalized = _normalizeJobRecipient(sender);

--- a/static/rules-panel.js
+++ b/static/rules-panel.js
@@ -112,8 +112,10 @@ function toggleRulesPanel() {
     window._preserveScroll(() => {
         const panel = document.getElementById('rules-panel');
         panel.classList.toggle('hidden');
-        document.getElementById('rules-toggle').classList.toggle('active', !panel.classList.contains('hidden'));
-        if (!panel.classList.contains('hidden')) {
+        const open = !panel.classList.contains('hidden');
+        document.body.classList.toggle('rules-panel-open', open);
+        document.getElementById('rules-toggle').classList.toggle('active', open);
+        if (open) {
             // Mark all current drafts as seen
             for (const r of window.rules) {
                 if (r.status === 'proposed' || r.status === 'draft') _seenRuleIds.add(r.id);

--- a/static/search-nav.css
+++ b/static/search-nav.css
@@ -1,0 +1,183 @@
+.search-nav-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 80;
+    background: rgba(0, 0, 0, 0.48);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 9vh 16px 16px;
+}
+
+.search-nav-backdrop.hidden { display: none; }
+
+.search-nav-dialog {
+    width: min(760px, 100%);
+    max-height: 78vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--bg-header);
+    box-shadow: var(--shadow-lg);
+}
+
+.search-nav-top {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: center;
+    padding: 12px;
+    border-bottom: 1px solid var(--border-subtle);
+}
+
+.search-nav-input {
+    width: 100%;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-input);
+    color: var(--text);
+    font: inherit;
+    font-size: 15px;
+    padding: 9px 10px;
+    outline: none;
+}
+
+.search-nav-input:focus { border-color: var(--accent); }
+
+.search-nav-close {
+    width: 34px;
+    height: 34px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--white-06);
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 20px;
+}
+
+.search-nav-close:hover { color: var(--text); }
+
+.search-nav-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border-subtle);
+}
+
+.search-nav-filters select,
+.search-nav-filters label {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--white-03);
+    color: var(--text-dim);
+    font: inherit;
+    font-size: 12px;
+}
+
+.search-nav-filters select {
+    padding: 5px 8px;
+}
+
+.search-nav-filters label {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 5px 7px;
+    cursor: pointer;
+}
+
+.search-nav-filters input { accent-color: var(--accent); }
+
+.search-nav-results {
+    overflow-y: auto;
+    padding: 8px;
+}
+
+.search-nav-group {
+    color: var(--text-dim);
+    font-size: 11px;
+    font-weight: 700;
+    padding: 8px 6px 5px;
+    text-transform: uppercase;
+}
+
+.search-nav-item {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 12px;
+    align-items: center;
+    border: 0;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--text);
+    cursor: pointer;
+    padding: 9px 10px;
+    text-align: left;
+}
+
+.search-nav-item:hover,
+.search-nav-item.active {
+    background: var(--white-08);
+}
+
+.search-nav-main {
+    min-width: 0;
+}
+
+.search-nav-title {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 650;
+}
+
+.search-nav-title span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.search-nav-snippet {
+    margin-top: 3px;
+    color: var(--text-dim);
+    font-size: 12px;
+    line-height: 1.35;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.search-nav-meta {
+    color: var(--text-dim);
+    font-size: 11px;
+    white-space: nowrap;
+}
+
+.search-nav-empty {
+    color: var(--text-dim);
+    font-size: 13px;
+    padding: 18px 10px;
+}
+
+@media (max-width: 640px) {
+    .search-nav-backdrop {
+        padding-top: 6vh;
+    }
+
+    .search-nav-dialog {
+        max-height: 84vh;
+    }
+
+    .search-nav-item {
+        grid-template-columns: 1fr;
+        gap: 4px;
+    }
+}

--- a/static/search-nav.js
+++ b/static/search-nav.js
@@ -1,0 +1,400 @@
+(function() {
+    let messages = [];
+    let commands = [];
+    let activeIndex = 0;
+    let lastOps = null;
+
+    function tokenHeaders() {
+        const token = window.__SESSION_TOKEN__ || window.SESSION_TOKEN || '';
+        return token ? { 'X-Session-Token': token } : {};
+    }
+
+    function esc(value) {
+        return String(value ?? '').replace(/[&<>"']/g, ch => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+        }[ch]));
+    }
+
+    function textOf(msg) {
+        return String(msg.text || msg.body || msg.message || '');
+    }
+
+    function ensureDialog() {
+        let backdrop = document.getElementById('search-nav-backdrop');
+        if (backdrop) return backdrop;
+        backdrop = document.createElement('div');
+        backdrop.id = 'search-nav-backdrop';
+        backdrop.className = 'search-nav-backdrop hidden';
+        backdrop.innerHTML = `
+            <div class="search-nav-dialog" role="dialog" aria-modal="true">
+                <div class="search-nav-top">
+                    <input id="search-nav-input" class="search-nav-input" type="text" autocomplete="off" spellcheck="false" placeholder="Search messages, @sender, channels, commands">
+                    <button id="search-nav-close" class="search-nav-close" title="Close">&times;</button>
+                </div>
+                <div class="search-nav-filters">
+                    <select id="search-nav-sender" title="Sender filter"><option value="">Any sender</option></select>
+                    <select id="search-nav-channel" title="Channel filter"><option value="">Any channel</option></select>
+                    <label><input type="checkbox" id="search-nav-pinned"> pinned</label>
+                    <label><input type="checkbox" id="search-nav-todo"> todo</label>
+                    <label><input type="checkbox" id="search-nav-done"> done</label>
+                    <label><input type="checkbox" id="search-nav-jobs"> jobs</label>
+                    <label><input type="checkbox" id="search-nav-session"> sessions</label>
+                    <label><input type="checkbox" id="search-nav-system"> system</label>
+                </div>
+                <div id="search-nav-results" class="search-nav-results"></div>
+            </div>
+        `;
+        backdrop.addEventListener('click', event => {
+            if (event.target === backdrop) closeSearchNav();
+        });
+        document.body.appendChild(backdrop);
+
+        const input = document.getElementById('search-nav-input');
+        input.addEventListener('input', render);
+        input.addEventListener('keydown', handleInputKeydown);
+        document.getElementById('search-nav-close').addEventListener('click', closeSearchNav);
+        backdrop.querySelectorAll('select,input[type="checkbox"]').forEach(el => {
+            el.addEventListener('change', render);
+        });
+        return backdrop;
+    }
+
+    async function fetchMessages() {
+        const resp = await fetch('/api/messages?limit=500', { headers: tokenHeaders() });
+        if (!resp.ok) return [];
+        return resp.json();
+    }
+
+    async function fetchOps() {
+        try {
+            const resp = await fetch('/api/agent-ops', { headers: tokenHeaders() });
+            if (resp.ok) lastOps = await resp.json();
+        } catch (_err) {
+            lastOps = null;
+        }
+    }
+
+    async function refreshData() {
+        const [msgs] = await Promise.all([fetchMessages(), fetchOps()]);
+        messages = Array.isArray(msgs) ? msgs.slice().reverse() : [];
+        buildCommands();
+        populateFilters();
+        render();
+    }
+
+    function buildCommands() {
+        const items = [];
+        const channels = Array.isArray(window.channelList) ? window.channelList : ['general'];
+        for (const ch of channels) {
+            items.push({
+                title: `Switch to #${ch}`,
+                detail: 'channel',
+                kind: 'channel',
+                value: ch,
+                keywords: `channel switch ${ch}`,
+                run: () => {
+                    window.switchChannel?.(ch);
+                },
+            });
+        }
+        items.push({
+            title: 'Open Jobs',
+            detail: 'panel',
+            keywords: 'jobs tasks work',
+            run: () => openPanel('jobs-panel', window.toggleJobsPanel),
+        });
+        items.push({
+            title: 'Open Rules',
+            detail: 'panel',
+            keywords: 'rules decisions',
+            run: () => openPanel('rules-panel', window.toggleRulesPanel),
+        });
+        items.push({
+            title: 'Open Agent Operations',
+            detail: 'panel',
+            keywords: 'agent operations ops tmux status',
+            run: () => window.toggleAgentOpsPanel?.(true),
+        });
+        items.push({
+            title: 'Open Pinned Items',
+            detail: 'panel',
+            keywords: 'pins pinned todos todo done',
+            run: () => openPanel('pins-panel', window.togglePinsPanel),
+        });
+        items.push({
+            title: 'Continue Loop Guard',
+            detail: 'chat',
+            keywords: 'continue loop guard resume routing',
+            run: () => {
+                const input = document.getElementById('input');
+                if (input) input.value = '/continue';
+                window.sendMessage?.();
+            },
+        });
+        for (const agent of lastOps?.configured_agents || []) {
+            if (agent.attach?.live) {
+                items.push({
+                    title: `Copy attach command for ${agent.label || agent.name}`,
+                    detail: 'tmux',
+                    keywords: `copy attach tmux ${agent.name} ${agent.label || ''}`,
+                    run: () => copyText(agent.attach.live),
+                });
+            }
+            if (agent.attach?.wrapper) {
+                items.push({
+                    title: `Copy wrapper attach for ${agent.label || agent.name}`,
+                    detail: 'tmux',
+                    keywords: `copy attach wrapper tmux ${agent.name} ${agent.label || ''}`,
+                    run: () => copyText(agent.attach.wrapper),
+                });
+            }
+        }
+        commands = items;
+    }
+
+    function openPanel(panelId, toggleFn) {
+        const panel = document.getElementById(panelId);
+        if (panel?.classList.contains('hidden')) toggleFn?.();
+    }
+
+    async function copyText(text) {
+        try {
+            await navigator.clipboard.writeText(text);
+        } catch (_err) {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            ta.remove();
+        }
+    }
+
+    function populateFilters() {
+        const senderSelect = document.getElementById('search-nav-sender');
+        const channelSelect = document.getElementById('search-nav-channel');
+        if (!senderSelect || !channelSelect) return;
+        const senderValue = senderSelect.value;
+        const channelValue = channelSelect.value;
+        const senders = [...new Set(messages.map(m => m.sender).filter(Boolean))].sort();
+        const channels = [...new Set([
+            ...(Array.isArray(window.channelList) ? window.channelList : []),
+            ...messages.map(m => m.channel || 'general'),
+        ].filter(Boolean))].sort();
+        senderSelect.innerHTML = '<option value="">Any sender</option>' + senders.map(s => `<option value="${esc(s)}">${esc(s)}</option>`).join('');
+        channelSelect.innerHTML = '<option value="">Any channel</option>' + channels.map(ch => `<option value="${esc(ch)}">#${esc(ch)}</option>`).join('');
+        senderSelect.value = senders.includes(senderValue) ? senderValue : '';
+        channelSelect.value = channels.includes(channelValue) ? channelValue : '';
+    }
+
+    function currentFilters() {
+        return {
+            query: document.getElementById('search-nav-input')?.value.trim() || '',
+            sender: document.getElementById('search-nav-sender')?.value || '',
+            channel: document.getElementById('search-nav-channel')?.value || '',
+            pinned: document.getElementById('search-nav-pinned')?.checked || false,
+            todo: document.getElementById('search-nav-todo')?.checked || false,
+            done: document.getElementById('search-nav-done')?.checked || false,
+            jobs: document.getElementById('search-nav-jobs')?.checked || false,
+            session: document.getElementById('search-nav-session')?.checked || false,
+            system: document.getElementById('search-nav-system')?.checked || false,
+        };
+    }
+
+    function render() {
+        const root = document.getElementById('search-nav-results');
+        if (!root) return;
+        const filters = currentFilters();
+        const commandOnly = filters.query.startsWith('>');
+        const query = filters.query.replace(/^>\s*/, '').toLowerCase();
+        const commandMatches = commandMatchesForQuery(query);
+        const messageMatches = commandOnly ? [] : messages.filter(msg => matchesMessage(msg, filters)).slice(0, 80);
+        const parts = [];
+        if (commandMatches.length) {
+            parts.push('<div class="search-nav-group">Commands</div>');
+            parts.push(commandMatches.map((cmd, idx) => renderCommand(cmd, idx)).join(''));
+        }
+        if (messageMatches.length) {
+            parts.push('<div class="search-nav-group">Messages</div>');
+            parts.push(messageMatches.map((msg, idx) => renderMessageResult(msg, commandMatches.length + idx)).join(''));
+        }
+        if (!parts.length) {
+            parts.push('<div class="search-nav-empty">No matches.</div>');
+        }
+        root.innerHTML = parts.join('');
+        root.querySelectorAll('.search-nav-item').forEach((item, idx) => {
+            item.classList.toggle('active', idx === activeIndex);
+            item.addEventListener('mouseenter', () => {
+                activeIndex = idx;
+                updateActive();
+            });
+        });
+        updateActive();
+    }
+
+    function matchesMessage(msg, filters) {
+        if (filters.query.startsWith('>')) return false;
+        const query = filters.query.toLowerCase();
+        const senderQuery = query.startsWith('@') ? query.slice(1) : '';
+        if (query === '@') return false;
+        const content = textOf(msg).toLowerCase();
+        if (senderQuery) {
+            const sender = String(msg.sender || '').toLowerCase();
+            if (!sender.startsWith(senderQuery)) return false;
+        } else if (query && !content.includes(query)) {
+            return false;
+        }
+        if (filters.sender && msg.sender !== filters.sender) return false;
+        if (filters.channel && (msg.channel || 'general') !== filters.channel) return false;
+
+        const todoStatus = window.todos?.[msg.id] || null;
+        const typeFilters = [];
+        if (filters.pinned) typeFilters.push(Boolean(todoStatus));
+        if (filters.todo) typeFilters.push(todoStatus === 'todo');
+        if (filters.done) typeFilters.push(todoStatus === 'done');
+        if (filters.jobs) typeFilters.push(Boolean(msg.job_id || msg.metadata?.job_id));
+        if (filters.session) typeFilters.push(Boolean(msg.type === 'session' || msg.metadata?.session_id || msg.metadata?.session_run_id));
+        if (filters.system) typeFilters.push(Boolean(msg.sender === 'system' || ['join', 'leave', 'summary', 'system'].includes(msg.type)));
+        return !typeFilters.length || typeFilters.some(Boolean);
+    }
+
+    function renderCommand(cmd, idx) {
+        return `
+            <button class="search-nav-item" data-index="${idx}" data-kind="command">
+                <div class="search-nav-main">
+                    <div class="search-nav-title"><span>${esc(cmd.title)}</span></div>
+                    <div class="search-nav-snippet">${esc(cmd.keywords || '')}</div>
+                </div>
+                <div class="search-nav-meta">${esc(cmd.detail || '')}</div>
+            </button>
+        `;
+    }
+
+    function renderMessageResult(msg, idx) {
+        const text = textOf(msg).replace(/\s+/g, ' ').trim();
+        const title = `${msg.sender || 'unknown'} in #${msg.channel || 'general'}`;
+        const meta = msg.time || (msg.timestamp ? new Date(msg.timestamp * 1000).toLocaleString() : '');
+        return `
+            <button class="search-nav-item" data-index="${idx}" data-kind="message" data-id="${esc(msg.id)}" data-channel="${esc(msg.channel || 'general')}">
+                <div class="search-nav-main">
+                    <div class="search-nav-title"><span>${esc(title)}</span></div>
+                    <div class="search-nav-snippet">${esc(text || '(no text)')}</div>
+                </div>
+                <div class="search-nav-meta">${esc(meta)}</div>
+            </button>
+        `;
+    }
+
+    function updateActive() {
+        const items = [...document.querySelectorAll('#search-nav-results .search-nav-item')];
+        if (!items.length) {
+            activeIndex = 0;
+            return;
+        }
+        if (activeIndex < 0) activeIndex = items.length - 1;
+        if (activeIndex >= items.length) activeIndex = 0;
+        items.forEach((item, idx) => item.classList.toggle('active', idx === activeIndex));
+    }
+
+    function activateCurrent() {
+        const items = [...document.querySelectorAll('#search-nav-results .search-nav-item')];
+        const item = items[activeIndex];
+        if (!item) return;
+        const kind = item.dataset.kind;
+        if (kind === 'command') {
+            const commandItems = currentCommandMatches();
+            const cmd = commandItems[Number(item.dataset.index)];
+            closeSearchNav();
+            cmd?.run();
+            return;
+        }
+        if (kind === 'message') {
+            const id = item.dataset.id;
+            const channel = item.dataset.channel || 'general';
+            closeSearchNav();
+            if (window.activeChannel !== channel) window.switchChannel?.(channel);
+            setTimeout(() => window.scrollToMessage?.(id), 80);
+        }
+    }
+
+    function currentCommandMatches() {
+        const filters = currentFilters();
+        const query = filters.query.replace(/^>\s*/, '').toLowerCase();
+        return commandMatchesForQuery(query);
+    }
+
+    function commandMatchesForQuery(query) {
+        if (!query) return commands.slice(0, 12);
+        return commands
+            .map((cmd, index) => ({ cmd, index, score: commandScore(cmd, query) }))
+            .filter(item => item.score !== null)
+            .sort((a, b) => a.score - b.score || a.index - b.index)
+            .map(item => item.cmd)
+            .slice(0, 12);
+    }
+
+    function commandScore(cmd, query) {
+        const title = String(cmd.title || '').toLowerCase();
+        const keywords = String(cmd.keywords || '').toLowerCase();
+        if (cmd.kind === 'channel') {
+            const channel = String(cmd.value || '').toLowerCase();
+            if (query === channel || query === `#${channel}`) return 0;
+            if (channel.startsWith(query) || `#${channel}`.startsWith(query)) return 1;
+        }
+        if (title.startsWith(query)) return 2;
+        if (keywords.split(/\s+/).some(word => word.startsWith(query))) return 3;
+        if (`${title} ${keywords}`.includes(query)) return 4;
+        return null;
+    }
+
+    function handleInputKeydown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            closeSearchNav();
+        } else if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            activeIndex += 1;
+            updateActive();
+        } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            activeIndex -= 1;
+            updateActive();
+        } else if (event.key === 'Enter') {
+            event.preventDefault();
+            activateCurrent();
+        }
+    }
+
+    window.openSearchNav = function() {
+        const backdrop = ensureDialog();
+        backdrop.classList.remove('hidden');
+        document.getElementById('search-nav-toggle')?.classList.add('active');
+        activeIndex = 0;
+        refreshData();
+        setTimeout(() => document.getElementById('search-nav-input')?.focus(), 0);
+    };
+
+    window.closeSearchNav = function() {
+        const backdrop = document.getElementById('search-nav-backdrop');
+        if (backdrop) backdrop.classList.add('hidden');
+        document.getElementById('search-nav-toggle')?.classList.remove('active');
+    };
+
+    document.addEventListener('keydown', event => {
+        if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+            event.preventDefault();
+            window.openSearchNav();
+        }
+    });
+
+    document.addEventListener('click', event => {
+        const item = event.target.closest?.('#search-nav-results .search-nav-item');
+        if (!item) return;
+        activeIndex = Number(item.dataset.index || 0);
+        activateCurrent();
+    });
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -639,9 +639,76 @@ header h1 {
     overflow: hidden;
 }
 
+/* --- Presence sidebar --- */
+
+#presence-sidebar {
+    order: 2;
+    width: 180px;
+    min-width: 150px;
+    max-width: 240px;
+    flex-shrink: 0;
+    border-left: 1px solid var(--border);
+    background: var(--bg-header, #1e1e2e);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+body.sidebars-agents-left #presence-sidebar {
+    order: 0;
+    border-left: none;
+    border-right: 1px solid var(--border);
+}
+
+.presence-sidebar-header {
+    padding: 10px 8px 6px 12px;
+    color: var(--text-dim);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    user-select: none;
+}
+
+#presence-sidebar #agent-status {
+    flex-direction: column;
+    gap: 6px;
+    max-width: none;
+    padding: 0 8px 10px;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+#presence-sidebar .status-pill {
+    width: 100%;
+    border-radius: var(--radius-md);
+    justify-content: flex-start;
+    padding: 6px 8px;
+}
+
+#presence-sidebar .status-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+body.jobs-panel-open #presence-sidebar,
+body.rules-panel-open #presence-sidebar,
+body.agent-ops-open #presence-sidebar {
+    display: none;
+}
+
+@media (max-width: 900px) {
+    #presence-sidebar {
+        display: none;
+    }
+}
+
 /* --- Timeline --- */
 
 main#timeline {
+    order: 1;
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
@@ -830,10 +897,6 @@ main#timeline {
     align-items: baseline;
     gap: 8px;
     margin-bottom: 6px;
-}
-
-.message.self .msg-sender {
-    display: none;
 }
 
 .message:hover .chat-bubble {
@@ -1515,6 +1578,7 @@ main#timeline {
 /* --- Sidebar panels (rules + jobs shared) --- */
 
 #rules-panel {
+    order: 3;
     --panel-w: 320px;
     width: var(--panel-w);
     min-width: 220px;
@@ -1530,6 +1594,11 @@ main#timeline {
     position: relative;
 }
 
+#jobs-panel,
+#agent-ops-panel {
+    order: 3;
+}
+
 #rules-panel.hidden {
     margin-right: calc(-1 * var(--panel-w));
     opacity: 0;
@@ -1539,16 +1608,23 @@ main#timeline {
 /* --- Channel sidebar (Discord/Slack-style) --- */
 
 #channel-sidebar {
+    order: 0;
     position: relative;
-    width: var(--channel-sidebar-w, 200px);
-    min-width: 140px;
-    max-width: 400px;
+    width: var(--channel-sidebar-w, 240px);
+    min-width: 180px;
+    max-width: 480px;
     flex-shrink: 0;
     border-right: 1px solid var(--border);
     background: var(--bg-header, #1e1e2e);
     display: flex;
     flex-direction: column;
     overflow: hidden;
+}
+
+body.sidebars-agents-left #channel-sidebar {
+    order: 2;
+    border-right: none;
+    border-left: 1px solid var(--border);
 }
 
 #channel-sidebar.hidden {
@@ -1609,7 +1685,7 @@ main#timeline {
     background: transparent;
     border: none;
     color: var(--text-dim);
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 600;
     font-family: inherit;
     cursor: pointer;
@@ -1691,6 +1767,11 @@ main#timeline {
     z-index: 10;
     background: transparent;
     transition: background 0.15s;
+}
+
+body.sidebars-agents-left .channel-sidebar-grip {
+    left: 0;
+    right: auto;
 }
 
 .channel-sidebar-grip:hover,

--- a/teams/api-agent.toml.example
+++ b/teams/api-agent.toml.example
@@ -1,0 +1,46 @@
+[project]
+name = "api-agent"
+title = "API Agent Room"
+accent_color = "#2fe898"
+tmux_prefix = "agentchattr-api-agent"
+# repo_url = "https://github.com/owner/repo"
+# board_url = "https://github.com/orgs/owner/projects/1"  # replaces Support pill with "Project Board"
+# link_label = "Project Board"  # optional override for the pill label
+# link_url = "https://github.com/orgs/owner/projects/1/views/1"  # optional override for the pill URL
+
+[server]
+port = 8330
+host = "127.0.0.1"
+data_dir = "./data/api-agent"
+
+[mcp]
+http_port = 8240
+sse_port = 8241
+
+[images]
+upload_dir = "./uploads/api-agent"
+
+[routing]
+default = "none"
+max_agent_hops = 100
+
+[agent_defaults.api]
+context_messages = 20
+temperature = 1.0
+
+[agents.local-qwen]
+type = "api"
+base_url = "http://localhost:8189/v1"
+model = "qwen3-4b"
+label = "Local Qwen"
+role = "Builder"
+color = "#8b5cf6"
+
+[agents.minimax]
+type = "api"
+base_url = "https://api.minimax.io/v1"
+model = "MiniMax-M2.7"
+api_key_env = "MINIMAX_API_KEY"
+label = "MiniMax"
+role = "Reviewer"
+color = "#2fe898"

--- a/teams/large-roster.toml.example
+++ b/teams/large-roster.toml.example
@@ -1,24 +1,24 @@
 [project]
-name = "project-a"
-title = "Project A"
-accent_color = "#7c3aed"
-tmux_prefix = "agentchattr-project-a"
+name = "large-roster"
+title = "Large Roster"
+accent_color = "#4285f4"
+tmux_prefix = "agentchattr-large-roster"
 # repo_url = "https://github.com/owner/repo"
 # board_url = "https://github.com/orgs/owner/projects/1"  # replaces Support pill with "Project Board"
 # link_label = "Project Board"  # optional override for the pill label
 # link_url = "https://github.com/orgs/owner/projects/1/views/1"  # optional override for the pill URL
 
 [server]
-port = 8301
+port = 8320
 host = "127.0.0.1"
-data_dir = "./data/project-a"
+data_dir = "./data/large-roster"
 
 [mcp]
-http_port = 8211
-sse_port = 8212
+http_port = 8230
+sse_port = 8231
 
 [images]
-upload_dir = "./uploads/project-a"
+upload_dir = "./uploads/large-roster"
 
 [routing]
 default = "none"
@@ -29,66 +29,37 @@ cwd = ".."
 
 [agent_defaults.codex]
 cwd = ".."
+args = ["--ask-for-approval", "never"]
 
 [agent_defaults.gemini]
 cwd = ".."
 
 [agents.claude-planner]
 provider = "claude"
-color = "#da7756"
 label = "Claude Planner"
 role = "Planner"
-
-[agents.claude-builder]
-provider = "claude"
-color = "#10a37f"
-label = "Claude Builder"
-role = "Builder"
+color = "#da7756"
 
 [agents.claude-reviewer]
 provider = "claude"
-color = "#8b5cf6"
 label = "Claude Reviewer"
 role = "Reviewer"
-
-[agents.claude-tester]
-provider = "claude"
-color = "#f59e0b"
-label = "Claude Tester"
-role = "Tester"
-
-[agents.claude-docs]
-provider = "claude"
-color = "#3b82f6"
-label = "Claude Docs"
-role = "Docs"
+color = "#8b5cf6"
 
 [agents.codex-builder]
 provider = "codex"
-color = "#14b8a6"
 label = "Codex Builder"
 role = "Builder"
-
-[agents.codex-reviewer]
-provider = "codex"
-color = "#ef4444"
-label = "Codex Reviewer"
-role = "Reviewer"
+color = "#10a37f"
 
 [agents.codex-tester]
 provider = "codex"
-color = "#84cc16"
 label = "Codex Tester"
 role = "Tester"
-
-[agents.codex-docs]
-provider = "codex"
-color = "#06b6d4"
-label = "Codex Docs"
-role = "Docs"
+color = "#84cc16"
 
 [agents.gemini-research]
 provider = "gemini"
-color = "#4285f4"
 label = "Gemini Research"
 role = "Researcher"
+color = "#4285f4"

--- a/teams/project-a.toml.example
+++ b/teams/project-a.toml.example
@@ -1,0 +1,89 @@
+[project]
+name = "project-a"
+tmux_prefix = "agentchattr-project-a"
+
+[server]
+port = 8301
+host = "127.0.0.1"
+data_dir = "./data/project-a"
+
+[mcp]
+http_port = 8211
+sse_port = 8212
+
+[images]
+upload_dir = "./uploads/project-a"
+
+[routing]
+default = "none"
+max_agent_hops = 100
+
+[agents.claude-planner]
+provider = "claude"
+cwd = ".."
+color = "#da7756"
+label = "Claude Planner"
+role = "Planner"
+
+[agents.claude-builder]
+provider = "claude"
+cwd = ".."
+color = "#10a37f"
+label = "Claude Builder"
+role = "Builder"
+
+[agents.claude-reviewer]
+provider = "claude"
+cwd = ".."
+color = "#8b5cf6"
+label = "Claude Reviewer"
+role = "Reviewer"
+
+[agents.claude-tester]
+provider = "claude"
+cwd = ".."
+color = "#f59e0b"
+label = "Claude Tester"
+role = "Tester"
+
+[agents.claude-docs]
+provider = "claude"
+cwd = ".."
+color = "#3b82f6"
+label = "Claude Docs"
+role = "Docs"
+
+[agents.codex-builder]
+provider = "codex"
+cwd = ".."
+color = "#14b8a6"
+label = "Codex Builder"
+role = "Builder"
+
+[agents.codex-reviewer]
+provider = "codex"
+cwd = ".."
+color = "#ef4444"
+label = "Codex Reviewer"
+role = "Reviewer"
+
+[agents.codex-tester]
+provider = "codex"
+cwd = ".."
+color = "#84cc16"
+label = "Codex Tester"
+role = "Tester"
+
+[agents.codex-docs]
+provider = "codex"
+cwd = ".."
+color = "#06b6d4"
+label = "Codex Docs"
+role = "Docs"
+
+[agents.gemini-research]
+provider = "gemini"
+cwd = ".."
+color = "#4285f4"
+label = "Gemini Research"
+role = "Researcher"

--- a/teams/two-agent.toml.example
+++ b/teams/two-agent.toml.example
@@ -1,0 +1,42 @@
+[project]
+name = "two-agent"
+title = "Two Agent Room"
+accent_color = "#10a37f"
+tmux_prefix = "agentchattr-two-agent"
+# repo_url = "https://github.com/owner/repo"
+# board_url = "https://github.com/orgs/owner/projects/1"  # replaces Support pill with "Project Board"
+# link_label = "Project Board"  # optional override for the pill label
+# link_url = "https://github.com/orgs/owner/projects/1/views/1"  # optional override for the pill URL
+
+[server]
+port = 8310
+host = "127.0.0.1"
+data_dir = "./data/two-agent"
+
+[mcp]
+http_port = 8220
+sse_port = 8221
+
+[images]
+upload_dir = "./uploads/two-agent"
+
+[routing]
+default = "none"
+max_agent_hops = 100
+
+[agent_defaults.claude]
+cwd = ".."
+args = ["--dangerously-skip-permissions"]
+
+[agents.architect]
+provider = "claude"
+label = "Architect"
+role = "Planner"
+color = "#da7756"
+
+[agents.builder]
+provider = "codex"
+cwd = ".."
+label = "Builder"
+role = "Builder"
+color = "#10a37f"

--- a/tests/test_ac_runner.py
+++ b/tests/test_ac_runner.py
@@ -1,0 +1,123 @@
+import importlib.util
+import importlib.machinery
+import io
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_ac():
+    loader = importlib.machinery.SourceFileLoader("ac_runner", str(ROOT / "ac"))
+    spec = importlib.util.spec_from_loader("ac_runner", loader)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class RunnerCommandTests(unittest.TestCase):
+    def setUp(self):
+        self.ac = load_ac()
+
+    def write_team(self, root: Path, name: str = "demo") -> Path:
+        path = root / f"{name}.toml"
+        path.write_text(
+            """
+[project]
+name = "demo"
+tmux_prefix = "agentchattr-demo"
+
+[server]
+port = 8390
+data_dir = "./data/demo"
+
+[mcp]
+http_port = 8290
+sse_port = 8291
+
+[images]
+upload_dir = "./uploads/demo"
+
+[agents.builder]
+command = "python"
+color = "#10a37f"
+args = ["--quiet"]
+""".strip(),
+            "utf-8",
+        )
+        return path
+
+    def test_dry_run_prints_sessions_ports_paths_and_commands(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            team = self.write_team(Path(tmp))
+            args = types.SimpleNamespace(project="demo", file=str(team), dry_run=True)
+            buf = io.StringIO()
+
+            with mock.patch.object(self.ac, "validate_known_team_files"), redirect_stdout(buf):
+                self.ac.up(args)
+
+        out = buf.getvalue()
+        self.assertIn("Team file:", out)
+        self.assertIn("http://127.0.0.1:8390", out)
+        self.assertIn("MCP HTTP: http://127.0.0.1:8290/mcp", out)
+        self.assertIn("Data dir: ./data/demo", out)
+        self.assertIn("agentchattr-demo-wrap-builder", out)
+        self.assertIn("wrapper.py builder --detach --tmux-prefix agentchattr-demo", out)
+
+    def test_logs_resolves_wrapper_target_and_lines(self):
+        args = types.SimpleNamespace(project="demo", file="/tmp/demo.toml", target="wrapper:builder", lines=50)
+        team = {"project": {"name": "demo", "tmux_prefix": "agentchattr-demo"}, "server": {"port": 8390}, "agents": {"builder": {"command": "python"}}}
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return types.SimpleNamespace(returncode=0, stdout="line\n", stderr="")
+
+        with mock.patch.object(self.ac, "_project_context", return_value=(Path("/tmp/demo.toml"), team, "demo", "agentchattr-demo", 8390, ["builder"])), \
+                mock.patch.object(self.ac, "_check_tmux"), \
+                mock.patch.object(self.ac, "_tmux_session_exists", return_value=True), \
+                mock.patch.object(self.ac.subprocess, "run", side_effect=fake_run):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.ac.logs(args)
+
+        self.assertEqual(calls[0], ["tmux", "capture-pane", "-p", "-t", "agentchattr-demo-wrap-builder", "-S", "-50"])
+        self.assertEqual(buf.getvalue().strip(), "line")
+
+    def test_restart_targets_only_requested_agent_sessions(self):
+        args = types.SimpleNamespace(project="demo", file="/tmp/demo.toml", target="builder")
+        team = {
+            "project": {"name": "demo", "tmux_prefix": "agentchattr-demo"},
+            "server": {"port": 8390},
+            "mcp": {"http_port": 8290, "sse_port": 8291},
+            "agents": {
+                "builder": {"command": "python"},
+                "reviewer": {"command": "python"},
+            },
+        }
+        killed = []
+        started = []
+
+        with mock.patch.object(self.ac, "_project_context", return_value=(Path("/tmp/demo.toml"), team, "demo", "agentchattr-demo", 8390, ["builder", "reviewer"])), \
+                mock.patch.object(self.ac, "_check_tmux"), \
+                mock.patch.object(self.ac, "_preflight_project"), \
+                mock.patch.object(self.ac, "_port_open", return_value=True), \
+                mock.patch.object(self.ac, "_tmux_session_exists", return_value=True), \
+                mock.patch.object(self.ac, "_kill_tmux_session", side_effect=killed.append), \
+                mock.patch.object(self.ac, "_ensure_venv", return_value=Path("/venv/bin/python")), \
+                mock.patch.object(self.ac, "_start_wrapper", side_effect=lambda *a: started.append(a)):
+            self.ac.restart(args)
+
+        self.assertEqual(killed, ["agentchattr-demo-builder", "agentchattr-demo-wrap-builder"])
+        self.assertEqual(len(started), 1)
+        self.assertEqual(started[0][3], "builder")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -7,6 +7,7 @@ same env vars produce the same config regardless of entry point.
 
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -23,6 +24,7 @@ ENV_VARS = [
     "AGENTCHATTR_MCP_HTTP_PORT",
     "AGENTCHATTR_MCP_SSE_PORT",
     "AGENTCHATTR_UPLOAD_DIR",
+    "AGENTCHATTR_PROJECT_CONFIG",
 ]
 
 
@@ -108,6 +110,39 @@ class ConfigOverrideTests(unittest.TestCase):
         # Agent definitions must be untouched by path/port overrides
         self.assertIn("claude", config["agents"])
         self.assertEqual(config["agents"]["claude"]["command"], "claude")
+
+    def test_project_config_replaces_agent_roster_and_merges_settings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project_cfg = Path(tmp) / "project-a.toml"
+            project_cfg.write_text(
+                """
+[server]
+port = 8301
+data_dir = "./data/project-a"
+
+[mcp]
+http_port = 8211
+sse_port = 8212
+
+[agents.architect]
+provider = "claude"
+label = "Architect"
+role = "Planner"
+color = "#da7756"
+""".strip(),
+                "utf-8",
+            )
+            os.environ["AGENTCHATTR_PROJECT_CONFIG"] = str(project_cfg)
+
+            config = config_loader.load_config(ROOT)
+
+        self.assertEqual(config["server"]["port"], 8301)
+        self.assertEqual(config["mcp"]["http_port"], 8211)
+        self.assertEqual(config["mcp"]["sse_port"], 8212)
+        self.assertEqual(list(config["agents"].keys()), ["architect"])
+        self.assertEqual(config["agents"]["architect"]["provider"], "claude")
+        self.assertEqual(config["agents"]["architect"]["command"], "claude")
+        self.assertEqual(config["agents"]["architect"]["role"], "Planner")
 
 
 class CliOverrideExtractionTests(unittest.TestCase):

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,164 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import config_loader  # noqa: E402
+
+
+class ConfigSchemaTests(unittest.TestCase):
+    def setUp(self):
+        self._project_env = os.environ.get(config_loader.PROJECT_CONFIG_ENV)
+        os.environ.pop(config_loader.PROJECT_CONFIG_ENV, None)
+
+    def tearDown(self):
+        if self._project_env is None:
+            os.environ.pop(config_loader.PROJECT_CONFIG_ENV, None)
+        else:
+            os.environ[config_loader.PROJECT_CONFIG_ENV] = self._project_env
+
+    def test_agent_defaults_merge_before_agent_overrides(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "config.toml").write_text(
+                """
+[server]
+port = 8300
+
+[agent_defaults.claude]
+cwd = "../default"
+args = ["--model", "sonnet"]
+color = "#111111"
+
+[agents.architect]
+provider = "claude"
+cwd = "../project"
+label = "Architect"
+color = "#222222"
+""".strip(),
+                "utf-8",
+            )
+
+            config = config_loader.load_config(root)
+
+        agent = config["agents"]["architect"]
+        self.assertEqual(agent["cwd"], "../project")
+        self.assertEqual(agent["args"], ["--model", "sonnet"])
+        self.assertEqual(agent["color"], "#222222")
+        self.assertEqual(agent["command"], "claude")
+
+    def test_project_metadata_and_args_load_from_team_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "config.toml").write_text(
+                """
+[server]
+port = 8300
+
+[agents.default]
+command = "python"
+""".strip(),
+                "utf-8",
+            )
+            project = root / "team.toml"
+            project.write_text(
+                """
+[project]
+name = "roadmap"
+title = "Roadmap Room"
+accent_color = "#10a37f"
+tmux_prefix = "agentchattr-roadmap"
+repo_url = "https://github.com/the-sarge/agentchattr"
+board_url = "https://github.com/orgs/the-sarge/projects/1"
+link_label = "Project Board"
+link_url = "https://github.com/orgs/the-sarge/projects/1/views/1"
+
+[server]
+port = 8310
+
+[agents.builder]
+provider = "codex"
+args = ["--profile", "work"]
+color = "#10a37f"
+role = "Builder"
+""".strip(),
+                "utf-8",
+            )
+            os.environ[config_loader.PROJECT_CONFIG_ENV] = str(project)
+
+            config = config_loader.load_config(root)
+
+        self.assertEqual(config["project"]["title"], "Roadmap Room")
+        self.assertEqual(config["project"]["accent_color"], "#10a37f")
+        self.assertEqual(config["project"]["repo_url"], "https://github.com/the-sarge/agentchattr")
+        self.assertEqual(config["project"]["board_url"], "https://github.com/orgs/the-sarge/projects/1")
+        self.assertEqual(config["project"]["link_label"], "Project Board")
+        self.assertEqual(config["project"]["link_url"], "https://github.com/orgs/the-sarge/projects/1/views/1")
+        self.assertEqual(config["server"]["port"], 8310)
+        self.assertEqual(list(config["agents"].keys()), ["builder"])
+        self.assertEqual(config["agents"]["builder"]["args"], ["--profile", "work"])
+        self.assertEqual(config["agents"]["builder"]["command"], "codex")
+
+    def test_invalid_color_and_role_raise(self):
+        bad = {
+            "project": {"tmux_prefix": "agentchattr-bad", "accent_color": "blue"},
+            "server": {"port": 8300},
+            "agents": {
+                "bad": {
+                    "provider": "claude",
+                    "color": "#xyz",
+                    "role": "this role name is far too long",
+                }
+            },
+        }
+        with self.assertRaises(config_loader.ConfigError) as ctx:
+            config_loader.validate_config(bad, source="bad.toml", require_project=True)
+        msg = str(ctx.exception)
+        self.assertIn("accent_color", msg)
+        self.assertIn("color", msg)
+        self.assertIn("role", msg)
+
+    def test_duplicate_known_team_ports_and_prefixes_raise(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            teams = root / "teams"
+            teams.mkdir()
+            body = """
+[project]
+name = "{name}"
+tmux_prefix = "{prefix}"
+
+[server]
+port = {server_port}
+
+[mcp]
+http_port = {http_port}
+sse_port = {sse_port}
+
+[agents.one]
+provider = "claude"
+""".strip()
+            (teams / "a.toml").write_text(
+                body.format(name="a", prefix="agentchattr-same", server_port=8310, http_port=8210, sse_port=8211),
+                "utf-8",
+            )
+            (teams / "b.toml").write_text(
+                body.format(name="b", prefix="agentchattr-same", server_port=8310, http_port=8220, sse_port=8221),
+                "utf-8",
+            )
+
+            with self.assertRaises(config_loader.ConfigError) as ctx:
+                config_loader.validate_known_team_files(root)
+
+        msg = str(ctx.exception)
+        self.assertIn("duplicate tmux_prefix", msg)
+        self.assertIn("duplicate port 8310", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_apis.py
+++ b/tests/test_project_apis.py
@@ -1,0 +1,142 @@
+import os
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import app  # noqa: E402
+import mcp_bridge  # noqa: E402
+from agents import AgentTrigger  # noqa: E402
+from registry import RuntimeRegistry  # noqa: E402
+
+
+class ProjectApiPayloadTests(unittest.TestCase):
+    def setUp(self):
+        self._saved_config = app.config
+        self._saved_registry = app.registry
+        self._saved_agents = app.agents
+        self._saved_project_env = os.environ.get("AGENTCHATTR_PROJECT_CONFIG")
+        self._saved_prefix_env = os.environ.get("AGENTCHATTR_TMUX_PREFIX")
+        self._presence = dict(mcp_bridge._presence)
+        self._activity = dict(mcp_bridge._activity)
+        self._activity_ts = dict(mcp_bridge._activity_ts)
+        mcp_bridge._presence.clear()
+        mcp_bridge._activity.clear()
+        mcp_bridge._activity_ts.clear()
+        os.environ.pop("AGENTCHATTR_PROJECT_CONFIG", None)
+        os.environ.pop("AGENTCHATTR_TMUX_PREFIX", None)
+
+    def tearDown(self):
+        app.config = self._saved_config
+        app.registry = self._saved_registry
+        app.agents = self._saved_agents
+        if self._saved_project_env is None:
+            os.environ.pop("AGENTCHATTR_PROJECT_CONFIG", None)
+        else:
+            os.environ["AGENTCHATTR_PROJECT_CONFIG"] = self._saved_project_env
+        if self._saved_prefix_env is None:
+            os.environ.pop("AGENTCHATTR_TMUX_PREFIX", None)
+        else:
+            os.environ["AGENTCHATTR_TMUX_PREFIX"] = self._saved_prefix_env
+        mcp_bridge._presence.clear()
+        mcp_bridge._presence.update(self._presence)
+        mcp_bridge._activity.clear()
+        mcp_bridge._activity.update(self._activity)
+        mcp_bridge._activity_ts.clear()
+        mcp_bridge._activity_ts.update(self._activity_ts)
+
+    def test_project_payload_defaults_without_team_file(self):
+        app.config = {
+            "server": {"port": 8300, "host": "127.0.0.1", "data_dir": "./data"},
+            "mcp": {"http_port": 8200, "sse_port": 8201},
+            "images": {"upload_dir": "./uploads"},
+            "agents": {"builder": {"command": "python"}},
+        }
+
+        payload = app._project_payload()
+
+        self.assertEqual(payload["name"], "agentchattr")
+        self.assertIsNone(payload["team_file"])
+        self.assertEqual(payload["server"]["port"], 8300)
+        self.assertEqual(payload["tmux_prefix"], "agentchattr-agentchattr")
+
+    def test_project_payload_uses_project_metadata_and_env_prefix(self):
+        os.environ["AGENTCHATTR_TMUX_PREFIX"] = "agentchattr-env"
+        app.config = {
+            "_meta": {"project_config_path": "/tmp/team.toml"},
+            "project": {
+                "name": "demo",
+                "title": "Demo Room",
+                "accent_color": "#10a37f",
+                "repo_url": "https://github.com/the-sarge/agentchattr",
+                "board_url": "https://github.com/orgs/the-sarge/projects/1",
+                "link_label": "Project Board",
+                "link_url": "https://github.com/orgs/the-sarge/projects/1/views/1",
+            },
+            "server": {"port": 8390, "host": "127.0.0.1", "data_dir": "./data/demo"},
+            "mcp": {"http_port": 8290, "sse_port": 8291},
+            "images": {"upload_dir": "./uploads/demo"},
+            "agents": {"builder": {"provider": "codex"}},
+        }
+
+        payload = app._project_payload()
+
+        self.assertEqual(payload["name"], "demo")
+        self.assertEqual(payload["title"], "Demo Room")
+        self.assertEqual(payload["accent_color"], "#10a37f")
+        self.assertEqual(payload["repo_url"], "https://github.com/the-sarge/agentchattr")
+        self.assertEqual(payload["board_url"], "https://github.com/orgs/the-sarge/projects/1")
+        self.assertEqual(payload["link_label"], "Project Board")
+        self.assertEqual(payload["link_url"], "https://github.com/orgs/the-sarge/projects/1/views/1")
+        self.assertEqual(payload["team_file"], "/tmp/team.toml")
+        self.assertEqual(payload["tmux_prefix"], "agentchattr-env")
+
+    def test_channel_name_limit_allows_24_characters(self):
+        self.assertRegex("abcdefghijklmnopqrstuvwx", app._CHANNEL_NAME_RE)
+        self.assertNotRegex("abcdefghijklmnopqrstuvwxy", app._CHANNEL_NAME_RE)
+
+    def test_agent_ops_payload_flags_configured_registered_and_wrapper_mismatches(self):
+        app.config = {
+            "project": {"name": "demo", "tmux_prefix": "agentchattr-demo"},
+            "server": {"port": 8390, "host": "127.0.0.1", "data_dir": "./data/demo"},
+            "mcp": {"http_port": 8290, "sse_port": 8291},
+            "images": {"upload_dir": "./uploads/demo"},
+            "agents": {
+                "builder": {"provider": "codex", "label": "Builder", "color": "#10a37f", "role": "Builder"},
+                "reviewer": {"provider": "claude", "label": "Reviewer", "color": "#da7756"},
+            },
+        }
+        registry = RuntimeRegistry(data_dir="./data/test")
+        registry.seed(app.config["agents"])
+        registry.register("builder")
+        registry._bases.pop("ghost", None)
+        app.registry = registry
+        app.agents = AgentTrigger(registry, data_dir="./data/test")
+        mcp_bridge._presence["builder"] = time.time() - 2
+        mcp_bridge._activity["builder"] = True
+        mcp_bridge._activity_ts["builder"] = time.time()
+
+        with mock.patch.object(app, "_tmux_sessions", return_value={
+            "agentchattr-demo-server",
+            "agentchattr-demo-builder",
+            "agentchattr-demo-wrap-builder",
+            "agentchattr-demo-wrap-reviewer",
+        }):
+            payload = app._agent_ops_payload()
+
+        self.assertIn("reviewer", payload["mismatches"]["configured_not_registered"])
+        self.assertIn("reviewer", payload["mismatches"]["wrapper_running_without_live_heartbeat"])
+        builder = next(row for row in payload["configured_agents"] if row["name"] == "builder")
+        self.assertTrue(builder["online"])
+        self.assertTrue(builder["busy"])
+        self.assertEqual(builder["registered_names"], ["builder"])
+        self.assertIn("tmux attach -t agentchattr-demo-builder", builder["attach"]["live"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrapper_mcp_config.py
+++ b/tests/test_wrapper_mcp_config.py
@@ -15,7 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from wrapper import _resolve_mcp_inject, _write_json_mcp_settings  # noqa: E402
+from wrapper import _build_provider_launch, _resolve_mcp_inject, _write_json_mcp_settings  # noqa: E402
 
 
 class JsonMcpSettingsTests(unittest.TestCase):
@@ -125,6 +125,30 @@ class ProviderAliasDefaultsTests(unittest.TestCase):
         })
         self.assertEqual(cfg["mcp_inject"], "settings_file")
         self.assertEqual(cfg["mcp_settings_path"], ".custom/settings.json")
+
+    def test_agent_args_are_between_mcp_args_and_user_passthrough(self):
+        launch_args, _env, _inject_env, _path = _build_provider_launch(
+            agent="builder",
+            agent_cfg={
+                "provider": "codex",
+                "mcp_inject": "proxy_flag",
+                "mcp_proxy_flag_template": "--mcp {url}",
+                "args": ["--model", "gpt-5.2"],
+            },
+            instance_name="builder",
+            data_dir=Path(tempfile.gettempdir()),
+            proxy_url="http://127.0.0.1:9999/mcp",
+            extra_args=["--ask-for-approval", "never"],
+            env={},
+        )
+        self.assertEqual(
+            launch_args,
+            [
+                "--mcp", "http://127.0.0.1:9999/mcp",
+                "--model", "gpt-5.2",
+                "--ask-for-approval", "never",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_wrapper_mcp_config.py
+++ b/tests/test_wrapper_mcp_config.py
@@ -15,7 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from wrapper import _write_json_mcp_settings  # noqa: E402
+from wrapper import _resolve_mcp_inject, _write_json_mcp_settings  # noqa: E402
 
 
 class JsonMcpSettingsTests(unittest.TestCase):
@@ -105,6 +105,26 @@ class ExpanduserPathTests(unittest.TestCase):
         raw = ".qwen/settings.json"
         expanded = Path(raw).expanduser()
         self.assertFalse(expanded.is_absolute())
+
+
+class ProviderAliasDefaultsTests(unittest.TestCase):
+    def test_claude_alias_uses_claude_mcp_defaults(self):
+        cfg = _resolve_mcp_inject("architect", {"provider": "claude"})
+        self.assertEqual(cfg["mcp_inject"], "flag")
+        self.assertEqual(cfg["mcp_flag"], "--mcp-config")
+
+    def test_codex_alias_uses_codex_mcp_defaults(self):
+        cfg = _resolve_mcp_inject("builder", {"provider": "codex"})
+        self.assertEqual(cfg["mcp_inject"], "proxy_flag")
+
+    def test_explicit_mcp_inject_still_wins(self):
+        cfg = _resolve_mcp_inject("architect", {
+            "provider": "claude",
+            "mcp_inject": "settings_file",
+            "mcp_settings_path": ".custom/settings.json",
+        })
+        self.assertEqual(cfg["mcp_inject"], "settings_file")
+        self.assertEqual(cfg["mcp_settings_path"], ".custom/settings.json")
 
 
 if __name__ == "__main__":

--- a/wrapper.py
+++ b/wrapper.py
@@ -164,12 +164,13 @@ _VALID_INJECT_MODES = {"settings_file", "env", "flag", "proxy_flag", "env_conten
 
 
 def _resolve_mcp_inject(agent: str, agent_cfg: dict) -> dict:
-    """Resolve MCP injection config: explicit agent_cfg > built-in defaults > None."""
+    """Resolve MCP injection config: explicit agent_cfg > provider defaults > None."""
     inject_mode = agent_cfg.get("mcp_inject")
     if inject_mode:
         return dict(agent_cfg)
-    if agent in _BUILTIN_DEFAULTS:
-        merged = dict(_BUILTIN_DEFAULTS[agent])
+    provider = str(agent_cfg.get("provider", agent)).strip().lower()
+    if provider in _BUILTIN_DEFAULTS:
+        merged = dict(_BUILTIN_DEFAULTS[provider])
         merged.update({k: v for k, v in agent_cfg.items() if k.startswith("mcp_")})
         return merged
     return {}
@@ -575,6 +576,8 @@ def main():
     parser.add_argument("agent", choices=agent_names, help=f"Agent to wrap ({', '.join(agent_names)})")
     parser.add_argument("--no-restart", action="store_true", help="Do not restart on exit")
     parser.add_argument("--label", type=str, default=None, help="Custom display label")
+    parser.add_argument("--detach", action="store_true", help="Start the agent tmux session without attaching")
+    parser.add_argument("--tmux-prefix", default=None, help="Prefix for Unix tmux session names")
     # Per-project isolation flags (must match the server's flags so wrappers
     # launched separately connect to the right instance). Values are consumed
     # by apply_cli_overrides() above; listing here so --help shows them.
@@ -588,7 +591,8 @@ def main():
     agent = args.agent
     agent_cfg = config.get("agents", {}).get(agent, {})
     cwd = agent_cfg.get("cwd", ".")
-    command = agent_cfg.get("command", agent)
+    provider = str(agent_cfg.get("provider", agent)).strip().lower()
+    command = agent_cfg.get("command", provider or agent)
     data_dir = ROOT / config.get("server", {}).get("data_dir", "./data")
     data_dir.mkdir(parents=True, exist_ok=True)
     server_port = config.get("server", {}).get("port", 8300)
@@ -715,7 +719,7 @@ def main():
 
     # Gemini: ensure the project directory is trusted so MCPs are allowed.
     # Gemini blocks ALL MCPs for untrusted folders — even system-settings ones.
-    if agent == "gemini" or inject_cfg.get("mcp_inject") == "env":
+    if provider == "gemini" or agent == "gemini" or inject_cfg.get("mcp_inject") == "env":
         _ensure_gemini_folder_trusted(project_dir)
 
     launch_args, env, inject_env, mcp_settings_path = _build_provider_launch(
@@ -868,7 +872,8 @@ def main():
     else:
         from wrapper_unix import get_activity_checker, run_agent
 
-        unix_session_name = f"agentchattr-{assigned_name}"
+        tmux_prefix = args.tmux_prefix or os.environ.get("AGENTCHATTR_TMUX_PREFIX", "")
+        unix_session_name = f"{tmux_prefix}-{assigned_name}" if tmux_prefix else f"agentchattr-{assigned_name}"
         _set_activity_checker(get_activity_checker(unix_session_name, trigger_flag=_trigger_flag))
 
     run_kwargs = dict(
@@ -890,6 +895,7 @@ def main():
         run_kwargs["enter_backend"] = agent_cfg.get("enter_backend", "console_input")
     if sys.platform != "win32":
         run_kwargs["session_name"] = unix_session_name
+        run_kwargs["attach"] = not args.detach
 
     try:
         run_agent(**run_kwargs)

--- a/wrapper.py
+++ b/wrapper.py
@@ -361,7 +361,12 @@ def _build_provider_launch(
         token=token, mcp_cfg=mcp_cfg, project_dir=project_dir,
     )
 
-    launch_args = [*mcp_args, *extra_args]
+    configured_args = agent_cfg.get("args", [])
+    if isinstance(configured_args, list):
+        configured_args = [str(arg) for arg in configured_args]
+    else:
+        configured_args = []
+    launch_args = [*mcp_args, *configured_args, *extra_args]
     launch_env = dict(env)
 
     return launch_args, launch_env, inject_env, settings_path
@@ -562,13 +567,17 @@ def main():
     import urllib.error
     import urllib.request
 
-    from config_loader import apply_cli_overrides, load_config
+    from config_loader import ConfigError, apply_cli_overrides, load_config
 
     # Apply AGENTCHATTR_* overrides (from CLI flags or env) BEFORE loading
     # config so the wrapper connects to the same data_dir/ports as a server
     # launched with matching flags.
     apply_cli_overrides()
-    config = load_config(ROOT)
+    try:
+        config = load_config(ROOT)
+    except ConfigError as exc:
+        print(f"  Config error: {exc}")
+        sys.exit(1)
 
     agent_names = list(config.get("agents", {}).keys())
 

--- a/wrapper_api.py
+++ b/wrapper_api.py
@@ -39,14 +39,18 @@ def _auth_headers(token: str, *, include_json: bool = False) -> dict[str, str]:
 
 
 def main():
-    from config_loader import apply_cli_overrides, load_config
+    from config_loader import ConfigError, apply_cli_overrides, load_config
     from wrapper import _register_instance
 
     # Apply AGENTCHATTR_* overrides (from CLI flags or env) BEFORE loading
     # config so the API wrapper connects to the same data_dir/ports as a
     # server launched with matching flags.
     apply_cli_overrides()
-    config = load_config(ROOT)
+    try:
+        config = load_config(ROOT)
+    except ConfigError as exc:
+        print(f"  Config error: {exc}")
+        sys.exit(1)
     agent_names = list(config.get("agents", {}).keys())
     api_agents = [n for n in agent_names if config["agents"][n].get("type") == "api"]
 

--- a/wrapper_unix.py
+++ b/wrapper_unix.py
@@ -93,6 +93,7 @@ def run_agent(
     session_name=None,
     inject_env=None,
     inject_delay: float = 0.3,
+    attach: bool = True,
 ):
     """Run agent inside a tmux session, inject via tmux send-keys."""
     _check_tmux()
@@ -145,6 +146,13 @@ def run_agent(
             )
             if result.returncode != 0:
                 print(f"  Error: failed to create tmux session (exit {result.returncode})")
+                break
+
+            if not attach:
+                print(f"  Started detached. {agent.capitalize()} is running in tmux.")
+                print(f"  Reattach: tmux attach -t {session_name}")
+                while _session_exists(session_name):
+                    time.sleep(1)
                 break
 
             # Attach — blocks until agent exits or user detaches (Ctrl+B, D)


### PR DESCRIPTION
## Summary
- add project-aware tmux runner commands: list, dry-run, restart, logs, and stronger preflight checks
- add shared team config validation/default merging plus project metadata fields
- add project and agent operations APIs, Agent Operations UI, command/search palette, configurable sidebars, and project board link support
- update examples, docs, and the temporary manual test checklist

## Validation
- .venv/bin/python -m pytest -q
- node --check static/channels.js && node --check static/chat.js && node --check static/agent-ops.js && node --check static/search-nav.js && node --check static/jobs.js && node --check static/rules-panel.js
- git diff --check
