### PR TITLE
fix(schedules): honest one-shot records, reject past send times, add relative scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Summaries are written by agents — either self-initiated when a significant dis
 ### Scheduled messages
 Schedule one-shot or recurring messages from the split send button. Click the clock icon next to Send to open the schedule popover — pick a date/time for one-shot, or check Recurring and set an interval (minutes, hours, or days). Scheduled messages fire as real chat messages from you, complete with @mentions that trigger agents automatically.
 
+Instead of a fixed date and time, check **In a while from now** and give it hours and minutes to send relative to the moment you schedule it, which helps when you are waiting on something rather than aiming at a clock time. A one-shot time that has already passed is refused with a reason instead of firing straight away.
+
 A schedule strip above the composer shows active and paused schedules. For a single schedule, inline pause and delete controls appear directly in the strip. For multiple schedules, expand the strip to manage them. Schedules persist across server restarts (stored in `data/schedules.json`).
 
 The schedule popover validates that at least one agent is toggled before enabling the Schedule button — a yellow warning tells you what's needed.

--- a/app.py
+++ b/app.py
@@ -1595,29 +1595,46 @@ async def create_schedule(request: Request):
     targets = body.get("targets", [])
     channel = body.get("channel", "general")
     spec = body.get("spec", "")
-    one_shot = body.get("one_shot", False)
+    one_shot = bool(body.get("one_shot", False))
     send_at_date = body.get("send_at_date", "")  # "YYYY-MM-DD" for one-shot
     created_by = body.get("created_by", "user")
     if not prompt or not targets or not spec:
         return JSONResponse({"error": "prompt, targets, and spec are required"}, status_code=400)
+    # A relative send ("in 2h 30m") is resolved by the client, which posts the
+    # resulting moment directly; there is no recurrence to parse out of it.
+    # A send_at names a single moment, so it only means anything for a one-shot.
+    # A recurring request ignores it, exactly as it did before the field
+    # existed; that keeps an unparseable spec falling through to the 400 below
+    # instead of being stored as an unasked-for daily repeat.
+    explicit_send_at = None
+    if one_shot and body.get("send_at") is not None:
+        try:
+            explicit_send_at = float(body["send_at"])
+        except (TypeError, ValueError, OverflowError):
+            return JSONResponse(
+                {"error": "send_at must be an epoch timestamp"}, status_code=400
+            )
     interval_sec, daily_at = parse_schedule_spec(spec)
-    if interval_sec is None:
+    if interval_sec is None and explicit_send_at is None:
         return JSONResponse({"error": f"Invalid schedule spec: {spec}"}, status_code=400)
     # For one-shot, compute exact send_at timestamp from date + daily_at time
-    send_at = None
-    if one_shot and daily_at and send_at_date:
+    send_at = explicit_send_at
+    if send_at is None and one_shot and daily_at and send_at_date:
         import datetime as _dt
         try:
             dt = _dt.datetime.strptime(f"{send_at_date} {daily_at}", "%Y-%m-%d %H:%M")
             send_at = dt.timestamp()
         except ValueError:
             pass
-    s = schedules.create(
-        prompt=prompt, targets=targets, channel=channel,
-        interval_seconds=interval_sec, daily_at=daily_at,
-        one_shot=one_shot, send_at=send_at,
-        created_by=created_by,
-    )
+    try:
+        s = schedules.create(
+            prompt=prompt, targets=targets, channel=channel,
+            interval_seconds=interval_sec, daily_at=daily_at,
+            one_shot=one_shot, send_at=send_at,
+            created_by=created_by,
+        )
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
     return JSONResponse(s)
 
 

--- a/schedules.py
+++ b/schedules.py
@@ -1,6 +1,7 @@
 """Schedule store — recurring prompts fired without human intervention."""
 
 import json
+import math
 import re
 import time
 import threading
@@ -17,6 +18,10 @@ _DAILY_RE = re.compile(
     r"daily\s+at\s+(\d{1,2}):(\d{2})\b",
     re.IGNORECASE
 )
+
+# Upper bound for an explicit send time (2100-01-01). Anything beyond this is
+# a mistake or an attack: it never fires, so the row sticks in the list forever.
+MAX_SEND_AT = 4102444800.0
 
 
 def parse_schedule_spec(spec: str) -> tuple[int | None, str | None]:
@@ -155,8 +160,26 @@ class ScheduleStore:
         last_run = None
         if daily_at:
             interval_seconds = 86400
