### PR TITLE
fix(registry): survive sleep/restart without stale-session errors or identity collisions

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -122,16 +122,18 @@ class RuntimeRegistry:
             data = json.loads(p.read_text("utf-8"))
         except Exception:
             return
-        for n, d in data.get("instances", {}).items():
-            try:
-                self._instances[n] = _inst_from_dict(d)
-            except Exception:
-                pass
-        for n, d in data.get("reclaimable", {}).items():
-            try:
-                self._reclaimable[n] = _inst_from_dict(d)
-            except Exception:
-                pass
+        # On startup nobody is proven alive: a persisted "active" instance may be a
+        # dead pre-restart wrapper. Load everything as reclaimable — a wrapper that is
+        # genuinely still alive reactivates its token on its next call (resolve_token),
+        # while dead wrappers stay dormant instead of squatting a slot. Loading them as
+        # active would make the empty post-restart presence map immortalize the ghost
+        # (the crash-timeout only fires for names with last_seen > 0).
+        for section in ("instances", "reclaimable"):
+            for n, d in data.get(section, {}).items():
+                try:
+                    self._reclaimable[n] = _inst_from_dict(d)
+                except Exception:
+                    pass
 
     def _restore_reclaimable_locked(self, sender: str, target_name: str | None):
         """Restore a reclaimable identity into the live set if its live copy is gone.
@@ -150,10 +152,16 @@ class RuntimeRegistry:
                 if inst.base == sender and name not in self._instances:
                     cand = name
                     break
-        if cand and cand not in self._instances:
-            inst = self._reclaimable.pop(cand)
-            self._reserved.pop(cand, None)
-            self._instances[cand] = inst
+        if not cand or cand in self._instances:
+            return
+        inst = self._reclaimable[cand]
+        # Fresh-wins: never revive an identity whose (base, slot) is already live
+        # (e.g. its slot was reclaimed by a fresh launch or a rename-back).
+        if any(li.base == inst.base and li.slot == inst.slot for li in self._instances.values()):
+            return
+        self._reclaimable.pop(cand, None)
+        self._reserved.pop(cand, None)
+        self._instances[cand] = inst
 
     # --- Registration ---
 
@@ -215,7 +223,12 @@ class RuntimeRegistry:
             state = "active"
             inst = Instance(name=name, base=base, slot=slot, label=lbl, color=color, state=state)
             self._instances[name] = inst
-            self._reclaimable.pop(name, None)  # fresh registration supersedes any reclaimable token
+            # Fresh registration supersedes any reclaimable identity occupying the same
+            # (base, slot) — including custom-named aliases (e.g. 'claude-music') that
+            # don't match `name`. Enforces fresh-wins by coordinate, not by string name.
+            for stale in [rn for rn, ri in self._reclaimable.items()
+                          if ri.base == base and ri.slot == slot]:
+                del self._reclaimable[stale]
             result = _inst_dict(inst, include_token=True)
             if renamed_slot1:
                 result["_renamed_slot1"] = renamed_slot1
@@ -589,21 +602,33 @@ class RuntimeRegistry:
         """
         result = None
         reactivated = False
+        changed = False
         with self._lock:
             for inst in self._instances.values():
                 if inst.token == token:
                     return _inst_dict(inst)
             for name, inst in list(self._reclaimable.items()):
-                if inst.token == token and name not in self._instances:
-                    inst.state = "active"
-                    self._instances[name] = inst
+                if inst.token != token or name in self._instances:
+                    continue
+                # Fresh-wins guard: if a live instance already holds this (base, slot),
+                # the token is stale (its identity was superseded by a fresh launch or a
+                # rename-back). Drop it rather than reviving a colliding second instance.
+                if any(li.base == inst.base and li.slot == inst.slot
+                       for li in self._instances.values()):
                     del self._reclaimable[name]
-                    self._reserved.pop(name, None)
-                    result = _inst_dict(inst)
-                    reactivated = True
-                    break
+                    changed = True
+                    continue
+                inst.state = "active"
+                self._instances[name] = inst
+                del self._reclaimable[name]
+                self._reserved.pop(name, None)
+                result = _inst_dict(inst)
+                reactivated = True
+                changed = True
+                break
         if reactivated:
             self._notify()
+        if changed:
             self._save_instances()
         return result
 

