### PR TITLE
fix(wrapper): deliver the injected prompt as one bracketed paste, not a keystroke burst

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ Available models: `MiniMax-M3` (default), `MiniMax-M2.7`, `MiniMax-M2.7-highspee
 | `mcp_proxy.py` | Per-instance MCP proxy — injects sender identity into all tool calls |
 | `wrapper.py` | Cross-platform dispatcher — registration, auto-trigger, heartbeat, activity monitor |
 | `wrapper_windows.py` | Windows: keystroke injection + screen buffer activity detection |
-| `wrapper_unix.py` | Mac/Linux: tmux keystroke injection + pane capture activity detection |
+| `wrapper_unix.py` | Mac/Linux: tmux bracketed-paste injection + pane capture activity detection |
 | `config.toml` | All configuration (agents, ports, routing) |
 | `windows/start_*_yolo/bypass.bat` | Auto-approve launchers (Windows) |
 | `macos-linux/start_*_yolo/bypass.sh` | Auto-approve launchers (Mac/Linux) |
@@ -597,7 +597,7 @@ Python package dependencies (`fastapi`, `uvicorn`, `mcp`) are listed in `require
 Auto-trigger works on all platforms:
 
 - **Windows** — `wrapper_windows.py` injects keystrokes into the agent's console via Win32 `WriteConsoleInput`. The agent runs as a direct subprocess.
-- **Mac/Linux** — `wrapper_unix.py` runs the agent inside a `tmux` session and injects keystrokes via `tmux send-keys`. Detach with `Ctrl+B, D` to leave the agent running in the background; reattach with `tmux attach -t agentchattr-claude`.
+- **Mac/Linux** — `wrapper_unix.py` runs the agent inside a `tmux` session and delivers each prompt as a single bracketed paste (`tmux paste-buffer -p`), so a CLI that supports bracketed paste reassembles a long prompt even when the pty splits it across reads. Detach with `Ctrl+B, D` to leave the agent running in the background; reattach with `tmux attach -t agentchattr-claude`.
 
 The chat server and web UI are fully cross-platform (Python + browser).
 

