### PR TITLE
fix(presence): _posted_leave `-=` shadows the closure, so _background_checks dies every tick

### DIFF
--- a/app.py
+++ b/app.py
@@ -411,7 +411,7 @@ def configure(cfg: dict, session_token: str = ""):
                         store.add(name, f"{name} disconnected", msg_type="leave", channel=_agent_last_channel.get(name, _last_active_channel))
 
                 # Clear leave debounce for agents that came back online
-                _posted_leave -= currently_online
+                _posted_leave.difference_update(currently_online)
 
                 # Detect other agents (non-registered) going offline
                 went_offline = (_known_online - currently_online) - timed_out


### PR DESCRIPTION
### Problem

`_background_checks()` (in the `app.py` startup block) is a nested function that
closes over three sets created just above it:

```python
_known_online: set[str] = set()
_posted_leave: set[str] = set()
_known_active = set()
```

It mutates two of them **in place**:

```python
_known_online.clear()
_known_online.update(currently_online)
```

but rebinds the third with an augmented assignment:

```python
_posted_leave -= currently_online          # app.py:414
```

`-=` on a name makes that name **local to the whole function**, so
`_posted_leave` inside `_background_checks` is no longer the closure variable.
Every use of it — including the ones *above* line 414 — hits an unbound local:

```
app.py:390        _posted_leave.add(name)
app.py:409        if name not in _posted_leave:
app.py:410            _posted_leave.add(name)
app.py:414        _posted_leave -= currently_online
app.py:426/427    ... not in _posted_leave / .add(name)
```

`symtable` on the current `main` copy of `app.py` shows it directly — the odd
one out is exactly the variable that gets `-=`:

```
=== UNPATCHED (upstream main) ===
  _posted_leave    -> LOCAL(shadows closure)
  _known_online    -> FREE(closure, correct)
  _known_active    -> FREE(closure, correct)
=== PATCHED ===
  _posted_leave    -> FREE(closure, correct)
  _known_online    -> FREE(closure, correct)
  _known_active    -> FREE(closure, correct)
```

and the closure shape reproduces the failure:

```
unpatched -> UnboundLocalError: cannot access local variable 'posted' where it is not associated with a value
patched   -> set() (no error)
```

### Impact

Line 414 is unconditional in the loop body, so **every** 3-second iteration
raises `UnboundLocalError` at line 414 at the latest (earlier, at 390/409, when
an agent actually times out or goes offline). The whole loop body sits in

```python
except Exception:
    pass
```

so nothing is logged. The result is silent: everything after line 414 never
runs — the non-registered `went_offline` detection, the `broadcast_status()`
SSE push, and the `_known_online.clear()/.update()` refresh at the end. The
leave-message debounce set is also never cleared for agents that come back.

### Fix

Mutate the set in place, the same way `_known_online` already is 34 lines
further down:

```python
_posted_leave.difference_update(currently_online)
```

One line, same semantics, no behaviour change other than the loop now getting
past line 414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