--- a/registry.py
+++ b/registry.py
@@ -40,9 +40,11 @@ class RuntimeRegistry:
         self._instances: dict[str, Instance] = {}   # canonical name → Instance
         self._reserved: dict[str, float] = {}       # name → deregister timestamp
         self._renames: dict[str, str] = {}           # old name → new name (for heartbeat redirect)
+        self._reclaimable: dict[str, Instance] = {}  # name → deregistered Instance, recoverable on reconnect
         self._on_change_cbs: list = []
         self._data_dir = Path(data_dir)
         self._load_renames()
+        self._load_instances()
 
     # --- Setup ---
 
@@ -87,6 +89,71 @@ class RuntimeRegistry:
             tmp.replace(self._renames_path())
         except Exception:
             pass
+
+    # --- Instance persistence (survives server restart) ---
+
+    def _instances_path(self) -> Path:
+        return self._data_dir / "registry.json"
+
+    def _save_instances(self):
+        """Persist live + reclaimable instances (incl. tokens) to disk.
+
+        Tokens live in the local ./data dir, consistent with the existing local-only
+        posture (server binds 127.0.0.1). Must be called outside the lock.
+        """
+        try:
+            self._data_dir.mkdir(parents=True, exist_ok=True)
+            with self._lock:
+                data = {
+                    "instances": {n: _inst_full(i) for n, i in self._instances.items()},
+                    "reclaimable": {n: _inst_full(i) for n, i in self._reclaimable.items()},
+                }
+            tmp = self._instances_path().with_suffix(".tmp")
+            tmp.write_text(json.dumps(data), "utf-8")
+            tmp.replace(self._instances_path())
+        except Exception:
+            pass
+
+    def _load_instances(self):
+        p = self._instances_path()
+        if not p.exists():
+            return
+        try:
+            data = json.loads(p.read_text("utf-8"))
+        except Exception:
+            return
+        for n, d in data.get("instances", {}).items():
+            try:
+                self._instances[n] = _inst_from_dict(d)
+            except Exception:
+                pass
+        for n, d in data.get("reclaimable", {}).items():
+            try:
+                self._reclaimable[n] = _inst_from_dict(d)
+            except Exception:
+                pass
+
+    def _restore_reclaimable_locked(self, sender: str, target_name: str | None):
+        """Restore a reclaimable identity into the live set if its live copy is gone.
+
+        Lets chat_claim recover an identity deregistered by the crash-timeout during
+        sleep. Must be called while holding self._lock. A name freshly re-registered by
+        someone else is left untouched (fresh registration wins).
+        """
+        if sender in self._instances:
+            return
+        cand = None
+        if sender in self._reclaimable:                      # exact name (e.g. 'claude-2')
+            cand = sender
+        elif sender in self._bases:                          # family: first free reclaimable of base
+            for name, inst in self._reclaimable.items():
+                if inst.base == sender and name not in self._instances:
+                    cand = name
+                    break
+        if cand and cand not in self._instances:
+            inst = self._reclaimable.pop(cand)
+            self._reserved.pop(cand, None)
+            self._instances[cand] = inst
 
     # --- Registration ---
 
@@ -148,12 +215,14 @@ class RuntimeRegistry:
             state = "active"
             inst = Instance(name=name, base=base, slot=slot, label=lbl, color=color, state=state)
             self._instances[name] = inst
+            self._reclaimable.pop(name, None)  # fresh registration supersedes any reclaimable token
             result = _inst_dict(inst, include_token=True)
             if renamed_slot1:
                 result["_renamed_slot1"] = renamed_slot1
 
         self._notify()
         self._save_renames()
+        self._save_instances()
         return result
 
     def deregister(self, name: str) -> dict | None:
@@ -165,9 +234,11 @@ class RuntimeRegistry:
         with self._lock:
             if name not in self._instances:
                 return None
-            base = self._instances[name].base
+            inst_removed = self._instances[name]
+            base = inst_removed.base
             del self._instances[name]
             self._reserved[name] = time.time()
+            self._reclaimable[name] = inst_removed  # keep token recoverable on reconnect
 
             # If family drops to 1 instance with a numbered name, rename back to base
             renamed_back = None
@@ -189,6 +260,7 @@ class RuntimeRegistry:
 
         self._notify()
         self._save_renames()
+        self._save_instances()
         result = {"ok": True}
         if renamed_back:
             result["_renamed_back"] = renamed_back
