### PR TITLE
fix(ui): keep unread badges, mention toggles, and pending switches across a channel rename

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -527,6 +527,23 @@ function connectWebSocket() {
             });
             _showNextPendingName();
         } else if (event.type === 'channel_renamed') {
+            // Migrate per-channel client state to the new name
+            const channelIndex = channelList.indexOf(event.old_name);
+            if (channelIndex !== -1) {
+                channelList = [...channelList];
+                channelList[channelIndex] = event.new_name;
+            }
+            if (channelUnread[event.old_name] !== undefined) {
+                channelUnread[event.new_name] = channelUnread[event.old_name];
+                delete channelUnread[event.old_name];
+            }
+            if (_channelMentions[event.old_name] !== undefined) {
+                _channelMentions[event.new_name] = _channelMentions[event.old_name];
+                delete _channelMentions[event.old_name];
+            }
+            if (pendingChannelSwitch === event.old_name) {
+                pendingChannelSwitch = event.new_name;
+            }
             // Migrate data-channel on existing DOM elements
             const container = document.getElementById('messages');
             for (const el of container.children) {
@@ -545,6 +562,8 @@ function connectWebSocket() {
                 localStorage.setItem('agentchattr-channel', event.new_name);
                 Store.set('activeChannel', event.new_name);
             }
+            filterMessagesByChannel();
+            renderChannelTabs();
         } else if (event.type === 'edit') {
             // A message was edited/demoted — re-render it in place
             const updatedMsg = event.message;

--- a/static/index.html
+++ b/static/index.html
@@ -345,6 +345,6 @@
     <script src="/static/jobs.js?v=224"></script>
     <script src="/static/channels.js?v=225"></script>
     <script src="/static/rules-panel.js?v=223"></script>
-    <script src="/static/chat.js?v=268"></script>
+    <script src="/static/chat.js?v=269"></script>
 </body>
 </html>


### PR DESCRIPTION
Rename a channel that has unread messages and its badge disappears. Reproducible on current main: let #foo accumulate unreads while you sit in #general, rename it to #bar from the tab — the badge is gone although the messages are still unread.

The `channel_renamed` handler in chat.js migrates DOM `data-channel` attributes, `lastMessageDates`, and `activeChannel`, but four pieces of state stay keyed under the old name: `channelUnread` (the count survives, invisible, under a key nothing reads anymore), `_channelMentions` (the per-channel mention toggle silently resets), `channelList`, and `pendingChannelSwitch` (a queued switch to the old name can never match again). The settings frame that accompanies a rename replaces `channelList` eventually, but it can't migrate unread/mention state it knows nothing about.

The handler now rekeys all four, retargets a pending switch to the new name so it can still resolve, and finishes with `filterMessagesByChannel()` + `renderChannelTabs()` so the tab re-renders with its migrated badge immediately. No protocol changes, no server changes; `?v=` bumped for chat.js.

There's no JS harness in the repo, so this was verified against a live server with a scripted browser (fresh data dir, one registered agent posting into the renamed channel), running the same scenario on this branch and on main:

- three unreads in #foo (badge "3"), rename to #bar → badge "3" on the #bar tab; on main the badge disappears and the count stays stranded under `foo`.
- a mention toggle remembered for #foo is remembered for #bar after the rename; on main it resets.
- a pending switch aimed at #foo gets retargeted to #bar; on main it stays aimed at a name that no longer exists.
- no console errors on the patched page.

Python suite untouched by this change (static/ isn't imported): 81 passed before and after.