-        if send_at:
+        if send_at is not None:
+            try:
+                send_at = float(send_at)
+            except (TypeError, ValueError, OverflowError):
+                # OverflowError: JSON ints are arbitrary precision, so a
+                # 400-digit literal reaches float() and blows up there.
+                raise ValueError("That time is not a real moment")
+            # NaN loses every comparison, so an unchecked NaN would slip past
+            # the past-time guard below and then be written to the JSON store
+            # as a bare NaN, which no later read of that file can parse.
+            if not math.isfinite(send_at) or send_at > MAX_SEND_AT:
+                raise ValueError("That time is not a real moment")
+            if send_at <= now:
+                raise ValueError("That time has already passed - pick a later one")
             next_run = send_at
+            if one_shot:
+                # A one-shot is defined solely by next_run. Keeping daily_at
+                # would claim a daily recurrence the schedule does not have,
+                # and the schedules bar renders that field verbatim.
+                daily_at = None
         else:
             next_run = compute_next_run(
                 interval_seconds or 86400,

--- a/static/chat.js
+++ b/static/chat.js
@@ -2349,6 +2349,9 @@ function setupInput() {
         updateSlashMenu(input.value);
         updateMentionMenu();
         updateSendButton();
+        // Targets come from the composer, so the schedule popover's state goes
+        // stale as soon as this changes. It no-ops while the popover is closed.
+        updateSchedulePopoverState();
     }
     input.addEventListener('input', onInputChange);
     // Voice typing doesn't always fire 'input' — catch with additional events
@@ -3429,7 +3432,22 @@ function formatScheduleTime(ts) {
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
+function formatOneShotWhen(ts) {
+    if (!ts) return 'once';
+    const d = new Date(ts * 1000);
+    const time = d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (d.toDateString() === today.toDateString()) return 'once at ' + time;
+    if (d.toDateString() === tomorrow.toDateString()) return 'once tomorrow at ' + time;
+    const day = d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+    return 'once on ' + day + ' at ' + time;
+}
+
 function formatScheduleInterval(s) {
+    // A one-shot has no recurrence; its next_run is the whole story.
+    if (s.one_shot) return formatOneShotWhen(s.next_run);
     if (s.daily_at) return 'daily at ' + s.daily_at;
     const sec = s.interval_seconds || 0;
     if (sec < 3600) return 'every ' + Math.round(sec / 60) + 'm';
@@ -3488,6 +3506,13 @@ function toggleSchedulePopover(e) {
     pop.classList.toggle('hidden');
     if (opening) {
         populateScheduleDropdowns();
+        // Always reopen on the absolute path. Leaving "in a while" checked
+        // from a previous send would carry its past-time guard off with it.
+        const rel = document.getElementById('sched-relative');
+        if (rel && rel.checked) {
+            rel.checked = false;
+            toggleRelativeFields();
+        }
         updateSchedulePopoverState();
     }
 }
@@ -3500,9 +3525,11 @@ function closeSchedulePopover() {
 function stepNumInput(id, delta) {
     const el = document.getElementById(id);
     if (!el) return;
-    const min = parseInt(el.min) || 1;
-    const max = parseInt(el.max) || 99;
-    const val = Math.max(min, Math.min(max, (parseInt(el.value) || min) + delta));
+    // Number.isFinite, not `||`: a legitimate min/value of 0 is falsy.
+    const min = Number.isFinite(parseInt(el.min)) ? parseInt(el.min) : 1;
+    const max = Number.isFinite(parseInt(el.max)) ? parseInt(el.max) : 99;
+    const current = Number.isFinite(parseInt(el.value)) ? parseInt(el.value) : min;
+    const val = Math.max(min, Math.min(max, current + delta));
     el.value = val;
     el.dispatchEvent(new Event('input', { bubbles: true }));
     el.dispatchEvent(new Event('change', { bubbles: true }));
@@ -3512,15 +3539,67 @@ function stepSchedNum(delta) {
     stepNumInput('sched-interval-val', delta);
 }
 
+let _scheduleSubmitInFlight = false;
+
+function isSchedulePopoverRecurring() {
+    return !!document.getElementById('sched-recurring')?.checked;
+}
+
+function isSchedulePopoverRelative() {
+    return !!document.getElementById('sched-relative')?.checked;
+}
+
+function readClampedNum(id) {
+    // There is no <form> here, so browsers do not enforce min/max on typed
+    // input. Clamp on read, or "999" in the hours box means a 999h delay.
+    const el = document.getElementById(id);
+    if (!el) return 0;
+    const min = Number.isFinite(parseInt(el.min)) ? parseInt(el.min) : 0;
+    const max = Number.isFinite(parseInt(el.max)) ? parseInt(el.max) : 99;
+    const val = Number.isFinite(parseInt(el.value)) ? parseInt(el.value) : min;
+    const clamped = Math.max(min, Math.min(max, val));
+    // Write back, or the box keeps showing "999" while 72 is what gets sent.
+    if (String(clamped) !== el.value) el.value = String(clamped);
+    return clamped;
+}
+
+function getScheduleRelativeSeconds() {
+    return readClampedNum('sched-rel-h') * 3600 + readClampedNum('sched-rel-m') * 60;
+}
+
 function toggleRecurringFields() {
-    const checked = document.getElementById('sched-recurring')?.checked;
+    const checked = isSchedulePopoverRecurring();
+    // Recurring and "in a while" are mutually exclusive ways to say when.
+    if (checked) {
+        const rel = document.getElementById('sched-relative');
+        if (rel) rel.checked = false;
+    }
     const fields = document.getElementById('sched-recurring-fields');
     if (fields) fields.classList.toggle('hidden', !checked);
-    // Dim both "When" and "At" rows when recurring is active
+    document.getElementById('sched-relative-fields')?.classList.add('hidden');
+    updateScheduleWhenRows();
+}
+
+function toggleRelativeFields() {
+    const checked = isSchedulePopoverRelative();
+    if (checked) {
+        const rec = document.getElementById('sched-recurring');
+        if (rec) rec.checked = false;
+    }
+    const fields = document.getElementById('sched-relative-fields');
+    if (fields) fields.classList.toggle('hidden', !checked);
+    document.getElementById('sched-recurring-fields')?.classList.add('hidden');
+    updateScheduleWhenRows();
+}
+
+function updateScheduleWhenRows() {
+    // Dim "When" and "At" whenever the send time comes from somewhere else
+    const dimmed = isSchedulePopoverRecurring() || isSchedulePopoverRelative();
     const whenRow = document.getElementById('sched-date')?.closest('.sched-pop-row');
     const atRow = document.getElementById('sched-hour')?.closest('.sched-pop-row');
-    if (whenRow) whenRow.classList.toggle('sched-dimmed', !!checked);
-    if (atRow) atRow.classList.toggle('sched-dimmed', !!checked);
+    if (whenRow) whenRow.classList.toggle('sched-dimmed', dimmed);
+    if (atRow) atRow.classList.toggle('sched-dimmed', dimmed);
+    updateSchedulePopoverState();
 }
 
 function populateScheduleDropdowns() {
@@ -3538,7 +3617,13 @@ function populateScheduleDropdowns() {
         const d = new Date(now);
         d.setDate(d.getDate() + i);
         const opt = document.createElement('option');
-        opt.value = d.toISOString().slice(0, 10);
+        // Local calendar date, not toISOString(): the option is labelled from
+        // the local day, and both the past-time guard and the server read this
+        // value as local wall-clock. A UTC date disagrees with the label for
+        // part of every day in any non-UTC timezone.
+        opt.value = d.getFullYear() + '-' +
+            String(d.getMonth() + 1).padStart(2, '0') + '-' +
+            String(d.getDate()).padStart(2, '0');
         opt.textContent = i === 0 ? 'Today' : i === 1 ? 'Tomorrow' : days[d.getDay()];
         dateEl.appendChild(opt);
     }
@@ -3590,6 +3675,14 @@ function getScheduleTime24() {
     return String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0');
 }
 
+function getScheduleSendAtMs() {
+    // Absolute date+time the popover currently describes, in epoch ms.
+    const dateVal = document.getElementById('sched-date')?.value;
+    if (!dateVal) return null;
+    const parsed = new Date(dateVal + 'T' + getScheduleTime24() + ':00');
+    return isNaN(parsed.getTime()) ? null : parsed.getTime();
+}
+
 function updateSchedulePopoverState() {
     const pop = document.getElementById('schedule-popover');
     if (!pop || pop.classList.contains('hidden')) return;
@@ -3600,12 +3693,28 @@ function updateSchedulePopoverState() {
     const mentionMatches = text.match(/@(\w[\w-]*)/g) || [];
     const targets = new Set(mentionMatches.map(m => m.slice(1)));
     for (const name of activeMentions) targets.add(name);
+
+    let problem = '';
     if (targets.size === 0) {
-        if (errEl) { errEl.textContent = 'Toggle an agent to set a target'; errEl.classList.remove('hidden'); }
+        problem = 'Toggle an agent to set a target';
+    } else if (isSchedulePopoverRelative()) {
+        if (getScheduleRelativeSeconds() <= 0) {
+            problem = 'Set how long from now';
+        }
+    } else if (!isSchedulePopoverRecurring()) {
+        const sendAt = getScheduleSendAtMs();
+        if (sendAt !== null && sendAt <= Date.now()) {
+            problem = 'That time has already passed';
+        }
+    }
+
+    if (problem) {
+        if (errEl) { errEl.textContent = problem; errEl.classList.remove('hidden'); }
         if (submitBtn) { submitBtn.disabled = true; }
     } else {
         if (errEl) { errEl.classList.add('hidden'); errEl.textContent = ''; }
-        if (submitBtn) { submitBtn.disabled = false; }
+        // Stay disabled while a submit is in flight, whatever else changed.
+        if (submitBtn) { submitBtn.disabled = _scheduleSubmitInFlight; }
     }
 }
 
@@ -3621,31 +3730,65 @@ async function submitSchedulePopover() {
 
     const errEl = document.getElementById('sched-pop-error');
 
-    if (targets.size === 0) return; // button should be disabled anyway
+    if (targets.size === 0) {
+        // Not a silent return: the button is only disabled if the state check
+        // has run since the composer last changed, so this is reachable and
+        // used to look like the click did nothing at all.
+        if (errEl) {
+            errEl.textContent = 'Toggle an agent to set a target';
+            errEl.classList.remove('hidden');
+        }
+        return;
+    }
     if (!prompt) {
         if (errEl) { errEl.textContent = 'Type a message first'; errEl.classList.remove('hidden'); }
         return;
     }
 
-    const recurring = document.getElementById('sched-recurring')?.checked;
+    const recurring = isSchedulePopoverRecurring();
+    const relative = isSchedulePopoverRelative();
     const dateVal = document.getElementById('sched-date')?.value;
     const timeVal = getScheduleTime24();
     const intervalVal = parseInt(document.getElementById('sched-interval-val')?.value) || 1;
     const intervalUnit = document.getElementById('sched-interval-unit')?.value || 'hours';
 
     // Build spec for the API
-    let spec, confirmText;
+    let spec, confirmText, sendAtEpoch = null;
     if (recurring) {
         const unitShort = intervalUnit === 'minutes' ? 'm' : intervalUnit === 'hours' ? 'h' : 'd';
         spec = `every ${intervalVal}${unitShort}`;
         confirmText = spec;
+    } else if (relative) {
+        const secs = getScheduleRelativeSeconds();
+        if (secs <= 0) {
+            if (errEl) { errEl.textContent = 'Set how long from now'; errEl.classList.remove('hidden'); }
+            return;
+        }
+        const h = Math.floor(secs / 3600);
+        const m = Math.round((secs % 3600) / 60);
+        spec = ('in ' + (h ? `${h}h ` : '') + (m ? `${m}m` : '')).trim();
+        confirmText = spec;
+        sendAtEpoch = Math.round(Date.now() / 1000 + secs);
     } else {
-        // One-shot: "daily at HH:MM" with one_shot flag
         spec = `daily at ${timeVal}`;
         confirmText = `${dateVal} at ${timeVal}`;
+        const sendAtMs = getScheduleSendAtMs();
+        if (sendAtMs === null || sendAtMs <= Date.now()) {
+            if (errEl) { errEl.textContent = 'That time has already passed'; errEl.classList.remove('hidden'); }
+            return;
+        }
+        // Post the resolved moment rather than a date string for the server to
+        // re-read in ITS timezone. Both one-shot paths now agree by
+        // construction, however far apart the browser and server clocks sit.
+        sendAtEpoch = Math.round(sendAtMs / 1000);
     }
 
-    closeSchedulePopover();
+    // The popover now stays open across the request, so nothing stops a second
+    // click landing a duplicate schedule while the first is still in flight.
+    if (_scheduleSubmitInFlight) return;
+    _scheduleSubmitInFlight = true;
+    const submitBtn = document.querySelector('.sched-pop-submit');
+    if (submitBtn) submitBtn.disabled = true;
 
     try {
         const body = {
@@ -3656,7 +3799,7 @@ async function submitSchedulePopover() {
             created_by: username,
         };
         if (!recurring) body.one_shot = true;
-        if (!recurring && dateVal) body.send_at_date = dateVal;
+        if (sendAtEpoch !== null) body.send_at = sendAtEpoch;
 
         const resp = await fetch('/api/schedules', {
             method: 'POST',
@@ -3667,17 +3810,29 @@ async function submitSchedulePopover() {
             body: JSON.stringify(body),
         });
         if (resp.ok) {
+            // Only now: a rejection must leave the popover open with the
+            // user's choices intact, rather than make them start over.
+            closeSchedulePopover();
             input.value = '';
             input.style.height = 'auto';
             updateSendButton();
             showScheduleConfirmation();
         } else {
             const err = await resp.json().catch(() => ({}));
-            showSlashHint(err.error || 'Failed to schedule');
+            if (errEl) {
+                errEl.textContent = err.error || 'Failed to schedule';
+                errEl.classList.remove('hidden');
+            }
         }
     } catch (e) {
         console.error('Failed to create schedule:', e);
-        showSlashHint('Failed to create schedule');
+        if (errEl) {
+            errEl.textContent = 'Failed to schedule';
+            errEl.classList.remove('hidden');
+        }
+    } finally {
+        _scheduleSubmitInFlight = false;
+        updateSchedulePopoverState();
     }
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>agentchattr</title>
-    <link rel="stylesheet" href="/static/style.css?v=251">
+    <link rel="stylesheet" href="/static/style.css?v=252">
     <link rel="stylesheet" href="/static/sessions.css?v=223">
     <link rel="stylesheet" href="/static/jobs.css?v=223">
     <link rel="icon" href="/static/favicon.ico">
@@ -290,14 +290,39 @@
                     <div class="sched-pop-body">
                         <div class="sched-pop-row">
                             <label class="sched-pop-label">When</label>
-                            <select id="sched-date" class="sched-pop-select"></select>
+                            <select id="sched-date" class="sched-pop-select" onchange="updateSchedulePopoverState()"></select>
                         </div>
                         <div class="sched-pop-row sched-time-row">
                             <label class="sched-pop-label">At</label>
-                            <select id="sched-hour" class="sched-pop-select sched-pop-select-sm"></select>
+                            <select id="sched-hour" class="sched-pop-select sched-pop-select-sm" onchange="updateSchedulePopoverState()"></select>
                             <span class="sched-time-colon">:</span>
-                            <select id="sched-minute" class="sched-pop-select sched-pop-select-sm"></select>
-                            <select id="sched-ampm" class="sched-pop-select sched-pop-select-sm"></select>
+                            <select id="sched-minute" class="sched-pop-select sched-pop-select-sm" onchange="updateSchedulePopoverState()"></select>
+                            <select id="sched-ampm" class="sched-pop-select sched-pop-select-sm" onchange="updateSchedulePopoverState()"></select>
+                        </div>
+                        <div class="sched-pop-row">
+                            <label class="sched-pop-check">
+                                <input type="checkbox" id="sched-relative" onchange="toggleRelativeFields()">
+                                <span>In a while from now</span>
+                            </label>
+                        </div>
+                        <div class="sched-pop-row sched-relative-fields hidden" id="sched-relative-fields">
+                            <label class="sched-pop-label">In</label>
+                            <div class="sched-num-wrap">
+                                <input type="number" id="sched-rel-h" class="sched-pop-num" value="0" min="0" max="72" onchange="updateSchedulePopoverState()">
+                                <div class="sched-num-btns">
+                                    <button type="button" onclick="stepNumInput('sched-rel-h',1)" tabindex="-1">&#9650;</button>
+                                    <button type="button" onclick="stepNumInput('sched-rel-h',-1)" tabindex="-1">&#9660;</button>
+                                </div>
+                            </div>
+                            <span class="sched-time-colon">h</span>
+                            <div class="sched-num-wrap">
+                                <input type="number" id="sched-rel-m" class="sched-pop-num" value="30" min="0" max="59" onchange="updateSchedulePopoverState()">
+                                <div class="sched-num-btns">
+                                    <button type="button" onclick="stepNumInput('sched-rel-m',1)" tabindex="-1">&#9650;</button>
+                                    <button type="button" onclick="stepNumInput('sched-rel-m',-1)" tabindex="-1">&#9660;</button>
+                                </div>
+                            </div>
+                            <span class="sched-time-colon">m</span>
                         </div>
                         <div class="sched-pop-row">
                             <label class="sched-pop-check">
@@ -345,6 +370,6 @@
     <script src="/static/jobs.js?v=224"></script>
     <script src="/static/channels.js?v=225"></script>
     <script src="/static/rules-panel.js?v=223"></script>
-    <script src="/static/chat.js?v=268"></script>
+    <script src="/static/chat.js?v=269"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -3600,6 +3600,7 @@ footer {
 }
 
 .sched-recurring-fields.hidden { display: none; }
+.sched-relative-fields.hidden { display: none; }
 
 .sched-pop-error {
     font-size: 11px;

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,0 +1,335 @@
+import asyncio
+import datetime
+import json
+import sys
+import time
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from schedules import ScheduleStore
+
+
+def _store():
+    tmp = tempfile.mkdtemp()
+    return ScheduleStore(str(Path(tmp) / "schedules.json"))
+
+
+class OneShotIsNotADailyRuleTests(unittest.TestCase):
+    """A message scheduled once must not be recorded as a daily recurrence.
+
+    The UI has no one-shot wire format, so it encodes the send time as the
+    recurring spec "daily at HH:MM". The server then stored daily_at on a
+    record whose one_shot flag was True, and the schedules bar rendered that
+    field verbatim -- so a one-time message was labelled "daily at 15:00".
+    """
+
+    def test_one_shot_with_an_explicit_send_time_is_not_stored_as_a_daily_rule(self):
+        store = _store()
+
+        s = store.create(
+            prompt="ping",
+            targets=["claude"],
+            daily_at="15:00",
+            one_shot=True,
+            send_at=time.time() + 3600,
+        )
+
+        self.assertTrue(s["one_shot"])
+        self.assertIsNone(
+            s["daily_at"],
+            "a one-shot carried a daily_at, which the UI renders as 'daily at ...'",
+        )
+
+    def test_one_shot_still_fires_at_the_requested_moment(self):
+        store = _store()
+        send_at = time.time() + 3600
+
+        s = store.create(
+            prompt="ping",
+            targets=["claude"],
+            daily_at="15:00",
+            one_shot=True,
+            send_at=send_at,
+        )
+
+        self.assertAlmostEqual(s["next_run"], send_at, places=3)
+
+    def test_a_genuine_daily_schedule_keeps_its_daily_rule(self):
+        """Control: the fix must not strip daily_at from real recurrences."""
+        store = _store()
+
+        s = store.create(
+            prompt="standup",
+            targets=["claude"],
+            daily_at="09:00",
+            one_shot=False,
+        )
+
+        self.assertFalse(s["one_shot"])
+        self.assertEqual(s["daily_at"], "09:00")
+
+
+class PastSendTimeIsRejectedTests(unittest.TestCase):
+    """Scheduling into the past must be refused, not silently fired.
+
+    Nothing validated send_at, so a past timestamp became next_run, run_due()
+    reported it immediately, and the runner delivered it on its next 30s tick
+    while the UI countdown rendered blank.
+    """
+
+    def test_create_rejects_a_send_time_in_the_past(self):
+        store = _store()
+
+        with self.assertRaises(ValueError):
+            store.create(
+                prompt="ping",
+                targets=["claude"],
+                daily_at="09:00",
+                one_shot=True,
+                send_at=time.time() - 7200,
+            )
+
+    def test_a_rejected_schedule_is_not_persisted(self):
+        store = _store()
+
+        with self.assertRaises(ValueError):
+            store.create(
+                prompt="ping",
+                targets=["claude"],
+                one_shot=True,
+                send_at=time.time() - 60,
+            )
+
+        self.assertEqual(store.list_all(), [])
+
+    def test_a_rejected_schedule_never_becomes_due(self):
+        store = _store()
+
+        try:
+            store.create(
+                prompt="ping",
+                targets=["claude"],
+                one_shot=True,
+                send_at=time.time() - 7200,
+            )
+        except ValueError:
+            pass
+
+        self.assertEqual(store.run_due(), [])
+
+    def test_epoch_zero_is_a_past_time_not_an_absent_one(self):
+        """send_at=0 is 1970, not "unset".
+
+        Guards the `send_at is not None` test against being weakened back to a
+        truthiness check, which would let 0 fall through to the recurring path.
+        """
+        store = _store()
+
+        with self.assertRaises(ValueError):
+            store.create(prompt="ping", targets=["claude"], one_shot=True, send_at=0)
+
+        self.assertEqual(store.list_all(), [])
+
+    def test_a_send_time_that_is_not_a_finite_number_is_refused(self):
+        """NaN defeats every comparison, so `send_at <= now` silently passes.
+
+        The record then reaches the JSON store, which writes bare NaN -- not
+        legal JSON -- and every later read of the schedules file fails.
+        """
+        store = _store()
+
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(value=bad):
+                with self.assertRaises(ValueError):
+                    store.create(
+                        prompt="ping", targets=["claude"], one_shot=True, send_at=bad
+                    )
+
+        self.assertEqual(store.list_all(), [])
+
+    def test_an_integer_too_large_for_a_float_is_refused_by_the_store_itself(self):
+        """The endpoint catches this first, so only a direct caller gets here.
+
+        Without its own guard the store raises OverflowError rather than the
+        ValueError every caller is told to expect.
+        """
+        store = _store()
+
+        with self.assertRaises(ValueError):
+            store.create(
+                prompt="ping", targets=["claude"], one_shot=True,
+                send_at=int("9" * 400),
+            )
+
+        self.assertEqual(store.list_all(), [])
+
+    def test_create_accepts_a_send_time_in_the_future(self):
+        """Control: only past times are refused, not the whole one-shot path."""
+        store = _store()
+
+        s = store.create(
+            prompt="ping",
+            targets=["claude"],
+            one_shot=True,
+            send_at=time.time() + 1800,
+        )
+
+        self.assertEqual(len(store.list_all()), 1)
+        self.assertEqual(store.run_due(), [], "a future schedule fired early")
+        self.assertGreater(s["next_run"], time.time())
+
+
+class _FakeRequest:
+    """create_schedule() only ever awaits request.json()."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+class CreateEndpointTests(unittest.TestCase):
+    def setUp(self):
+        import app
+
+        self.app = app
+        self._saved = app.schedules
+        app.schedules = _store()
+        self.addCleanup(lambda: setattr(app, "schedules", self._saved))
+
+    def _post(self, **body):
+        payload = {"prompt": "ping", "targets": ["claude"]}
+        payload.update(body)
+        return asyncio.run(self.app.create_schedule(_FakeRequest(payload)))
+
+    def test_a_past_send_time_is_refused_with_400_not_a_server_error(self):
+        past = datetime.datetime.now() - datetime.timedelta(hours=2)
+
+        response = self._post(
+            spec=f"daily at {past.strftime('%H:%M')}",
+            one_shot=True,
+            send_at_date=past.date().isoformat(),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.app.schedules.list_all(), [])
+
+    def test_a_future_send_time_is_still_accepted(self):
+        future = datetime.datetime.now() + datetime.timedelta(hours=2)
+
+        response = self._post(
+            spec=f"daily at {future.strftime('%H:%M')}",
+            one_shot=True,
+            send_at_date=future.date().isoformat(),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(self.app.schedules.list_all()), 1)
+
+
+class RelativeSendAtTests(unittest.TestCase):
+    """'Send in 2h 30m' -- the client computes the moment and posts it.
+
+    The absolute date+time path cannot express "right after my credits reset",
+    which is the case Max asked for.
+    """
+
+    def setUp(self):
+        import app
+
+        self.app = app
+        self._saved = app.schedules
+        app.schedules = _store()
+        self.addCleanup(lambda: setattr(app, "schedules", self._saved))
+
+    def _post(self, **body):
+        payload = {"prompt": "ping", "targets": ["claude"]}
+        payload.update(body)
+        return asyncio.run(self.app.create_schedule(_FakeRequest(payload)))
+
+    def test_an_explicit_send_at_epoch_is_honoured(self):
+        target = time.time() + 9000
+
+        response = self._post(spec="in 2h 30m", one_shot=True, send_at=target)
+
+        self.assertEqual(response.status_code, 200)
+        stored = self.app.schedules.list_all()[0]
+        self.assertAlmostEqual(stored["next_run"], target, places=3)
+
+    def test_a_relative_schedule_is_a_one_shot_not_a_daily_rule(self):
+        response = self._post(
+            spec="in 2h 30m", one_shot=True, send_at=time.time() + 9000
+        )
+
+        self.assertEqual(response.status_code, 200)
+        stored = self.app.schedules.list_all()[0]
+        self.assertTrue(stored["one_shot"])
+        self.assertIsNone(stored["daily_at"])
+
+    def test_an_explicit_send_at_in_the_past_is_refused(self):
+        response = self._post(spec="in 2h 30m", one_shot=True, send_at=time.time() - 60)
+
+        self.assertEqual(response.status_code, 400)
+        # Assert WHY it was refused: a bare 400 also passes when the spec is
+        # simply unparseable, which would prove nothing about the time check.
+        self.assertIn("already passed", json.loads(response.body)["error"])
+        self.assertEqual(self.app.schedules.list_all(), [])
+
+    def test_a_non_finite_send_at_is_refused_before_it_reaches_the_store(self):
+        for bad in ("NaN", "Infinity", float("nan"), float("inf")):
+            with self.subTest(value=bad):
+                response = self._post(spec="in 2h", one_shot=True, send_at=bad)
+
+                self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.app.schedules.list_all(), [])
+
+    def test_a_send_at_without_one_shot_cannot_smuggle_in_a_bad_spec(self):
+        """An unparseable spec must still 400, not become a daily repeat.
+
+        A send_at is only meaningful for a one-shot, so a recurring request
+        ignores it and the spec has to stand on its own.
+        """
+        response = self._post(spec="banana", send_at=time.time() + 3600)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("banana", json.loads(response.body)["error"])
+        self.assertEqual(self.app.schedules.list_all(), [])
+
+    def test_a_recurring_request_still_succeeds_when_a_stray_send_at_rides_along(self):
+        """Compatibility: this request returned 200 before send_at existed."""
+        response = self._post(spec="every 2h", send_at=time.time() + 3600)
+
+        self.assertEqual(response.status_code, 200)
+        stored = self.app.schedules.list_all()[0]
+        self.assertFalse(stored["one_shot"])
+        self.assertEqual(stored["interval_seconds"], 7200)
+
+    def test_an_integer_too_large_for_a_float_is_refused_not_a_server_error(self):
+        """JSON ints are arbitrary precision; float() raises OverflowError."""
+        response = self._post(spec="in 2h", one_shot=True, send_at=int("9" * 400))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.app.schedules.list_all(), [])
+
+    def test_a_send_time_beyond_any_plausible_date_is_refused(self):
+        """1e300 is finite, never fires, and sticks in the list forever."""
+        response = self._post(spec="in 2h", one_shot=True, send_at=1e300)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.app.schedules.list_all(), [])
+
+    def test_an_unparseable_spec_is_still_refused_when_no_send_at_is_given(self):
+        """Control: relaxing the spec check must not disable it generally."""
+        response = self._post(spec="banana")
+
+        self.assertEqual(response.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two bugs in one-shot schedules, plus a new relative option that runs through the same popover state, the same submit path and the same store invariant. They are one PR because splitting them would mean shipping a cut-down version of those functions and then rewriting the same lines.

### Bug 1: a one-shot described itself as a daily recurrence

Open the schedule popover, pick a date and time, leave Recurring unchecked, schedule it. The strip reads `daily at 14:30`, and the record in `data/schedules.json` carries `daily_at: "14:30"` alongside `one_shot: true`.

It did fire once, so the behaviour was correct. The record and the UI both described a recurrence that did not exist.

A one-shot no longer stores `daily_at`. `next_run` is the whole story, and the strip now renders `once at 14:30`, `once tomorrow at 14:30`, or `once on Fri, 22 Aug at 14:30`.

### Bug 2: a time in the past was accepted and fired immediately

At 15:00, schedule a one-shot for 14:00 today. It is accepted, the countdown renders blank, and it sends on the next tick.

`ScheduleStore.create()` now refuses a send time that is in the past, non-finite, or beyond the year 2100, raising `ValueError`. `POST /api/schedules` turns that into a 400 carrying the reason instead of a 500 error page, and the popover stays open and shows it.

### The client and the server could disagree about "today at 3pm"

The browser sent a date string and a time string; the server re-parsed them with `strptime(...).timestamp()`, which resolves in the server's timezone. On one machine both sides agree, so it is invisible in the usual setup, but two independent places were deciding what the user meant.

The endpoint now accepts an explicit `send_at` epoch and the browser resolves its own selection, which removes the second code path rather than patching it.

`send_at` is additive and optional. It is read only when `one_shot` is true, ignored for a recurring request, and a request that omits it behaves exactly as before, so existing `send_at_date` callers are unaffected. The store stays the final validator either way.

Separately, the date dropdown was built with `toISOString()`, which is UTC, so anyone far enough east or west could be offered the wrong calendar day. It now uses local calendar fields.

### New: "In a while from now"

Hours and minutes, relative to the moment you schedule. Mutually exclusive with Recurring, and it resets when the popover reopens so a stale value cannot be used to slip past the past-time check. It covers "in 2h 30m" when you are waiting on something rather than aiming at a clock time.

### Also in the popover

It stays open and shows the reason when a request is rejected instead of closing silently, it re-checks its target as you type rather than acting on a stale one, and it guards against a double submit.

### Tests

21 new in `tests/test_schedules.py`. Each new guard was mutation-checked by reverting it on its own and confirming the matching test fails.

`static/chat.js` has no test framework in this repo, so the browser side is covered by review plus a static check that every DOM id and inline handler it references resolves.

Full suite on this branch: 102 tests, 0 failures, 1 skipped.

### README

One paragraph added to the Scheduled messages section, since it currently describes only a fixed date/time and Recurring.

### One thing to know if you merge this second

A companion PR adds an optional per-server subtitle. Both PRs bump `style.css?v=` and `chat.js?v=` in `static/index.html`, and both bump them to the same values. They merge cleanly, but the second merge then leaves the stamps unchanged from the first, so a browser that loaded after the first merge would keep those assets. Please bump both stamps once more when you take the second of the two.

---

Closes #97
Closes #98
Closes #99