@@ -209,6 +281,8 @@ class RuntimeRegistry:
         error = None
         result = None
         with self._lock:
+            # Recover a reclaimable identity (e.g. deregistered by crash-timeout during sleep)
+            self._restore_reclaimable_locked(sender, target_name)
             inst = None
 
             # If sender is a base family name, use family-based matching
@@ -286,6 +360,7 @@ class RuntimeRegistry:
             return error
         self._notify()
         self._save_renames()
+        self._save_instances()
         return result
 
     def confirm_pending(self, name: str) -> bool:
@@ -298,6 +373,7 @@ class RuntimeRegistry:
 
         self._notify()
         self._save_renames()
+        self._save_instances()
         return True
 
     # --- Rename / Label ---
@@ -361,6 +437,7 @@ class RuntimeRegistry:
 
         self._notify()
         self._save_renames()
+        self._save_instances()
         return result
 
     def set_label(self, name: str, label: str) -> bool:
@@ -373,6 +450,7 @@ class RuntimeRegistry:
 
         self._notify()
         self._save_renames()
+        self._save_instances()
         return True
 
     # --- Queries ---
@@ -503,12 +581,31 @@ class RuntimeRegistry:
             return i is not None and i.state == "pending"
 
     def resolve_token(self, token: str) -> dict | None:
-        """Map an instance_token to the current canonical instance dict, or None."""
+        """Map an instance_token to the current canonical instance dict, or None.
+
+        If the token belongs to a deregistered-but-reclaimable instance (e.g. the agent
+        was crash-timed-out while the machine slept), reactivate it transparently rather
+        than rejecting it — provided its name has not since been freshly re-registered.
+        """
+        result = None
+        reactivated = False
         with self._lock:
             for inst in self._instances.values():
                 if inst.token == token:
                     return _inst_dict(inst)
-        return None
+            for name, inst in list(self._reclaimable.items()):
+                if inst.token == token and name not in self._instances:
+                    inst.state = "active"
+                    self._instances[name] = inst
+                    del self._reclaimable[name]
+                    self._reserved.pop(name, None)
+                    result = _inst_dict(inst)
+                    reactivated = True
+                    break
+        if reactivated:
+            self._notify()
+            self._save_instances()
+        return result
 
     def get_pending(self) -> list[dict]:
         """All pending instances (for timeout checks)."""
@@ -575,6 +672,24 @@ def _inst_dict(inst: Instance, include_token: bool = False) -> dict:
     if include_token:
         d["token"] = inst.token
     return d
+
+
+def _inst_full(inst: Instance) -> dict:
+    """Full serialization incl. token + identity, for persistence/reclaim."""
+    return {
+        "name": inst.name, "base": inst.base, "slot": inst.slot, "label": inst.label,
+        "color": inst.color, "identity_id": inst.identity_id, "token": inst.token,
+        "epoch": inst.epoch, "state": inst.state, "registered_at": inst.registered_at,
+    }
+
+
+def _inst_from_dict(d: dict) -> Instance:
+    return Instance(
+        name=d["name"], base=d["base"], slot=int(d["slot"]), label=d["label"],
+        color=d["color"], identity_id=d.get("identity_id", uuid.uuid4().hex),
+        token=d["token"], epoch=int(d.get("epoch", 1)), state=d.get("state", "active"),
+        registered_at=float(d.get("registered_at", time.time())),
+    )
 
 
 def _derive_color(base_hex: str, slot: int) -> str:

--- a/registry.py
+++ b/registry.py
@@ -163,6 +163,24 @@ class RuntimeRegistry:
         self._reserved.pop(cand, None)
         self._instances[cand] = inst
 
+    def _evict_reclaimable_collisions_locked(self):
+        """Drop reclaimables that collide with any live instance, by name or (base, slot).
+
+        The live instance is authoritative: a reclaimable sharing its canonical name or
+        its (base, slot) coordinate is stale and must not survive to be persisted. If it
+        did, `_save_instances` would write both records and `_load_instances` could let
+        the stale one overwrite the live one (same dict key) on restart — reviving a dead
+        token and stranding the live one. Call this after any mutation that creates or
+        moves a live instance (register incl. slot-1 rename, deregister rename-back,
+        claim, rename), while holding self._lock. Keeps _instances and _reclaimable
+        disjoint so the persisted snapshot is always unambiguous.
+        """
+        live_names = set(self._instances.keys())
+        live_coords = {(i.base, i.slot) for i in self._instances.values()}
+        for rn in [rn for rn, ri in self._reclaimable.items()
+                   if rn in live_names or (ri.base, ri.slot) in live_coords]:
+            del self._reclaimable[rn]
+
     # --- Registration ---
 
     def register(self, base: str, label: str | None = None) -> dict | None:
