### PR TITLE
fix(ui): skip a replayed message that is already rendered

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -755,6 +755,19 @@ function dayFloatRefresh() {
 function appendMessage(msg) {
     const container = document.getElementById('messages');
 
+    // Skip a message that is already rendered. The server replays a channel's
+    // whole history on every connect, and ws.onclose reconnects without
+    // clearing the timeline, so without this guard every reconnect appended the
+    // entire history again and the message list grew without bound.
+    //
+    // Above maybeInsertDateDivider on purpose, so a replayed message cannot add
+    // a duplicate divider either. The 'edit' handler re-renders through this
+    // function but removes the old element first, so its lookup misses and the
+    // re-render still works - keep that order if it is ever reworked.
+    if (msg.id != null && container.querySelector(`.message[data-id="${msg.id}"]`)) {
+        return;
+    }
+
     // Insert date divider if needed
     maybeInsertDateDivider(container, msg);
 

--- a/static/index.html
+++ b/static/index.html
@@ -374,6 +374,6 @@
     <script src="/static/jobs.js?v=224"></script>
     <script src="/static/channels.js?v=225"></script>
     <script src="/static/rules-panel.js?v=223"></script>
-    <script src="/static/chat.js?v=271"></script>
+    <script src="/static/chat.js?v=272"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #106.

`appendMessage` now returns early when a message id is already on the page.

## Why

The server replays a channel's whole history on every WebSocket connect, and
`ws.onclose` reconnects after 2s without clearing the timeline, so before this
guard every reconnect appended the entire history again and the message list
grew without bound. Mechanism, measurements and a console repro are in the
issue.

## Two things worth a reviewer's attention

**The guard's placement is deliberate.** It sits above `maybeInsertDateDivider`,
so a replayed message cannot insert a duplicate date divider or disturb
`lastMessageDates` either. Putting it after the divider call would fix the
message duplication and leave a subtler version of the same bug.

**The one interaction I checked.** The `edit` handler re-renders a message
through `appendMessage`. It still works, because it removes the old element
before calling, so the new lookup misses. I have left a comment at the guard
saying that ordering is now load-bearing, since a future rework that appended
before removing would silently stop edits from re-rendering.

The guard uses `msg.id != null`, matching the existing idiom in the `edit`
handler, so a message without an id is never deduplicated against another.

## The version bump is part of the fix, not housekeeping

`static/index.html` loads `chat.js?v=271`, so a browser holding the cached file
keeps the old behaviour after this merges. Without the bump to `v=272` the fix
does not reach anyone already running the app. This surfaced while testing on a
live instance: a normal reload served the cached file and the fix appeared to do
nothing until the page was hard-reloaded.

## Verification

- **Measured on a live instance, before and after.**

  | | rendered elements |
  |---|---|
  | before, fresh page | 6883 |
  | before, one reconnect | 13766 |
  | before, two reconnects | 20649 |
  | after, fresh page | 6887 |
  | after, one reconnect | 6887 |
  | after, two reconnects | 6887 |

  One full extra copy per reconnect before, flat after. (The 6887 against 6883
  is four messages posted in between, not drift.) Before counting, the loaded
  build was confirmed to be the patched one with
  `appendMessage.toString().includes('already rendered')`, because a cached
  script would otherwise have produced a confident and meaningless number. It
  did exactly that on the first attempt.
- `node --check` passes on the patched file. I ran it against a deliberately
  malformed file first and confirmed it fails there, so the pass means the syntax
  is valid rather than that the checker is inert.

I have deliberately not added a JS test stack for this: it would be a second,
larger concern and a dependency choice that is yours rather than mine. Happy to
follow up with one if you want it.
