### PR TITLE
fix(tests): consume the request body in the proxy stub before replying

### DIFF
--- a/tests/test_identity_contract.py
+++ b/tests/test_identity_contract.py
@@ -346,6 +346,11 @@ class ProxyHeaderForwardingTests(unittest.TestCase):
                 pass
 
             def do_POST(self):
+                # Consume the request body before replying. Closing a socket
+                # with unread data makes the OS send RST, which can discard the
+                # response already sitting in the client's receive queue - the
+                # source of a load-sensitive 502 failure in this test.
+                self.rfile.read(int(self.headers.get("Content-Length") or 0))
                 seen["authorization"] = self.headers.get("Authorization")
                 seen["agent_token"] = self.headers.get("X-Agent-Token")
                 body = b'event: message\r\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\r\n\r\n'


### PR DESCRIPTION
Closes #89.

`ProxyHeaderForwardingTests`' stub server replies to a POST without reading the request body. Closing a socket that still holds unread data can make the OS send RST rather than a clean FIN, and an RST can cause the peer's kernel to discard what it has already buffered for that socket — including the response the client received but had not yet read. `mcp_proxy` then correctly surfaces the dead connection as a 502, so the test fails while the product code is behaving properly.

It is load-sensitive, which is why the same commit can pass one run and fail the next.

Test-only: no product code, no live server, no credentials, no user data.

The sibling stub in the same class implements only `do_GET`, which carries no request body, so it cannot hit this and is left alone.

Locally, running that file 15 times went from 6 failures to 0. Load was not held constant between the two runs, so that number is indicative; the mechanism in #89 is the substantive claim.

---

This is the first of several small changes we would like to offer, and it is deliberately first: until it lands, a full-suite run on any of the others has a chance of failing for reasons unrelated to the change under review. The rest are #67 (concurrent per-project wrapper sessions) and the three-PR stack described in #90.