@@ -223,12 +241,10 @@ class RuntimeRegistry:
             state = "active"
             inst = Instance(name=name, base=base, slot=slot, label=lbl, color=color, state=state)
             self._instances[name] = inst
-            # Fresh registration supersedes any reclaimable identity occupying the same
-            # (base, slot) — including custom-named aliases (e.g. 'claude-music') that
-            # don't match `name`. Enforces fresh-wins by coordinate, not by string name.
-            for stale in [rn for rn, ri in self._reclaimable.items()
-                          if ri.base == base and ri.slot == slot]:
-                del self._reclaimable[stale]
+            # Fresh registration (plus any slot-1 rename above) supersedes reclaimable
+            # identities sharing those names/(base, slot) coordinates — including custom
+            # aliases that don't match `name`. Enforces fresh-wins by coordinate, not name.
+            self._evict_reclaimable_collisions_locked()
             result = _inst_dict(inst, include_token=True)
             if renamed_slot1:
                 result["_renamed_slot1"] = renamed_slot1
@@ -270,6 +286,11 @@ class RuntimeRegistry:
                     self._instances[base] = remaining
                     self._renames[old_name] = base
                     renamed_back = {"old": old_name, "new": base}
+
+            # A rename-back may have moved a live instance onto a (base, slot) that the
+            # just-deregistered identity still occupies in _reclaimable — drop such stale
+            # collisions so they can't outlive the live identity across a restart.
+            self._evict_reclaimable_collisions_locked()
 
         self._notify()
         self._save_renames()
@@ -369,6 +390,11 @@ class RuntimeRegistry:
                         self._renames[old_name] = target_name
                         result = _inst_dict(inst)
 
+            # If we activated/renamed a live instance into a (base, slot), drop any
+            # reclaimable now colliding with it (same invariant as register/deregister).
+            if not error:
+                self._evict_reclaimable_collisions_locked()
+
         if error:
             return error
         self._notify()
@@ -447,6 +473,10 @@ class RuntimeRegistry:
                 self._instances[new_name] = inst
                 self._renames[old_name] = new_name
                 result = _inst_dict(inst)
+
+            # Renaming moved a live instance onto new_name/(base, slot); drop any
+            # reclaimable now colliding with it (same fresh-wins invariant).
+            self._evict_reclaimable_collisions_locked()
 
         self._notify()
         self._save_renames()