--- a/tests/test_inject_transport.py
+++ b/tests/test_inject_transport.py
@@ -1,0 +1,221 @@
+"""Transport contract for wrapper_unix.inject (Mac/Linux tmux injection).
+
+Background: the wrapper used to deliver a prompt as ONE `tmux send-keys -l`
+burst. A pty's raw input queue is finite (1024 bytes on macOS, 4096 on Linux),
+so a longer prompt reaches the CLI as several reads. Claude Code classifies a
+read above ~800 bytes as a paste and, when typed text follows a paste before
+Enter, submits only the typed text: the first 1022 bytes of every long prompt
+were silently lost on macOS. Bracketed paste fixes that because the CLI
+reassembles one paste between the ESC[200~ / ESC[201~ delimiters regardless of
+how the bytes were chunked.
+
+These tests drive a REAL tmux server. The pane runs a raw-mode reader that,
+depending on the case, enables bracketed paste mode (DECSET 2004) or not,
+deliberately delays its reads so the kernel queue fills, and records the exact
+byte stream it received. Assertions are on the reconstructed stream, never on
+how many reads the OS chose to make.
+
+Skipped when tmux is not installed. What they do NOT prove: that every CLI
+handles a bracketed paste; that is the CLI's contract, verified separately
+against Claude Code by transcript.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+import wrapper_unix  # noqa: E402
+
+OPEN = b"\x1b[200~"
+CLOSE = b"\x1b[201~"
+HAVE_TMUX = shutil.which("tmux") is not None
+
+# Raw-mode reader that runs INSIDE the tmux pane. argv: mode delay stream reads
+READER = textwrap.dedent(r"""
+    import os, select, sys, termios, time, tty
+    mode, delay, stream_path, reads_path = sys.argv[1], float(sys.argv[2]), sys.argv[3], sys.argv[4]
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    tty.setraw(fd)
+    if mode == "bracketed":
+        sys.stdout.write("\x1b[?2004h")
+        sys.stdout.flush()
+    with open(reads_path, "w") as f:
+        f.write("READY\n")
+    time.sleep(delay)                      # let the pty queue fill before the first read
+    stream = bytearray()
+    reads = []
+    deadline = time.time() + 40
+    while time.time() < deadline:
+        r, _, _ = select.select([fd], [], [], 0.5)
+        if not r:
+            continue
+        data = os.read(fd, 65536)
+        if not data:
+            break
+        stream += data
+        reads.append(len(data))
+        time.sleep(0.05)                   # keep the reader slower than the writer
+        body = bytes(stream)
+        if b"\r" in body:
+            last_open = body.rfind(b"\x1b[200~")
+            last_close = body.rfind(b"\x1b[201~")
+            if last_open == -1 or last_close > last_open:
+                break                      # Enter arrived outside any open paste
+    with open(stream_path, "wb") as f:
+        f.write(bytes(stream))
+    with open(reads_path, "w") as f:
+        f.write("\n".join(str(n) for n in reads) + "\nDONE\n")
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+""")
+
+
+def _payload() -> str:
+    """> 4 KB of UTF-8 with non-ASCII, no newlines (the caller flattens)."""
+    unit = "use mcp to read #général - you're mentioned; règle 中文 → ok; "
+    text = ""
+    while len(text.encode("utf-8")) < 4600:
+        text += unit
+    assert "\n" not in text
+    return text
+
+
+def _wait_for(path: str, marker: bytes, timeout: float) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.exists(path):
+            with open(path, "rb") as f:
+                if marker in f.read():
+                    return True
+        time.sleep(0.1)
+    return False
+
+
+@unittest.skipIf(sys.platform == "win32", "tmux transport is unix-only")
+@unittest.skipUnless(HAVE_TMUX, "tmux not installed")
+class InjectTransportTests(unittest.TestCase):
+    """Real tmux, real pty, raw-mode reader pane."""
+
+    def _run(self, mode: str, payload: str, delay: float = 1.0):
+        session = f"agentchattr-test-inject-{os.getpid()}-{mode}"
+        tmp = tempfile.mkdtemp(prefix="agentchattr-inject-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        reader = os.path.join(tmp, "reader.py")
+        with open(reader, "w", encoding="utf-8") as f:
+            f.write(READER)
+        stream = os.path.join(tmp, "stream.bin")
+        reads = os.path.join(tmp, "reads.txt")
+        subprocess.run(["tmux", "kill-session", "-t", session], capture_output=True)
+        result = subprocess.run(
+            ["tmux", "new-session", "-d", "-s", session, "-x", "200", "-y", "50",
+             f"{sys.executable} {reader} {mode} {delay} {stream} {reads}"],
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.addCleanup(subprocess.run, ["tmux", "kill-session", "-t", session],
+                        capture_output=True)
+        self.assertTrue(_wait_for(reads, b"READY", 10), "reader pane never became ready")
+        time.sleep(0.3)                    # let tmux parse the DECSET before pasting
+
+        ok = wrapper_unix.inject(payload, tmux_session=session, delay=0.1)
+
+        self.assertTrue(_wait_for(reads, b"DONE", 45), "reader never saw Enter")
+        with open(stream, "rb") as f:
+            data = f.read()
+        with open(reads, "r") as f:
+            sizes = [int(n) for n in f.read().split() if n.isdigit()]
+        return ok, data, sizes
+
+    def test_bracketed_pane_receives_one_framed_paste_then_enter(self):
+        payload = _payload()
+        ok, data, sizes = self._run("bracketed", payload)
+        self.assertEqual(data.count(OPEN), 1, f"exactly one paste start; reads={sizes}")
+        self.assertEqual(data.count(CLOSE), 1, f"exactly one paste end; reads={sizes}")
+        self.assertEqual(data, OPEN + payload.encode("utf-8") + CLOSE + b"\r",
+                         f"stream must be one framed paste then Enter; reads={sizes}")
+        self.assertIs(ok, True, "inject must report delivery")
+
+    def test_plain_pane_receives_raw_bytes_then_enter(self):
+        payload = _payload()
+        ok, data, sizes = self._run("plain", payload)
+        self.assertNotIn(OPEN, data, "no delimiters when the app never asked for them")
+        self.assertEqual(data, payload.encode("utf-8") + b"\r",
+                         f"plain pane must get the raw bytes then Enter; reads={sizes}")
+        self.assertIs(ok, True, "inject must report delivery")
+
+    def test_missing_target_returns_false_and_leaves_no_buffer(self):
+        ok = wrapper_unix.inject("hello", tmux_session="agentchattr-test-no-such-session",
+                                 delay=0.1)
+        self.assertIs(ok, False)
+        result = subprocess.run(["tmux", "list-buffers", "-F", "#{buffer_name}"],
+                                capture_output=True, text=True)
+        leftovers = [b for b in result.stdout.split() if b.startswith("agentchattr-inject-")]
+        self.assertEqual(leftovers, [], "a failed injection must not leak its paste buffer")
+
+
+class InjectFailurePathTests(unittest.TestCase):
+    """A paste that fails must be visible and must NOT be followed by Enter."""
+
+    def test_failed_paste_sends_no_enter_and_reports(self):
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            verb = argv[1]
+            if verb == "display-message":
+                return subprocess.CompletedProcess(argv, 0, stdout=b"%7\n", stderr=b"")
+            if verb == "paste-buffer":
+                return subprocess.CompletedProcess(argv, 1, stdout=b"", stderr=b"can't find pane\n")
+            return subprocess.CompletedProcess(argv, 0, stdout=b"", stderr=b"")
+
+        with mock.patch.object(wrapper_unix.subprocess, "run", side_effect=fake_run), \
+             mock.patch.object(wrapper_unix.time, "sleep"), \
+             mock.patch("sys.stdout") as out:
+            ok = wrapper_unix.inject("x" * 10, tmux_session="s", delay=0.1)
+
+        self.assertIs(ok, False)
+        self.assertFalse(any("Enter" in argv for argv in calls),
+                         f"Enter must not be sent after a failed paste: {calls}")
+        self.assertTrue(any(argv[1] == "delete-buffer" for argv in calls),
+                        f"the paste buffer must be cleaned up: {calls}")
+        printed = "".join(str(c.args[0]) for c in out.write.call_args_list)
+        self.assertIn("INJECT FAILED", printed, "failure must be visible in the wrapper log")
+
+    def test_exception_launching_paste_is_reported_cleaned_up_and_sends_no_enter(self):
+        """An OSError starting tmux (not a non-zero exit) must not escape inject()."""
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            verb = argv[1]
+            if verb == "display-message":
+                return subprocess.CompletedProcess(argv, 0, stdout=b"%7\n", stderr=b"")
+            if verb == "paste-buffer":
+                raise OSError("tmux vanished")
+            return subprocess.CompletedProcess(argv, 0, stdout=b"", stderr=b"")
+
+        with mock.patch.object(wrapper_unix.subprocess, "run", side_effect=fake_run), \
+             mock.patch.object(wrapper_unix.time, "sleep"), \
+             mock.patch("sys.stdout") as out:
+            ok = wrapper_unix.inject("x" * 10, tmux_session="s", delay=0.1)
+
+        self.assertIs(ok, False)
+        self.assertFalse(any("Enter" in argv for argv in calls),
+                         f"Enter must not be sent after an exception: {calls}")
+        self.assertTrue(any(argv[1] == "delete-buffer" for argv in calls),
+                        f"best-effort cleanup must still run: {calls}")
+        printed = "".join(str(c.args[0]) for c in out.write.call_args_list)
+        self.assertIn("INJECT FAILED", printed, "the exception must be visible in the wrapper log")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wrapper_unix.py
+++ b/wrapper_unix.py
@@ -1,4 +1,4 @@
-"""Mac/Linux agent injection — uses tmux send-keys to type into the agent CLI.
+"""Mac/Linux agent injection — pastes the prompt into the agent CLI via tmux.
 
 Called by wrapper.py on Mac and Linux. Requires tmux to be installed.
   - Mac:   brew install tmux
@@ -6,16 +6,19 @@ Called by wrapper.py on Mac and Linux. Requires tmux to be installed.
 
 How it works:
   1. Creates a tmux session running the agent CLI
-  2. Queue watcher sends keystrokes via 'tmux send-keys'
+  2. Queue watcher delivers the prompt as one bracketed paste
+     ('tmux load-buffer' + 'tmux paste-buffer -p'), then presses Enter
   3. Wrapper attaches to the session so you see the full TUI
   4. Ctrl+B, D to detach (agent keeps running in background)
 """
 
