### PR TITLE
fix(mcp): migrate the last-read fallback on identity rename, purge, and channel rename/delete

### DIFF
--- a/mcp_bridge.py
+++ b/mcp_bridge.py
@@ -510,6 +510,11 @@ def migrate_identity(old_name: str, new_name: str):
     with _cursors_lock:
         if old_name in _cursors:
             _cursors[new_name] = _cursors.pop(old_name)
+    with _last_read_lock:
+        if old_name in _last_read_channel:
+            _last_read_channel[new_name] = _last_read_channel.pop(old_name)
+        if old_name in _last_read_job_id:
+            _last_read_job_id[new_name] = _last_read_job_id.pop(old_name)
     if old_name in _roles:
         _roles[new_name] = _roles.pop(old_name)
         _save_roles()
@@ -524,6 +529,9 @@ def purge_identity(name: str):
         _activity_ts.pop(name, None)
     with _cursors_lock:
         _cursors.pop(name, None)
+    with _last_read_lock:
+        _last_read_channel.pop(name, None)
+        _last_read_job_id.pop(name, None)
     if name in _roles:
         del _roles[name]
         _save_roles()
@@ -531,19 +539,27 @@ def purge_identity(name: str):
 
 
 def migrate_cursors_rename(old_name: str, new_name: str):
-    """Move cursor entries from old channel name to new channel name."""
+    """Move cursor and fallback entries from old channel to new channel."""
     with _cursors_lock:
         for agent_cursors in _cursors.values():
             if old_name in agent_cursors:
                 agent_cursors[new_name] = agent_cursors.pop(old_name)
+    with _last_read_lock:
+        for sender, fallback in list(_last_read_channel.items()):
+            if fallback == old_name:
+                _last_read_channel[sender] = new_name
     _save_cursors()
 
 
 def migrate_cursors_delete(channel: str):
-    """Remove cursor entries for a deleted channel."""
+    """Remove cursors and reset every stale fallback to #general."""
     with _cursors_lock:
         for agent_cursors in _cursors.values():
             agent_cursors.pop(channel, None)
+    with _last_read_lock:
+        for sender, fallback in list(_last_read_channel.items()):
+            if fallback == channel:
+                _last_read_channel[sender] = "general"
     _save_cursors()
 
 

--- a/tests/test_channel_fallback.py
+++ b/tests/test_channel_fallback.py
@@ -144,5 +144,54 @@ class ChannelFallbackStateTests(unittest.TestCase):
         self.assertEqual(channel, "portfolio")
 
 
+class ChannelFallbackMigrationTests(unittest.TestCase):
+    """Tests that identity and channel lifecycle hooks keep the fallback
+    maps in sync (rename/purge of agents, rename/delete of channels)."""
+
+    def setUp(self):
+        self._saved_ch = dict(mcp_bridge._last_read_channel)
+        self._saved_job = dict(mcp_bridge._last_read_job_id)
+        mcp_bridge._last_read_channel.clear()
+        mcp_bridge._last_read_job_id.clear()
+
+    def tearDown(self):
+        mcp_bridge._last_read_channel.clear()
+        mcp_bridge._last_read_channel.update(self._saved_ch)
+        mcp_bridge._last_read_job_id.clear()
+        mcp_bridge._last_read_job_id.update(self._saved_job)
+
+    def test_identity_rename_carries_fallback_state(self):
+        mcp_bridge._last_read_channel["alice"] = "bugfixing"
+        mcp_bridge._last_read_job_id["alice"] = 7
+        mcp_bridge.migrate_identity("alice", "alice-2")
+        self.assertEqual(mcp_bridge._last_read_channel["alice-2"], "bugfixing")
+        self.assertEqual(mcp_bridge._last_read_job_id["alice-2"], 7)
+        self.assertNotIn("alice", mcp_bridge._last_read_channel)
+        self.assertNotIn("alice", mcp_bridge._last_read_job_id)
+
+    def test_purge_identity_drops_fallback_state(self):
+        mcp_bridge._last_read_channel["alice"] = "bugfixing"
+        mcp_bridge._last_read_job_id["alice"] = 7
+        mcp_bridge.purge_identity("alice")
+        self.assertNotIn("alice", mcp_bridge._last_read_channel)
+        self.assertNotIn("alice", mcp_bridge._last_read_job_id)
+
+    def test_channel_rename_rewrites_matching_fallbacks(self):
+        mcp_bridge._last_read_channel["alice"] = "bugfixing"
+        mcp_bridge._last_read_channel["bob"] = "portfolio"
+        mcp_bridge.migrate_cursors_rename("bugfixing", "hotfixes")
+        self.assertEqual(mcp_bridge._last_read_channel["alice"], "hotfixes")
+        # Other agents' fallbacks are untouched
+        self.assertEqual(mcp_bridge._last_read_channel["bob"], "portfolio")
+
+    def test_channel_delete_resets_fallbacks_to_general(self):
+        mcp_bridge._last_read_channel["alice"] = "bugfixing"
+        mcp_bridge._last_read_channel["bob"] = "portfolio"
+        mcp_bridge.migrate_cursors_delete("bugfixing")
+        self.assertEqual(mcp_bridge._last_read_channel["alice"], "general")
+        # Other agents' fallbacks are untouched
+        self.assertEqual(mcp_bridge._last_read_channel["bob"], "portfolio")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The #58 fallback (`chat_send` with no channel goes to the sender's last-read channel or job) is keyed by sender name and channel name, but none of the existing migration hooks move that state:

- `migrate_identity()` moves the read cursors but not `_last_read_channel`/`_last_read_job_id`. After `claude` becomes `claude-1` (happens automatically when a second instance registers), its next bare `chat_send` falls back to #general instead of the channel it was just reading — the exact misfire #58 was about.
- `migrate_cursors_rename()`/`migrate_cursors_delete()` leave stale channel values behind, so after a channel rename a fallback send posts into the old name and resurrects it as a ghost tab; after a delete it posts into a channel that no longer exists.
- `purge_identity()` leaks both maps, so an agent that later registers under the reused name inherits someone else's fallback.

The fix wires the maps into those four hooks, under the existing `_last_read_lock`: identity migrate rekeys both, purge pops both, channel rename rewrites matching channel values, channel delete resets them to `general`. (Job-id fallbacks are untouched by the channel hooks — job ids don't change when a channel is renamed.) +20/-2 in mcp_bridge.py.

Tests: four new cases in `tests/test_channel_fallback.py` following its existing state-map pattern, one per hook; the rename case also checks that other senders' fallbacks are left alone. `python -m pytest -q tests/test_channel_fallback.py` → 12 passed (8 on main). Full suite: 85 passed (81 on current main).