--- a/tests/test_session_reclaim.py
+++ b/tests/test_session_reclaim.py
@@ -1,0 +1,81 @@
+"""Tests for session reclaim / reconnection survival.
+
+Regression coverage for the "stale or unknown authenticated agent session" issue:
+a long-running agent (e.g. Claude Code) gets deregistered by the crash-timeout when
+the machine sleeps (heartbeat threads freeze), then on wake re-presents its old token.
+The registry must let that identity recover (reactivate the token) instead of treating
+it as permanently dead — while a *fresh* re-registration (e.g. Codex relaunch) must
+still supersede the old token.
+"""
+
+import sys
+import unittest
+import tempfile
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from registry import RuntimeRegistry
+
+
+class SessionReclaimTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.reg = RuntimeRegistry(data_dir=self.tmp)
+        self.reg.seed({
+            "claude": {"label": "Claude", "color": "#ff6a00"},
+            "codex": {"label": "Codex", "color": "#00B67D"},
+        })
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_deregistered_token_is_reclaimable(self):
+        """Single persistent agent deregistered during sleep recovers via its token."""
+        inst = self.reg.register("claude")
+        token = inst["token"]
+        self.reg.deregister("claude")          # crash-timeout fires during sleep
+        resolved = self.reg.resolve_token(token)  # same token presented on wake
+        self.assertIsNotNone(resolved, "stale token should reactivate, not be rejected")
+        self.assertEqual(resolved["name"], "claude")
+        self.assertEqual(resolved["state"], "active")
+
+    def test_fresh_registration_supersedes_reclaimable(self):
+        """A fresh relaunch (new token) must win; the old token must NOT reactivate."""
+        first = self.reg.register("codex")
+        old_tok = first["token"]
+        self.reg.deregister("codex")
+        # The overnight gap is far longer than the 30s name-reservation grace, so the
+        # fresh morning relaunch reclaims the canonical 'codex' name (not 'codex-2').
+        self.reg._reserved.clear()
+        second = self.reg.register("codex")     # fresh relaunch, new token, same name
+        new_tok = second["token"]
+        self.assertEqual(second["name"], "codex")
+        self.assertIsNone(self.reg.resolve_token(old_tok),
+                          "old token must stay stale once the name is freshly re-registered")
+        self.assertIsNotNone(self.reg.resolve_token(new_tok))
+
+    def test_claim_recovers_reclaimable_identity(self):
+        """chat_claim(sender='claude') after deregister recovers the identity."""
+        self.reg.register("claude")
+        self.reg.deregister("claude")
+        result = self.reg.claim("claude")
+        self.assertIsInstance(result, dict, f"claim should recover, got: {result!r}")
+        self.assertEqual(result["name"], "claude")
+        self.assertEqual(result["state"], "active")
+
+    def test_persistence_round_trip_survives_server_restart(self):
+        """A live token must survive a server restart (new RuntimeRegistry, same data_dir)."""
+        inst = self.reg.register("claude")
+        token = inst["token"]
+        reg2 = RuntimeRegistry(data_dir=self.tmp)   # simulates server process restart
+        reg2.seed({"claude": {"label": "Claude", "color": "#ff6a00"}})
+        self.assertIsNotNone(reg2.resolve_token(token),
+                             "token should survive a server restart via persistence")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_reclaim.py
+++ b/tests/test_session_reclaim.py
@@ -139,6 +139,85 @@ class SessionReclaimTests(unittest.TestCase):
         self.assertEqual(active_slot1, ["claude"],
                          f"claim must not create a second active slot-1; got {active_slot1}")
 
