### PR TITLE
Add floating day indicator (WhatsApp-style) + fix orphaned date dividers on per-channel clear

### DIFF
--- a/static/channels.js
+++ b/static/channels.js
@@ -308,9 +308,14 @@ function switchChannel(name) {
     const savedId = _channelScrollMsg[name];
     if (savedId) {
         const el = document.querySelector(`.message[data-id="${savedId}"]`);
-        if (el) { el.scrollIntoView({ block: 'start' }); return; }
+        if (el) {
+            el.scrollIntoView({ block: 'start' });
+            if (typeof dayFloatRefresh === 'function') dayFloatRefresh();
+            return;
+        }
     }
     window.scrollToBottom();
+    if (typeof dayFloatRefresh === 'function') dayFloatRefresh();
 }
 
 function filterMessagesByChannel() {

--- a/static/chat.js
+++ b/static/chat.js
@@ -577,7 +577,8 @@ function connectWebSocket() {
                 const container = document.getElementById('messages');
                 const toRemove = [];
                 for (const el of container.children) {
-                    if (el.dataset.id && (el.dataset.channel || 'general') === clearChannel) {
+                    const isDivider = el.classList.contains('date-divider');
+                    if ((el.dataset.id || isDivider) && (el.dataset.channel || 'general') === clearChannel) {
                         toRemove.push(el);
                     }
                 }
@@ -591,6 +592,7 @@ function connectWebSocket() {
                 lastMessageDate = null;
                 lastMessageDates = {};
             }
+            dayFloatRefresh();
             requestAnimationFrame(() => {
                 const _clearDbgAfter = _clearDbgList ? _clearDbgList.children.length : -1;
                 console.log('CLEAR_DEBUG after clear (next frame), jobs-panel-children=' + _clearDbgAfter);
@@ -664,6 +666,69 @@ function maybeInsertDateDivider(container, msg) {
         }
         container.appendChild(divider);
     }
+}
+
+// --- Floating day indicator ---
+
+let dayFloatDividers = null;   // live HTMLCollection — follows divider add/remove
+let dayFloatFadeTimer = null;
+let dayFloatRafPending = false;
+
+function dayFloatLabel() {
+    if (!dayFloatDividers) {
+        const container = document.getElementById('messages');
+        if (!container) return null;
+        dayFloatDividers = container.getElementsByClassName('date-divider');
+    }
+    const scroll = document.getElementById('timeline');
+    if (!scroll) return null;
+    const top = scroll.getBoundingClientRect().top;
+    let label = null;
+    for (const d of dayFloatDividers) {
+        if (d.style.display === 'none') continue;
+        if (d.getBoundingClientRect().top <= top) {
+            label = d.textContent;
+        } else {
+            break;
+        }
+    }
+    return label;
+}
+
+function dayFloatHide() {
+    const float = document.getElementById('day-float');
+    if (!float) return;
+    if (dayFloatFadeTimer) { clearTimeout(dayFloatFadeTimer); dayFloatFadeTimer = null; }
+    float.classList.remove('visible');
+}
+
+function dayFloatOnScroll() {
+    if (dayFloatRafPending) return;
+    dayFloatRafPending = true;
+    requestAnimationFrame(() => {
+        dayFloatRafPending = false;
+        const float = document.getElementById('day-float');
+        if (!float) return;
+        const label = dayFloatLabel();
+        if (!label) { dayFloatHide(); return; }
+        float.querySelector('span').textContent = label;
+        float.classList.add('visible');
+        if (dayFloatFadeTimer) clearTimeout(dayFloatFadeTimer);
+        dayFloatFadeTimer = setTimeout(() => {
+            dayFloatFadeTimer = null;
+            float.classList.remove('visible');
+        }, 1200);
+    });
+}
+
+function dayFloatRefresh() {
+    // Recompute without starting the show/fade cycle: swap the label if the
+    // pill is relevant, hide (cancelling any fade) if no day is above the top.
+    const float = document.getElementById('day-float');
+    if (!float) return;
+    const label = dayFloatLabel();
+    if (!label) { dayFloatHide(); return; }
+    float.querySelector('span').textContent = label;
 }
 
 // --- Messages ---
@@ -2499,6 +2564,7 @@ function setupScroll() {
             unreadCount = 0;
         }
         updateScrollAnchor();
+        dayFloatOnScroll();
     });
 
     // Keep pinned to bottom when content changes (e.g. images load)

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>agentchattr</title>
-    <link rel="stylesheet" href="/static/style.css?v=249">
+    <link rel="stylesheet" href="/static/style.css?v=250">
     <link rel="stylesheet" href="/static/sessions.css?v=223">
     <link rel="stylesheet" href="/static/jobs.css?v=223">
     <link rel="icon" href="/static/favicon.ico">
@@ -172,6 +172,7 @@
                 <div class="channel-sidebar-grip" id="channel-sidebar-grip"></div>
             </aside>
             <main id="timeline">
+                <div id="day-float" aria-hidden="true"><span></span></div>
                 <div id="loading-indicator">
                     <div class="loading-spinner"></div>
                     <span>Loading messages...</span>
@@ -342,8 +343,8 @@
     <script src="/static/store.js?v=223"></script>
     <script src="/static/sessions.js?v=223"></script>
     <script src="/static/jobs.js?v=224"></script>
-    <script src="/static/channels.js?v=224"></script>
+    <script src="/static/channels.js?v=225"></script>
     <script src="/static/rules-panel.js?v=223"></script>
-    <script src="/static/chat.js?v=266"></script>
+    <script src="/static/chat.js?v=267"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -2553,6 +2553,38 @@ body.channels-in-sidebar #channel-bar {
     background: var(--border);
 }
 
