### PR TITLE
fix(rules): report proposal resolution failures instead of pretending success

### DIFF
--- a/app.py
+++ b/app.py
@@ -1778,13 +1778,19 @@ async def resolve_rule_proposal(msg_id: int, request: Request):
     rule_id = meta.get("rule_id")
 
     if action == "activate" and rule_id is not None:
-        rules.activate(int(rule_id))
+        if not rules.activate(int(rule_id)):
+            return JSONResponse(
+                {"error": "could not activate rule (active limit reached or rule not found)"},
+                status_code=409,
+            )
         meta["status"] = "activated"
     elif action == "draft" and rule_id is not None:
-        rules.make_draft(int(rule_id))
+        if not rules.make_draft(int(rule_id)):
+            return JSONResponse({"error": "rule not found"}, status_code=409)
         meta["status"] = "drafted"
     elif action == "dismiss" and rule_id is not None:
-        rules.delete(int(rule_id))
+        if not rules.delete(int(rule_id)):
+            return JSONResponse({"error": "rule not found"}, status_code=409)
         meta["status"] = "dismissed"
     else:
         return JSONResponse({"error": "invalid action"}, status_code=400)
@@ -1814,7 +1820,8 @@ async def demote_rule_proposal(msg_id: int):
     meta = msg.get("metadata", {})
     rule_id = meta.get("rule_id")
     if rule_id is not None:
-        rules.delete(int(rule_id))
+        if not rules.delete(int(rule_id)):
+            return JSONResponse({"error": "rule not found"}, status_code=409)
     text = meta.get("text", msg.get("text", ""))
     updated = store.update_message(msg_id, {
         "type": "chat",

--- a/static/index.html
+++ b/static/index.html
@@ -344,7 +344,7 @@
     <script src="/static/sessions.js?v=223"></script>
     <script src="/static/jobs.js?v=224"></script>
     <script src="/static/channels.js?v=225"></script>
-    <script src="/static/rules-panel.js?v=223"></script>
+    <script src="/static/rules-panel.js?v=224"></script>
     <script src="/static/chat.js?v=268"></script>
 </body>
 </html>

--- a/static/rules-panel.js
+++ b/static/rules-panel.js
@@ -534,25 +534,39 @@ function cancelDeleteRule(id) {
 
 async function resolveRuleProposal(msgId, action) {
     try {
-        await fetch(`/api/messages/${msgId}/resolve_rule_proposal`, {
+        const response = await fetch(`/api/messages/${msgId}/resolve_rule_proposal`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-Session-Token': window.SESSION_TOKEN },
             body: JSON.stringify({ action }),
         });
+        if (!response.ok) {
+            const payload = await response.json().catch(() => ({}));
+            throw new Error(payload.error || `Request failed (HTTP ${response.status})`);
+        }
     } catch (e) {
         console.error('Failed to resolve rule proposal:', e);
+        if (typeof showToast === 'function') {
+            showToast(`Failed to update rule: ${e.message}`, 'error');
+        }
     }
 }
 
 async function dismissRuleProposal(msgId) {
     // Demote to regular chat message — same as job proposal dismiss
     try {
-        await fetch(`/api/messages/${msgId}/demote_rule_proposal`, {
+        const response = await fetch(`/api/messages/${msgId}/demote_rule_proposal`, {
             method: 'POST',
             headers: { 'X-Session-Token': window.SESSION_TOKEN },
         });
+        if (!response.ok) {
+            const payload = await response.json().catch(() => ({}));
+            throw new Error(payload.error || `Request failed (HTTP ${response.status})`);
+        }
     } catch (e) {
         console.error('Failed to dismiss rule proposal:', e);
+        if (typeof showToast === 'function') {
+            showToast(`Failed to dismiss rule proposal: ${e.message}`, 'error');
+        }
     }
 }
 

--- a/tests/test_rule_proposals.py
+++ b/tests/test_rule_proposals.py
@@ -1,0 +1,104 @@
+import asyncio
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import app
+from rules import MAX_ACTIVE_RULES, RuleStore
+from store import MessageStore
+
+
+class FakeRequest:
+    def __init__(self, headers=None, body=None):
+        self.headers = headers or {}
+        self._body = body
+
+    async def json(self):
+        if self._body is None:
+            raise ValueError("no body")
+        return self._body
+
+
+class RuleProposalResolutionTests(unittest.TestCase):
+    """Resolving a rule proposal must fail loudly when the RuleStore rejects
+    the action (active limit reached, rule already gone) instead of stamping
+    the message as resolved anyway."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+        self.store = MessageStore(str(Path(self.tmp.name) / "messages.jsonl"))
+        self.rules = RuleStore(str(Path(self.tmp.name) / "rules.json"))
+
+        app.store = self.store
+        app.rules = self.rules
+
+    def _propose(self, text="keep replies short"):
+        rule = self.rules.propose(text, "claude")
+        msg = self.store.add(
+            "claude",
+            text,
+            msg_type="rule_proposal",
+            metadata={"rule_id": rule["id"], "status": "pending", "text": text},
+        )
+        return rule, msg
+
+    def test_activate_at_active_limit_returns_409_and_keeps_pending(self):
+        for i in range(MAX_ACTIVE_RULES):
+            filler = self.rules.propose(f"rule {i}", "claude")
+            self.rules.activate(filler["id"])
+        rule, msg = self._propose()
+
+        resp = asyncio.run(
+            app.resolve_rule_proposal(msg["id"], FakeRequest(body={"action": "activate"}))
+        )
+
+        self.assertEqual(resp.status_code, 409)
+        current = self.store.get_by_id(msg["id"])
+        self.assertEqual(current["metadata"]["status"], "pending")
+        self.assertEqual(self.rules.get(rule["id"])["status"], "pending")
+
+    def test_activate_unknown_rule_returns_409_and_keeps_pending(self):
+        rule, msg = self._propose()
+        self.rules.delete(rule["id"])
+
+        resp = asyncio.run(
+            app.resolve_rule_proposal(msg["id"], FakeRequest(body={"action": "activate"}))
+        )
+
+        self.assertEqual(resp.status_code, 409)
+        current = self.store.get_by_id(msg["id"])
+        self.assertEqual(current["metadata"]["status"], "pending")
+
+    def test_activate_success_marks_message_activated(self):
+        rule, msg = self._propose()
+
+        result = asyncio.run(
+            app.resolve_rule_proposal(msg["id"], FakeRequest(body={"action": "activate"}))
+        )
+
+        self.assertEqual(result["metadata"]["status"], "activated")
+        current = self.store.get_by_id(msg["id"])
+        self.assertEqual(current["metadata"]["status"], "activated")
+        self.assertEqual(self.rules.get(rule["id"])["status"], "active")
+
+    def test_demote_unknown_rule_returns_409_and_keeps_proposal(self):
+        rule, msg = self._propose()
+        self.rules.delete(rule["id"])
+
+        resp = asyncio.run(app.demote_rule_proposal(msg["id"]))
+
+        self.assertEqual(resp.status_code, 409)
+        current = self.store.get_by_id(msg["id"])
+        self.assertEqual(current["type"], "rule_proposal")
+        self.assertEqual(current["metadata"]["status"], "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Approve a rule proposal while 10 rules are already active (`MAX_ACTIVE_RULES`) and watch it "activate": `resolve_rule_proposal` calls `rules.activate(rule_id)`, ignores that it returned `None`, stamps the message metadata `activated`, and returns 200. The proposal card renders "Activated" forever while the rule is still pending in the Rules panel — the two permanently disagree, and nothing in the UI hints that the click did nothing. The same pattern sits on every branch of the endpoint (`activate`, `draft`, `dismiss` — the store also returns `None` for an unknown or deleted rule id) and on `demote_rule_proposal`.

The frontend has the matching half of the problem: `resolveRuleProposal`/`dismissRuleProposal` never check `response.ok`, so even an honest 4xx dies as a `console.error` with no user feedback.

The backend now checks each store call's return value; on failure it answers 409 with an error body and leaves the message metadata alone. The frontend checks `response.ok` and surfaces the error through the existing `showToast`, so the card keeps its real pending state. Happy path unchanged; `?v=` bumped for rules-panel.js.

Tests: new `tests/test_rule_proposals.py` — activate at the active-rule limit → 409 and metadata stays pending; activate a deleted rule id → 409, metadata unchanged; happy-path activate → 200, metadata `activated`, rule active; demote of a deleted rule → 409. 4 passed. Full suite: 85 passed (81 on current main).

Also verified against a live server with a scripted browser, seeding rules through the store and running the same scenario on this branch and on main. With 10 active rules, clicking Activate on a pending proposal now shows the error toast and the card keeps its buttons, and the server keeps the rule `pending`. On main the card flips to "Activated" and the message metadata records `activated` while the rule's real status stays `pending` — the permanent disagreement described above. With 9 active rules the card resolves and the rule activates exactly as before.