+    def test_live_slot1_token_survives_restart_despite_stale_reclaimable(self):
+        """Rename-back + re-register must not strand the current live token on restart.
+
+        6-step repro: register claude (A); register claude (A->'claude-1', B->'claude-2');
+        deregister 'claude-1' (A reclaimable@'claude-1', B renamed back to 'claude');
+        register claude (B->'claude-1', C->'claude-2') — stale A still sits at
+        reclaimable['claude-1']. On restart both instances['claude-1']=B and
+        reclaimable['claude-1']=A were persisted; loading the reclaimable section over
+        the instances section by the same key let stale A overwrite live B, killing B's
+        token and reviving A. The current 'claude-1' wrapper is B; B's token must survive.
+        """
+        a = self.reg.register("claude")              # A = 'claude'
+        tok_a = a["token"]
+        b = self.reg.register("claude")              # A -> 'claude-1', B = 'claude-2'
+        tok_b = b["token"]
+        self.reg.deregister("claude-1")              # A reclaimable@'claude-1'; B renamed back to 'claude'
+        self.reg.register("claude")                  # B -> 'claude-1', C = 'claude-2'; stale A lingers
+        reg2 = RuntimeRegistry(data_dir=self.tmp)    # server restart
+        reg2.seed({
+            "claude": {"label": "Claude", "color": "#ff6a00"},
+            "codex": {"label": "Codex", "color": "#00B67D"},
+        })
+        rb = reg2.resolve_token(tok_b)
+        self.assertIsNotNone(rb, "current live 'claude-1' (B) token must survive restart")
+        self.assertEqual(rb["name"], "claude-1")
+        self.assertIsNone(reg2.resolve_token(tok_a),
+                          "older stale token (A) must not revive over the live identity")
+
+    def test_claim_into_live_slot_keeps_current_token_alive_after_restart(self):
+        """Same invariant via the claim rename path.
+
+        A stale reclaimable at 'claude-1' (base=claude, slot=1) remains while a live
+        instance is claimed into the canonical 'claude' (also base=claude, slot=1). The
+        current identity's token must survive a restart even if the stale wrapper
+        reconnects first and tries to grab the slot.
+        """
+        a = self.reg.register("claude")              # A = 'claude'
+        tok_a = a["token"]
+        b = self.reg.register("claude")              # A -> 'claude-1', B = 'claude-2'
+        tok_b = b["token"]
+        self.reg.register("claude")                  # C = 'claude-3'
+        self.reg.deregister("claude-1")              # A reclaimable@'claude-1' (base=claude, slot=1)
+        claimed = self.reg.claim("claude-2", "claude")   # B claims canonical 'claude' (base=claude, slot=1)
+        self.assertEqual(claimed["name"], "claude")
+        reg2 = RuntimeRegistry(data_dir=self.tmp)    # server restart
+        reg2.seed({
+            "claude": {"label": "Claude", "color": "#ff6a00"},
+            "codex": {"label": "Codex", "color": "#00B67D"},
+        })
+        reg2.resolve_token(tok_a)                    # stale wrapper (A) reconnects first
+        rb = reg2.resolve_token(tok_b)               # current 'claude' wrapper (B)
+        self.assertIsNotNone(rb, "current live 'claude' (B) token must survive even if stale A resolved first")
+        self.assertEqual(rb["name"], "claude")
+
+    def test_rename_into_live_slot_keeps_current_token_alive_after_restart(self):
+        """Same invariant via the human-initiated rename path.
+
+        Renaming a live instance onto a (base, slot) still occupied by a stale
+        reclaimable must drop the stale record, so the current identity's token
+        survives a restart even if the stale wrapper reconnects first.
+        """
+        a = self.reg.register("claude")              # A = 'claude'
+        tok_a = a["token"]
+        b = self.reg.register("claude")              # A -> 'claude-1', B = 'claude-2'
+        tok_b = b["token"]
+        self.reg.register("claude")                  # C = 'claude-3'
+        self.reg.deregister("claude-1")              # A reclaimable@'claude-1' (base=claude, slot=1)
+        renamed = self.reg.rename("claude-2", "claude")  # B renamed onto canonical 'claude' (base=claude, slot=1)
+        self.assertEqual(renamed["name"], "claude")
+        reg2 = RuntimeRegistry(data_dir=self.tmp)    # server restart
+        reg2.seed({
+            "claude": {"label": "Claude", "color": "#ff6a00"},
+            "codex": {"label": "Codex", "color": "#00B67D"},
+        })
+        reg2.resolve_token(tok_a)                    # stale wrapper (A) reconnects first
+        rb = reg2.resolve_token(tok_b)               # current 'claude' wrapper (B)
+        self.assertIsNotNone(rb, "current live 'claude' (B) token must survive even if stale A resolved first")
+        self.assertEqual(rb["name"], "claude")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_reclaim.py
+++ b/tests/test_session_reclaim.py
@@ -76,6 +76,69 @@ class SessionReclaimTests(unittest.TestCase):
         self.assertIsNotNone(reg2.resolve_token(token),
                              "token should survive a server restart via persistence")
 
