### PR TITLE
feat: add OrcaRouter as a built-in API agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Windows](https://img.shields.io/badge/platform-Windows-blue) ![macOS](https://img.shields.io/badge/platform-macOS-lightgrey) ![Linux](https://img.shields.io/badge/platform-Linux-orange) ![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-green) [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/qzfn5YTT9a)
 
-A local chat server for real-time coordination between AI coding agents and humans. Ships with built-in support for **Claude Code**, **Codex**, **Gemini CLI**, **[GitHub Copilot CLI](https://github.com/github/copilot-cli)**, **Kimi**, **Qwen**, **Kilo CLI**, **[CodeBuddy](https://www.codebuddy.ai/cli)**, and **[MiniMax](https://platform.minimax.io)** — and any MCP-compatible agent can join.
+A local chat server for real-time coordination between AI coding agents and humans. Ships with built-in support for **Claude Code**, **Codex**, **Gemini CLI**, **[GitHub Copilot CLI](https://github.com/github/copilot-cli)**, **Kimi**, **Qwen**, **Kilo CLI**, **[CodeBuddy](https://www.codebuddy.ai/cli)**, **[MiniMax](https://platform.minimax.io)**, and **[OrcaRouter](https://www.orcarouter.ai)** — and any MCP-compatible agent can join.
 
 Agents and humans talk in a shared chat room with multiple channels — when anyone @mentions an agent, the server auto-injects a prompt into that agent's terminal, the agent reads the conversation and responds, and the loop continues hands-free. No copy-pasting between ugly terminals. No manual prompting.
 
@@ -30,6 +30,7 @@ On first launch, the script auto-creates a virtual environment, installs Python 
 - `start_kilo.bat provider/model` — starts Kilo with a specific model (e.g. `start_kilo.bat anthropic/claude-sonnet-4-20250514`)
 - `start_codebuddy.bat` — starts CodeBuddy (first launch prompts interactive login)
 - `start_minimax.bat` — starts MiniMax (requires `MINIMAX_API_KEY` env var)
+- `start_orca.bat` — starts OrcaRouter (requires `ORCAROUTER_API_KEY` env var)
 
 **Auto-approve variants** (agents run tools without asking permission):
 
@@ -42,7 +43,7 @@ On first launch, the script auto-creates a virtual environment, installs Python 
 
 **2. Open the chat:** Go to **http://localhost:8300** in your browser, or double-click `open_chat.html`.
 
-**3. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, `@copilot`, `@kimi`, `@qwen`, `@kilo`, `@codebuddy`, or `@minimax` in your message, or use the toggle buttons above the input. The agent will wake up, read the chat, and respond.
+**3. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, `@copilot`, `@kimi`, `@qwen`, `@kilo`, `@codebuddy`, `@minimax`, or `@orca` in your message, or use the toggle buttons above the input. The agent will wake up, read the chat, and respond.
 
 > **Tip:** To manually prompt an agent to check chat, type `mcp read #general` in their terminal.
 
@@ -75,6 +76,7 @@ On first launch, the script auto-creates a virtual environment, installs Python 
 - `sh start_kilo.sh provider/model` — starts Kilo with a specific model (e.g. `sh start_kilo.sh anthropic/claude-sonnet-4-20250514`)
 - `sh start_codebuddy.sh` — starts CodeBuddy (first launch prompts interactive login)
 - `sh start_minimax.sh` — starts MiniMax (requires `MINIMAX_API_KEY` env var)
+- `sh start_orca.sh` — starts OrcaRouter (requires `ORCAROUTER_API_KEY` env var)
 
 **Auto-approve variants** (agents run tools without asking permission):
 
@@ -87,7 +89,7 @@ On first launch, the script auto-creates a virtual environment, installs Python 
 
 **3. Open the chat:** Go to **http://localhost:8300** or open `open_chat.html`.
 
-**4. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, `@copilot`, `@kimi`, `@qwen`, `@kilo`, `@codebuddy`, or `@minimax` in your message, or use the toggle buttons above the input. The agent will wake up, read the chat, and respond.
+**4. Talk to your agents:** Type `@claude`, `@codex`, `@gemini`, `@copilot`, `@kimi`, `@qwen`, `@kilo`, `@codebuddy`, `@minimax`, or `@orca` in your message, or use the toggle buttons above the input. The agent will wake up, read the chat, and respond.
 
 ---
 
@@ -534,6 +536,31 @@ The wrapper registers with the server, watches for @mentions, reads recent chat 
    ```
 
 Available models: `MiniMax-M3` (default), `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` (faster). China mainland users can change `base_url` to `https://api.minimaxi.com/v1` in `config.toml`.
+
+### OrcaRouter (cloud gateway)
+
+[OrcaRouter](https://www.orcarouter.ai) is a built-in cloud API agent. It routes every call through OpenAI- and Anthropic-compatible endpoints, so it works with agentchattr's OpenAI-compatible API agents out of the box. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. To use it:
+
+1. Get an API key at [www.orcarouter.ai](https://www.orcarouter.ai)
+
+2. Set the environment variable:
+   ```bash
+   export ORCAROUTER_API_KEY=your-key-here
+   ```
+
+3. Launch:
+   ```bash
+   # Windows
+   windows\start_orca.bat
+
+   # Mac/Linux
+   sh macos-linux/start_orca.sh
+
+   # Or directly
+   python wrapper_api.py orca
+   ```
+
+Model IDs are namespaced (e.g. `anthropic/claude-sonnet-5`, `z-ai/glm-4.6`); browse the full catalog at the [models endpoint](https://api.orcarouter.ai/v1/models) and edit `model` in `config.toml` to switch. Like all API agents, this one works even without a launcher — add an `[agents.*]` block with `base_url = "https://api.orcarouter.ai/v1"` to `config.local.toml`.
 
 ## Architecture
 

--- a/config.local.toml.example
+++ b/config.local.toml.example
@@ -52,3 +52,18 @@
 # label = "MiniMax"
 # api_key_env = "MINIMAX_API_KEY"
 # temperature = 1.0
+
+# --- Example: OrcaRouter (cloud gateway) ---
+# OrcaRouter routes every call through OpenAI- and Anthropic-compatible endpoints.
+# Get an API key at https://www.orcarouter.ai and set ORCAROUTER_API_KEY in your
+# environment before launching. Model IDs are namespaced (e.g. anthropic/claude-sonnet-5,
+# z-ai/glm-4.6) — see https://api.orcarouter.ai/v1/models for the full catalog.
+#
+# [agents.orca]
+# type = "api"
+# base_url = "https://api.orcarouter.ai/v1"
+# model = "anthropic/claude-sonnet-5"
+# color = "#4f46e5"
+# label = "OrcaRouter"
+# api_key_env = "ORCAROUTER_API_KEY"
+# temperature = 1.0

--- a/config.toml
+++ b/config.toml
@@ -93,6 +93,15 @@ label = "MiniMax"
 api_key_env = "MINIMAX_API_KEY"
 temperature = 1.0
 
+[agents.orca]
+type = "api"
+base_url = "https://api.orcarouter.ai/v1"
+model = "anthropic/claude-sonnet-5"
+color = "#4f46e5"
+label = "OrcaRouter"
+api_key_env = "ORCAROUTER_API_KEY"
+temperature = 1.0
+
 [routing]
 # "none" = only route on explicit @mention. "all" = route to all agents by default.
 default = "none"

--- a/macos-linux/start_orca.sh
+++ b/macos-linux/start_orca.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env sh
+# agentchattr — starts server (if not running) + OrcaRouter API agent wrapper
+# Usage: sh start_orca.sh
+# Requires ORCAROUTER_API_KEY environment variable.
+cd "$(dirname "$0")/.."
+
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+else
+    echo "Python 3 is required but was not found on PATH."
+    exit 1
+fi
+
+ensure_venv() {
+    if [ -d ".venv" ] && [ ! -x ".venv/bin/python" ]; then
+        echo "Recreating .venv for this platform..."
+        rm -rf .venv
+    fi
+
+    if [ ! -x ".venv/bin/python" ]; then
+        echo "Creating virtual environment..."
+        "$PYTHON_BIN" -m venv .venv || {
+            echo "Error: failed to create .venv with $PYTHON_BIN."
+            exit 1
+        }
+        .venv/bin/python -m pip install -q -r requirements.txt || {
+            echo "Error: failed to install Python dependencies."
+            exit 1
+        }
+    fi
+}
+
+is_server_running() {
+    lsof -i :8300 -sTCP:LISTEN >/dev/null 2>&1 || \
+    ss -tlnp 2>/dev/null | grep -q ':8300 '
+}
+
+# Check API key
+if [ -z "$ORCAROUTER_API_KEY" ]; then
+    echo "Error: ORCAROUTER_API_KEY environment variable is not set."
+    echo "Get an API key at https://www.orcarouter.ai"
+    echo "Then: export ORCAROUTER_API_KEY=your-key-here"
+    exit 1
+fi
+
+ensure_venv
+
+if ! is_server_running; then
+    if [ "$(uname -s)" = "Darwin" ]; then
+        osascript -e "tell app \"Terminal\" to do script \"cd '$(pwd)' && .venv/bin/python run.py\"" > /dev/null 2>&1
+    else
+        if command -v gnome-terminal >/dev/null 2>&1; then
+            gnome-terminal -- sh -c "cd '$(pwd)' && .venv/bin/python run.py; printf 'Press Enter to close... '; read _"
+        elif command -v xterm >/dev/null 2>&1; then
+            xterm -e sh -c "cd '$(pwd)' && .venv/bin/python run.py" &
+        else
+            .venv/bin/python run.py > data/server.log 2>&1 &
+        fi
+    fi
+
+    i=0
+    while [ "$i" -lt 30 ]; do
+        if is_server_running; then
+            break
+        fi
+        sleep 0.5
+        i=$((i + 1))
+    done
+fi
+
+.venv/bin/python wrapper_api.py orca

--- a/windows/start_orca.bat
+++ b/windows/start_orca.bat
@@ -1,0 +1,42 @@
+@echo off
+REM agentchattr — starts server (if not running) + OrcaRouter API agent wrapper
+REM Usage: start_orca.bat
+REM Requires ORCAROUTER_API_KEY environment variable.
+cd /d "%~dp0.."
+
+REM Auto-create venv and install deps on first run
+if not exist ".venv" (
+    python -m venv .venv
+    .venv\Scripts\pip install -q -r requirements.txt >nul 2>nul
+)
+call .venv\Scripts\activate.bat
+
+REM Check API key
+if "%ORCAROUTER_API_KEY%"=="" (
+    echo.
+    echo   Error: ORCAROUTER_API_KEY environment variable is not set.
+    echo   Get an API key at https://www.orcarouter.ai
+    echo   Then: set ORCAROUTER_API_KEY=your-key-here
+    echo.
+    pause
+    exit /b 1
+)
+
+REM Start server if not already running, then wait for it
+netstat -ano | findstr :8300 | findstr LISTENING >nul 2>&1
+if %errorlevel% neq 0 (
+    start "agentchattr server" cmd /c "python run.py"
+)
+:wait_server
+netstat -ano | findstr :8300 | findstr LISTENING >nul 2>&1
+if %errorlevel% neq 0 (
+    timeout /t 1 /nobreak >nul
+    goto :wait_server
+)
+
+python wrapper_api.py orca
+if %errorlevel% neq 0 (
+    echo.
+    echo   Agent exited unexpectedly. Check the output above.
+    pause
+)


### PR DESCRIPTION
## What this adds

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a built-in API agent, mirroring the existing MiniMax cloud API agent pattern. OrcaRouter is an AI gateway that serves OpenAI- and Anthropic-compatible endpoints from one base URL and one API key, so it plugs into agentchattr's existing API-agent wrapper with no code changes. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Key changes

- `config.toml`: ships an `[agents.orca]` preset alongside `[agents.minimax]` — `base_url = "https://api.orcarouter.ai/v1"`, namespaced default model `anthropic/claude-sonnet-5`, key read from `ORCAROUTER_API_KEY`
- `windows/start_orca.bat` + `macos-linux/start_orca.sh`: one-click launchers that check the API key, auto-start the server, and run `wrapper_api.py orca`
- `config.local.toml.example`: documented OrcaRouter example block alongside the MiniMax one
- `README.md`: OrcaRouter added to the built-in agents list, launcher lists, @mention lists, and a new "OrcaRouter (cloud gateway)" section

## Why a named preset

agentchattr already treats MiniMax as a first-class built-in cloud API agent (shipped `[agents.minimax]` preset + dedicated launchers + README section). This mirrors that exact pattern so OrcaRouter gets the same discoverable slot — a visible `@orca` agent, a working default model, and correct namespaced model IDs (`anthropic/claude-sonnet-5`, `z-ai/glm-4.6`, etc.) that the gateway requires. No generic "just edit base_url yourself" documentation.

## How to use it

1. Get an API key at [www.orcarouter.ai](https://www.orcarouter.ai)
2. `export ORCAROUTER_API_KEY=your-key-here`
3. Launch `windows\start_orca.bat` (or `sh macos-linux/start_orca.sh`), then mention `@orca` in the chat.

Like MiniMax, the agent degrades gracefully without a key set, and you can switch models by editing `model` in the `[agents.orca]` block.

## Verification

- `config.toml` parses and the `orca` agent loads (`tomllib`)
- `pytest tests/` — 80 passed, 1 pre-existing Windows-only failure in `test_identity_contract.py` (`latin-1` codec in the proxy test, unrelated; this change touches no Python)
- Live check of the exact wrapper code path: `POST {base_url}/chat/completions` with `anthropic/claude-sonnet-5` + `ORCAROUTER_API_KEY` returns a model response

I'm an engineer on the OrcaRouter team.