+/* --- Floating day indicator --- */
+
+#day-float {
+    position: sticky;
+    top: 8px;
+    height: 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    z-index: 6;
+    pointer-events: none;
+}
+
+#day-float span {
+    background: var(--bg-msg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-full);
+    padding: 3px 10px;
+    color: var(--text-dim);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    text-indent: 0.06em;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
+
+#day-float.visible span {
+    opacity: 1;
+}
+
 /* --- Code copy button --- */
 
 .code-copy-btn {


### PR DESCRIPTION
Closes #77

## What this does

While scrolling, a small floating capsule appears top-centre showing the day the messages at the top of the view belong to ("Today", "Yesterday", or the full date; same formatting as the existing separators), and fades out ~1.2s after scrolling stops. In busy channels the in-flow day separators are often hundreds of messages above the viewport; this keeps the day visible without them. The separators themselves are untouched, nothing shifts, only the small transient capsule overlays content, and clicks pass through it.

Also fixes a pre-existing bug this feature would otherwise expose (reproducible on current `main`): **per-channel Clear leaves orphaned day separators in the DOM**: the clear loop matches only `dataset.id`, dividers carry only `dataset.channel`, and `filterMessagesByChannel` only toggles visibility. Cleared channels kept their old separators and duplicated one on the next message.

## How it works

- **Host:** `<div id="day-float" aria-hidden="true"><span></span></div>` as the first child of `#timeline`. It has zero height and `position: sticky; top: 8px`, so CSS keeps it pinned and centred (including during panel resizes) with no scroll-position bookkeeping. `pointer-events: none` on the host (inherited by the capsule) guarantees click-through; `align-items: flex-start` keeps the capsule's intrinsic padded height inside the zero-height flex line. `z-index` sits above message content and below panels/menus.
- **Label scan:** a cached **live** `HTMLCollection` of `.date-divider` elements (`getElementsByClassName` on `#messages`; follows divider add/remove automatically, survives full clear since the container node persists). The scan runs at most once per `requestAnimationFrame`, triggered from the existing `setupScroll` listener; it skips other channels' hidden dividers and breaks at the first divider below the scrollport edge (`<=` so handoff lands exactly at the edge). Cost scales with day-divider count (tens), not message count (thousands).
- **Show/fade:** scroll → label update + `.visible` class + 1200ms fade timer reset; opacity transition 0.25s. No divider above the viewport → hide immediately and cancel the timer.
- **Stale-state hooks:** `dayFloatRefresh()` recomputes the label *without* starting the show/fade cycle; called at both exits of `switchChannel` (guarded `typeof`, since channels.js loads before chat.js) and after both clear paths, so a channel switch or clear can never leave a stale day on screen even when no scroll event fires.
- **Clear fix:** the per-channel clear loop now removes elements that are either messages (`dataset.id`) or `.date-divider`s of the cleared channel; the next message re-creates exactly one divider (its `lastMessageDates` entry is reset, as before).
- **Cache-busts:** `?v=` bumped for `style.css`, `channels.js`, `chat.js`.

Scope: 4 static files, ≈110 lines, no server changes, no settings, no dependencies.

## Test plan

- `node --check static/chat.js` and `node --check static/channels.js` pass.
- Live verification on a real multi-agent workspace (3000+ messages, 8 channels), all passing:
  1. correct day shown while scrolling, both directions, with clean handoff at day boundaries;
  2. fades out after scrolling stops; hidden at the very top of history (no day above the viewport);
  3. capsule background/border fully encloses the label;
  4. channel switch away/back shows no stale day;
  5. per-channel clear shows no cleared-history day, and orphaned separators no longer linger (bug above);
  6. pill never blocks clicks on messages/buttons beneath it;
  7. narrow-window layout stays centred and readable.