+    def test_fresh_register_after_restart_takes_slot1_not_ghost(self):
+        """After a server restart, a fresh wrapper must reclaim slot-1 'claude'.
+
+        Regression for the restart-ghost bug: persisted instances must reload as
+        reclaimable (token recoverable) rather than active. If they reload active,
+        the empty post-restart presence map means the crash-timeout never clears the
+        dead wrapper, so the fresh launch is bumped to 'claude-2' and the ghost is
+        renamed 'claude-1' — two active instances where there should be one.
+        """
+        self.reg.register("claude")                  # long-running agent, persisted to disk
+        reg2 = RuntimeRegistry(data_dir=self.tmp)    # server restart, presence map empty
+        reg2.seed({
+            "claude": {"label": "Claude", "color": "#ff6a00"},
+            "codex": {"label": "Codex", "color": "#00B67D"},
+        })
+        fresh = reg2.register("claude")              # fresh wrapper launches
+        self.assertEqual(fresh["name"], "claude",
+                         "fresh register after restart must get slot-1 'claude', not a numbered slot")
+        active = [n for n, d in reg2.get_all().items()
+                  if d["base"] == "claude" and d["state"] == "active"]
+        self.assertEqual(active, ["claude"], f"exactly one active claude expected, got {active}")
+
+    def test_custom_name_fresh_register_supersedes_old_token(self):
+        """Fresh register('claude') must supersede a deregistered custom-name identity.
+
+        Regression for the exact-name supersede gap: a custom alias (claude-music,
+        base=claude slot=1) is not removed by register's name-keyed pop, so its old
+        token can later reactivate alongside the fresh slot-1 'claude' — two active
+        instances at base=claude slot=1. Fresh-wins must be enforced by (base, slot).
+        """
+        first = self.reg.register("claude")
+        old_tok = first["token"]
+        self.reg.claim("claude", "claude-music")     # custom identity, base=claude slot=1
+        self.reg.deregister("claude-music")          # crash-timeout / shutdown -> reclaimable
+        self.reg._reserved.clear()                   # overnight gap >> 30s name-reservation grace
+        fresh = self.reg.register("claude")          # fresh relaunch of the base
+        self.assertEqual(fresh["name"], "claude")
+        self.assertIsNone(self.reg.resolve_token(old_tok),
+                          "old custom-name token must not reactivate once slot-1 is freshly registered")
+        active_slot1 = [n for n, d in self.reg.get_all().items()
+                        if d["base"] == "claude" and d["slot"] == 1 and d["state"] == "active"]
+        self.assertEqual(active_slot1, ["claude"],
+                         f"exactly one active base=claude slot=1 expected, got {active_slot1}")
+
+    def test_claim_cannot_revive_identity_whose_slot_is_now_live(self):
+        """chat_claim must not recover a reclaimable identity whose (base, slot) is live.
+
+        Same fresh-wins invariant as register/resolve_token, but at the claim path
+        (_restore_reclaimable_locked). Repro via rename-back: two claude instances, the
+        slot-1 deregisters (→ reclaimable as 'claude-1'), the survivor is renamed back to
+        the canonical 'claude' (slot 1). A later claim('claude-1') must NOT revive the old
+        slot-1 identity on top of the live 'claude' — that would be two active slot-1s.
+        """
+        self.reg.register("claude")                  # claude (slot 1)
+        self.reg.register("claude")                  # -> claude-1 (slot 1) + claude-2 (slot 2)
+        self.reg.deregister("claude-1")              # slot-1 leaves -> reclaimable; claude-2 renamed back to 'claude'
+        self.assertIn("claude", self.reg.get_all_names(), "survivor should be renamed back to canonical 'claude'")
+        self.reg.claim("claude-1")                   # stale wrapper tries to recover its old slot-1 identity
+        active_slot1 = [n for n, d in self.reg.get_all().items()
+                        if d["base"] == "claude" and d["slot"] == 1 and d["state"] == "active"]
+        self.assertEqual(active_slot1, ["claude"],
+                         f"claim must not create a second active slot-1; got {active_slot1}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes the recurring `stale or unknown authenticated agent session` error a long-running client (e.g. Claude Code) hits after the machine sleeps or the server restarts, and prevents identity collisions in the recovery path.

**Root cause:** on sleep, heartbeat threads freeze and the 15s crash-timeout deregisters agents, deleting their in-memory tokens. A long-running client reuses its token on wake → rejected; a fresh-launch client re-registers cleanly — hence the asymmetry only the persistent client hit.

**Fix (3 commits):**
1. `1639097` — deregistered sessions are kept in a reclaimable store (token preserved) and reactivated transparently on reconnect; instances persist to `data/registry.json` (gitignored) so a server restart doesn't wipe tokens.
2. `fcb66e6` — enforce "fresh registration wins" by `(base, slot)` rather than by name, so a fresh launch supersedes a reclaimable token (including custom-named aliases) at every reactivation site.
3. `a88e4f3` — maintain the underlying invariant centrally: `_instances` and `_reclaimable` are kept disjoint by both name and `(base, slot)` via one helper called after every mutation that creates/moves a live instance (`register` incl. slot-1 rename, `deregister` rename-back, `claim`, `rename`). Prevents a stale reclaimable from overwriting a live record across the persist→reload round trip (which would revive a dead token and strand the live one).

## Test plan

New regression suite `tests/test_session_reclaim.py` (10 tests): token reclaim on reconnect, fresh-supersedes-reclaimable, claim recovery, persistence round-trip, fresh-register-after-restart (no ghost), custom-name supersede, claim/rename cannot revive a live slot, and the rename-back + re-register restart collision.

- `python -m pytest -q tests/test_session_reclaim.py` → **10 passed**
- full suite (excluding two modules that need `mcp` / `python-multipart` in this env) → **39 passed**, no regressions

## Follow-ups (non-blocking)
- Optional `_load_instances` dedup as upgrade-insurance against `registry.json` files written by pre-fix experimental builds.
- TTL/expiry for `_reclaimable` to bound its growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)