### PR TITLE
fix(deps): cap mcp at <2.0 so fresh installs keep the v1 SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fastapi>=0.110
 uvicorn[standard]>=0.29
-mcp>=1.0
+mcp>=1.0,<2.0  # v2 removes mcp.server.fastmcp (issue #85)


### PR DESCRIPTION
requirements.txt declares `mcp>=1.0` with no upper bound. Since the mcp 2.0 release, a fresh `pip install -r requirements.txt` resolves to 2.x, where FastMCP was renamed and `mcp.server.fastmcp` no longer exists, so the server dies on startup with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` (reported in #85; the mcp 2.x import error itself suggests pinning `mcp<2`).

One line: `mcp>=1.0` becomes `mcp>=1.0,<2.0`, with a short comment so the cap survives future cleanups.

Verification:
- In a clean venv, `pip install "mcp>=1.0"` resolves to 2.x and reproduces the traceback from #85.
- With the cap, pip resolves 1.29.1 and `from mcp.server.fastmcp import Context, FastMCP` succeeds.
- End-to-end fresh install: a clean venv + `pip install -r requirements.txt` (this branch) resolves mcp 1.29.1, and the full suite passes against it: 81 tests, 0 failures. Existing installs that already have a 1.x are unaffected.

Closes #85