+import os
 import shlex
 import shutil
 import subprocess
 import sys
 import time
+import uuid
 
 
 def _session_exists(session_name: str) -> bool:
@@ -39,20 +42,93 @@ def _check_tmux():
     sys.exit(1)
 
 
-def inject(text: str, *, tmux_session: str, delay: float = 0.3):
-    """Send text + Enter to a tmux session via send-keys."""
-    # Use -l to send text literally (avoids misinterpreting as key names),
-    # then send Enter as a separate key press
-    subprocess.run(
-        ["tmux", "send-keys", "-t", tmux_session, "-l", text],
+def _pane_id(tmux_session: str) -> str | None:
+    """Resolve the session's active pane once, so paste and Enter hit the same pane."""
+    result = subprocess.run(
+        ["tmux", "display-message", "-p", "-t", tmux_session, "#{pane_id}"],
         capture_output=True,
     )
+    if result.returncode != 0:
+        return None
+    pane = result.stdout.decode(errors="replace").strip()
+    return pane or None
+
+
+def _drop_buffer(name: str) -> None:
+    subprocess.run(["tmux", "delete-buffer", "-b", name], capture_output=True)
+
+
+def inject(text: str, *, tmux_session: str, delay: float = 0.3) -> bool:
+    """Deliver text to the agent CLI as ONE bracketed paste, then press Enter.
+
+    Why a paste and not send-keys: a pty's raw input queue is finite (1024
+    bytes on macOS), so a single long `send-keys -l` can reach the CLI as
+    several reads. Claude Code treats a large read as a paste and, when typed
+    text follows a paste before Enter, submits only the typed text: measured on
+    macOS, a 1204-byte prompt arrived as its last 182 characters. With
+    `paste-buffer -p`, tmux wraps the text in ESC[200~ / ESC[201~ when the CLI
+    has enabled bracketed paste mode, and those delimiters let the CLI
+    reassemble one paste across split reads. A CLI that never asked for
+    bracketed paste gets the plain bytes, exactly as before.
+
+    Returns True only when tmux accepted both the paste and Enter. On any
+    failure, a non-zero exit or an exception launching tmux, it prints a
+    diagnostic, cleans up its buffer on a best-effort basis, sends nothing
+    further, and returns False (the queue watcher swallows exceptions, so a
+    raise alone would be invisible).
+    """
+    buffer_name = f"agentchattr-inject-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    try:
+        return _deliver(text, tmux_session, buffer_name, delay)
+    except Exception as exc:  # launching tmux itself failed, not a non-zero exit
+        print(f"  INJECT FAILED: {type(exc).__name__}: {exc}")
+        try:
+            _drop_buffer(buffer_name)
+        except Exception:
+            pass
+        return False
+
+
+def _deliver(text: str, tmux_session: str, buffer_name: str, delay: float) -> bool:
+    """The paste-then-Enter sequence; every tmux exit status is checked."""
+    pane = _pane_id(tmux_session)
+    if pane is None:
+        print(f"  INJECT FAILED: no pane for tmux session {tmux_session!r}")
+        return False
+
+    loaded = subprocess.run(
+        ["tmux", "load-buffer", "-b", buffer_name, "-"],
+        input=text.encode("utf-8"),
+        capture_output=True,
+    )
+    if loaded.returncode != 0:
+        print(f"  INJECT FAILED: load-buffer exit {loaded.returncode}: "
+              f"{loaded.stderr.decode(errors='replace').strip()}")
+        _drop_buffer(buffer_name)
+        return False
+
+    # -p: bracket the paste if the pane asked for it; -d: drop the buffer after.
+    pasted = subprocess.run(
+        ["tmux", "paste-buffer", "-p", "-d", "-b", buffer_name, "-t", pane],
+        capture_output=True,
+    )
+    if pasted.returncode != 0:
+        print(f"  INJECT FAILED: paste-buffer exit {pasted.returncode}: "
+              f"{pasted.stderr.decode(errors='replace').strip()}")
+        _drop_buffer(buffer_name)
+        return False
+
     # Scale delay with text length so longer prompts get more processing time
     time.sleep(max(delay, len(text) * 0.001))
-    subprocess.run(
-        ["tmux", "send-keys", "-t", tmux_session, "Enter"],
+    entered = subprocess.run(
+        ["tmux", "send-keys", "-t", pane, "Enter"],
         capture_output=True,
     )
+    if entered.returncode != 0:
+        print(f"  INJECT FAILED: Enter exit {entered.returncode}: "
+              f"{entered.stderr.decode(errors='replace').strip()}")
+        return False
+    return True
 
 
 def get_activity_checker(session_name, trigger_flag=None):


### PR DESCRIPTION
## The bug

A long injected prompt can reach Claude Code with its prefix missing on macOS. In every case measured, a 1,204-byte mention prompt arrived as its last 182 characters. The single `tmux send-keys -l` burst is longer than the pty's raw input queue, so the CLI receives it in more than one read; Claude Code treats a large first read as a paste, the remainder as typed text, and on Enter submits only the typed text. With 9 approved rules the standard mention prompt is 1,204 bytes, and the transcript shows a 182-character prompt starting mid-word, with the "read the channel" instruction gone. Full write-up with measurements in the linked issue.

## The change

`wrapper_unix.inject` delivers the prompt as one bracketed paste instead of a keystroke burst:

- the text is loaded into a uniquely named tmux buffer via stdin (`load-buffer -b NAME -`), so no temporary file and no collision between concurrent injections;
- the session's active pane is resolved once (`display-message -p '#{pane_id}'`) and that pane id is used for both the paste and the Enter, so a pane switch during the delay cannot split delivery;
- `paste-buffer -p -d` pastes and drops the buffer. tmux adds the ESC[200~ / ESC[201~ delimiters only when the pane's application has enabled bracketed paste mode, and the delimiters let the CLI reassemble one paste across split reads; an application that never asked for it gets the plain bytes exactly as before;
- every tmux step is checked, and an exception launching tmux is caught as well as a non-zero exit. On either, the wrapper prints `INJECT FAILED: ...`, deletes its buffer on a best-effort basis, sends no Enter, and returns `False`. The queue watcher swallows exceptions, so a raise alone would have been invisible; the return value is new and the caller is unchanged.

The newline flattening in `wrapper.py` and the Windows path are untouched.

## Verified

- **The user-visible failure, before and after, on a throwaway Claude Code 2.1.261 in tmux on macOS.** Old transport, 1,204-byte prompt then Enter: transcript records 182 characters. New `inject()`, same prompt: transcript records all 1,204 characters.
- **Codex CLI 0.153.2**: the composer shows `[Pasted Content 1204 chars]` after the new transport. Not submitted, so composer-level only.
- **`tests/test_inject_transport.py`.** Three cases against a real tmux server with a raw-mode reader pane that deliberately delays its reads so the kernel queue fills: a pane in bracketed-paste mode receives exactly one framed paste of a >4 KB non-ASCII payload then Enter; a plain pane receives the raw bytes then Enter; a missing target returns `False` and leaks no buffer. Two cases with `subprocess.run` mocked: a failed paste, and an exception launching the paste, each sends no Enter, cleans up, and is reported. The bracketed case fails on the old transport (no delimiters, reads of 1,022 bytes visible in the assertion message) and passes on the new one. The real-tmux cases are skipped when tmux is not installed.
- Full suite on this branch: 86 tests, 0 failures, 1 skipped.

## Not verified, stated plainly

Linux was not measured; its pty queue is larger, so the split point moves, and whether Claude Code loses the prefix there was not tested. Gemini, Qwen, Kilo, CodeBuddy and Antigravity were not on the test machine. A CLI that has enabled bracketed paste mode will receive one framed paste; one that has not will receive the same plain bytes it receives today. What each of them does with a paste in its composer is their contract, and I could not check it here.

Claude Code now renders the injected prompt as `[Pasted text #1]` in its input box rather than as visible text. The submitted content is complete; only the on-screen rendering changed.

Unchanged and out of scope: the queue watcher clears the queue file before delivery and does not act on the new `False`, so a failed injection is visible in the wrapper log but not retried. This is a transport fix, not a delivery guarantee.

Closes #101
